### PR TITLE
#1229

### DIFF
--- a/static-assets/scripts/pointer-controller.js
+++ b/static-assets/scripts/pointer-controller.js
@@ -85,9 +85,11 @@ define('pointer-controller', ['crafter', 'jquery', 'jquery-ui', 'animator', 'com
             $(divMouse).css('left',e.pageX + 4 );
             $(divMouse).css('top',e.pageY );
         });
-        $body.keyup(function(e) {
+        $(window.parent.document).keyup(function(e) {
+            var _self = this;
             if (e.keyCode == 27){ // esc
                 me.done();
+                _self.css( 'cursor', 'pointer' );
             }
         });
 


### PR DESCRIPTION
[studio-ui] Pressing the <esc> key does not cancel placing an existing component in the drag and drop zone #1229
https://github.com/craftercms/craftercms/issues/1229 - 