### PR TITLE
#1206

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -1290,7 +1290,11 @@ var nodeOpen = false;
                 var previewFrameEl = document.getElementById("engineWindow");
                 if(previewFrameEl){
                     if(!context || context.isComponent){
-                        previewFrameEl.src += '';
+                        try{
+                            previewFrameEl.contentWindow.location.reload();
+                        }catch(err){
+                            previewFrameEl.src += '';
+                        }
                     }else{
                         if (context && context.browserUri) {
                             amplify.publish(crafter.studio.preview.Topics.GUEST_CHECKIN, CStudioAuthoring.Operations.getPreviewUrl(context, false));


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/1206 - [studio-ui] Clicking on "Save and Close" or "Save Draft" in in-context edit takes you back to the home page instead of the previous page being previewed #1206