### PR TITLE
[studio-ui] Uploading an image into static assets results in `//` in the file path #1572

### DIFF
--- a/static-assets/components/cstudio-forms/data-sources/img-desktop-upload.js
+++ b/static-assets/components/cstudio-forms/data-sources/img-desktop-upload.js
@@ -33,9 +33,11 @@ YAHOO.extend(CStudioForms.Datasources.ImgDesktopUpload, CStudioForms.CStudioForm
 		
 		var callback = { 
 			success: function(imageData) {
-				var url = this.context.createPreviewUrl(path + "/" + imageData.fileName);
+				var relativeUrl = path.endsWith("/") ? path + imageData.fileName : path + "/" + imageData.fileName;
+				var url = this.context.createPreviewUrl(relativeUrl);
 				imageData.previewUrl = url + "?" + new Date().getTime();
-				imageData.relativeUrl = path + "/" + imageData.fileName
+				imageData.relativeUrl = relativeUrl;
+
 				insertCb.success(imageData);
 			}, 
 			failure: function() {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/1572