### PR TITLE
#1586

### DIFF
--- a/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-root-folder.js
+++ b/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-root-folder.js
@@ -2279,7 +2279,10 @@
                                                 
 					                        }
 				                        	if (isUserAllowed) {
-				                        		p_aArgs.addItems([ menuItems.separator ]);
+
+                                                if (isDeleteAllowed || !isFolder && isChangeContentTypeAllowed){
+                                                    p_aArgs.addItems([ menuItems.separator ]);
+                                                }
 				                        		if (isDeleteAllowed) {
 					                        	    p_aArgs.addItems([ menuItems.deleteOption ]);
 					                        	}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/1586 - [studio-ui] There are 2 separators next to each other rendered for user author when right clicking a folder under components and Home #1586