### PR TITLE
#1518

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -7301,7 +7301,7 @@ var nodeOpen = false,
                 var toolTipMarkup = [
                  "<table class='width300 acn-tooltip'>",
                     "<tr>",
-                    "<td class='acn-width280' colspan='2'><strong>{1}</strong></td>",
+                    "<td class='acn-width280 acn-name' colspan='2'><strong>{1}</strong></td>",
                     "</tr>",
                     "<tr><td class='acn-width80'><strong>Content&nbsp;Type:</strong> </td>",
                         "<td class='acn-width200' style='text-transform: capitalize;'>{8}</td></tr>",

--- a/static-assets/styles/temp.css
+++ b/static-assets/styles/temp.css
@@ -3490,6 +3490,9 @@ span.acn-page-deleted a, span.acn-page-deleted a:hover {
   text-align: left;
   vertical-align: top; }
 
+.acn-tooltip .acn-name {
+  word-break: break-word; }
+
 .acn-width80 {
   width: 80px; }
 
@@ -15345,3 +15348,5 @@ body.masked {
 #activeContentActions li > .navbar-text {
   margin-left: 0;
   margin-right: 10px; }
+
+/*# sourceMappingURL=temp.css.map */

--- a/ui/scss/temp.scss
+++ b/ui/scss/temp.scss
@@ -929,6 +929,10 @@ span.acn-page-deleted a, span.acn-page-deleted a:hover {
   vertical-align: top;
 }
 
+.acn-tooltip .acn-name {
+  word-break: break-word;
+}
+
 .acn-width80 {
   width: 80px;
 }


### PR DESCRIPTION
[studio-ui] Asset filenames with a parenthesis in the name has content type listed as unknown and if the name is long, goes out of the tooltip box #1518
