### PR TITLE
Date-Time control , added Populate Date Expression property:

### DIFF
--- a/components/cstudio-common/resources/en/base.js
+++ b/components/cstudio-common/resources/en/base.js
@@ -491,6 +491,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "en", {
     setNowLink: "Set Now Link",
     populated: "Populated",
     allowPastDate: "Allow Past Date",
+    populateExpression:"Populate Expression",
     useCustomTimezone: "Use Custom Timezone",
     readonly: "Readonly",
     readonlyOnEdit: "Readonly on Edit",

--- a/components/cstudio-common/resources/es/base.js
+++ b/components/cstudio-common/resources/es/base.js
@@ -473,6 +473,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "es", {
     setNowLink: "Establecer Link de Ahora",
     populated: "Poblado",
     allowPastDate: "Permitir Fecha Pasada",
+    populateExpression:"Expresion valor por defecto",
     useCustomTimezone: "Usar Timezone Personalizado",
     readonly: "Solo Lectura",
     readonlyOnEdit: "Editar en Solo Lectura",

--- a/components/cstudio-common/resources/kr/base.js
+++ b/components/cstudio-common/resources/kr/base.js
@@ -445,6 +445,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "kr", {
     setNowLink: "이제 링크 설정",
     populated: "인구",
     allowPastDate: "과거 날짜 허용",
+    populateExpression:"",
     readonly: "읽기 전용",
     readonlyOnEdit: "편집에 읽기 전용",
     datasource: "데이터 소스",


### PR DESCRIPTION
This property will work in conjunction with populate,if populate is set to true and the expression is valid
will add/remove days/weeks/years from the current date. _This will only affect new content_.

Valid expressions are
`(+|-)NumberType`

Examples:

```
+120days # will add 120 days from now
-12weeks # Will subtract 12 weeks (7 days each) from now
+1230years #Will add 1230 years from now.
```

This expression will only work with Dates, time are left __as is__
