### PR TITLE
Feature/aws video upload properties support

### DIFF
--- a/static-assets/components/cstudio-forms/controls/aws-video-upload.js
+++ b/static-assets/components/cstudio-forms/controls/aws-video-upload.js
@@ -154,6 +154,9 @@ YAHOO.extend(CStudioForms.Controls.AWSVideoUpload, CStudioForms.CStudioFormField
     
     var formEl = document.createElement("form");
     formEl.id = "upload_form";
+
+    var inputContainerEl = document.createElement("div");
+    YAHOO.util.Dom.addClass(inputContainerEl, "cstudio-form-control-input-help-container");
     
     var inputEl = document.createElement("input");
 		this.inputEl = inputEl;
@@ -162,8 +165,12 @@ YAHOO.extend(CStudioForms.Controls.AWSVideoUpload, CStudioForms.CStudioFormField
 		YAHOO.util.Dom.addClass(inputEl, "datum");
 		YAHOO.util.Dom.addClass(inputEl, "cstudio-form-control-input");
     YAHOO.util.Event.on(inputEl, "change",  this._onChange, this);
+
+    inputContainerEl.appendChild(inputEl);
+
+    this.renderHelp(config, inputContainerEl);
     
-		formEl.appendChild(inputEl);
+    formEl.appendChild(inputContainerEl);
     
     var profileEl = document.createElement("input");
     profileEl.type = "hidden";
@@ -180,6 +187,13 @@ YAHOO.extend(CStudioForms.Controls.AWSVideoUpload, CStudioForms.CStudioFormField
     formEl.appendChild(siteEl);
     
     controlWidgetContainerEl.appendChild(formEl);
+
+    var descriptionEl = document.createElement("span");
+    YAHOO.util.Dom.addClass(descriptionEl, 'description');
+    YAHOO.util.Dom.addClass(descriptionEl, 'cstudio-form-field-description');
+    descriptionEl.innerHTML = config.description;
+
+    controlWidgetContainerEl.appendChild(descriptionEl);
     
     containerEl.appendChild(controlWidgetContainerEl);
   }

--- a/static-assets/themes/cstudioTheme/css/forms-default.css
+++ b/static-assets/themes/cstudioTheme/css/forms-default.css
@@ -523,6 +523,10 @@ div.yui-calcontainer.cstudio-form-field-calendar {
 	display: inline;
 }
 
+.cstudio-form-control-input-help-container input {
+    display: inline;
+}
+
 .cstudio-form-control-input-data {
 	display: inline-block;
 }


### PR DESCRIPTION
This change adds support to the AWS Video Upload Control for the Description and Help properties.

Here is a rendered example of the change:
![image](https://user-images.githubusercontent.com/20078963/33738810-872e608a-db68-11e7-9321-37cb07faad53.png)
