### PR TITLE
#1319

### DIFF
--- a/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-root-folder.js
+++ b/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-root-folder.js
@@ -2303,7 +2303,10 @@
                                                     }
 						                        	p_aArgs.addItems([ menuItems.newFolderOption ]);
 
-						                        	p_aArgs.addItems([ menuItems.separator ]);
+                                                    if (isDeleteAllowed || !isFolder && isChangeContentTypeAllowed) {
+                                                        p_aArgs.addItems([ menuItems.separator ]);
+                                                    }
+
 						                        	if (isDeleteAllowed) {
 						                        	    p_aArgs.addItems([ menuItems.deleteOption ]);
 						                        	}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/1319 - [studio-ui] Right click on wcm-root-folder or wcm-asset-folder in sidebar should not render 2 separators #1319