### PR TITLE
 #1125

### DIFF
--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1929,7 +1929,7 @@ var CStudioForms = CStudioForms || function() {
                                                 return
                                             }
                                         }
-                                    }, 1200);
+                                    }, 1500);
                                 }
                             }catch (err){
                                 //console.log(err);


### PR DESCRIPTION
[studio-ui] Cursor is not in the first field when creating a new article page in editorial bp #1125
https://github.com/craftercms/craftercms/issues/1125 - 