### PR TITLE
#1615

### DIFF
--- a/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-assets-folder.js
+++ b/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-assets-folder.js
@@ -1239,7 +1239,7 @@ CStudioAuthoring.ContextualNav.WcmAssetsFolder = CStudioAuthoring.ContextualNav.
                         }
                     }
 
-                    if (CSA.Utils.hasPerm(CSA.Constants.PERMISSION_WRITE, perms)){
+                    if (CSA.Utils.hasPerm(CSA.Constants.PERMISSION_WRITE, perms) && oCurrentTextNode.data.isContainer){
                         this.aMenuItems.push({
                             text: CMgs.format(siteDropdownLangBundle, "bulkUploadAssets"),
                             onclick: { fn: CSA.ContextualNav.WcmAssetsFolder.bulkUpload }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/1615 - [studio-ui] Remove "Bulk Upload Assets" option when right clicking on a template or a script #1615