### PR TITLE
#929

### DIFF
--- a/static-assets/modules/editors/tiny_mce/themes/advanced/skins/cstudio-rte/content.css
+++ b/static-assets/modules/editors/tiny_mce/themes/advanced/skins/cstudio-rte/content.css
@@ -48,4 +48,5 @@ font[face=mceinline] {font-family:inherit !important}
 
 .mceContentBody  {
     background: #fff;
+    height: 100%;
 }


### PR DESCRIPTION
Firefox, only the top portion of an RTE (about 40px high) is clickable to activate that placeholder #929
https://github.com/craftercms/craftercms/issues/929 - 