### PR TITLE
Groovy Controller/Extractor for New Content Types

### DIFF
--- a/static-assets/components/cstudio-dialogs/new-content-type.js
+++ b/static-assets/components/cstudio-dialogs/new-content-type.js
@@ -382,13 +382,13 @@ CStudioAuthoring.Dialogs.NewContentType = CStudioAuthoring.Dialogs.NewContentTyp
 							},
 							context: this.context
 						}
-						this.context.writeConfig(baseServicePath + 'extract.js', extractionContent, writeExtractionCb);
+						this.context.writeConfig(baseServicePath + 'extract.groovy', extractionContent, writeExtractionCb);
 					},
 					failure: function() {
 					},
 					context: this.context
 				};
-				this.context.writeConfig(baseServicePath + 'controller.js', controllerContent, writeControllerCb);
+				this.context.writeConfig(baseServicePath + 'controller.groovy', controllerContent, writeControllerCb);
 			},
 			failure: function() {
 			},


### PR DESCRIPTION
Changed the file name for 'extract' 'controller' to have the extension groovy.