### PR TITLE
#1230

### DIFF
--- a/static-assets/components/cstudio-view-controllers/approve.js
+++ b/static-assets/components/cstudio-view-controllers/approve.js
@@ -320,6 +320,7 @@
 
         $(document).on("keyup", function(e) {
             if (e.keyCode === 27) {	// esc
+                $('.date-picker').datetimepicker('hide');
                 me.end();
                 $(document).off("keyup");
             }

--- a/static-assets/components/cstudio-view-controllers/request-publish.js
+++ b/static-assets/components/cstudio-view-controllers/request-publish.js
@@ -28,6 +28,7 @@
 
     function closeButtonClicked() {
         $(document).off("keyup");
+        $('.date-picker').datetimepicker('hide');
         this.end();
     }
 
@@ -178,7 +179,7 @@
 
         $(document).on("keyup", function(e) {
             if (e.keyCode === 27) {	// esc
-                me.closeButtonClicked();
+                me.closeButtonActionClicked();
                 $(document).off("keyup");
             }
         });


### PR DESCRIPTION
[studio-ui] Datetime picker in the "Approve for Publish" dialog does not go away after pressing the <esc> escape key #1230
https://github.com/craftercms/craftercms/issues/1230 - 