### PR TITLE
Studio: RTE toolbar does not close when the user clicks any element that is not a field #270

### DIFF
--- a/components/cstudio-forms/forms-engine.js
+++ b/components/cstudio-forms/forms-engine.js
@@ -649,8 +649,8 @@ var CStudioForms = CStudioForms || function() {
                 var previousFocusedField = this.focusedField;
                 this.focusedField = field;
 
-                if(previousFocusedField && (previousFocusedField !== field))
-                    if(field && previousFocusedField && previousFocusedField.focusOut) {
+                if((previousFocusedField && (previousFocusedField !== field)) || field == null)
+                    if(previousFocusedField && previousFocusedField.focusOut) {
                         previousFocusedField.focusOut();
                     }
 


### PR DESCRIPTION
Studio: RTE toolbar does not close when the user clicks any element that is not a field #270