### PR TITLE
#1322

### DIFF
--- a/static-assets/components/cstudio-preview-tools/mods/component-panel.js
+++ b/static-assets/components/cstudio-preview-tools/mods/component-panel.js
@@ -247,6 +247,9 @@
                 },
 
                 getPreviewPagePath: function (previewPath) {
+                    if(previewPath.indexOf("?") > 0){
+                        previewPath = previewPath.split("?")[0];
+                    }
                     var pagePath = previewPath.replace(".html", ".xml");
                     if (pagePath.indexOf(".xml") == -1) {
                         if (pagePath.substring(pagePath.length - 1) != "/") {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/1322 - [studio-ui] url parameters cause drag and drop to fail #1322