### PR TITLE
[studio] 2.5.x dependencies is referenced by returns the object itself #1819

### DIFF
--- a/static-assets/components/cstudio-view-controllers/dependencies.js
+++ b/static-assets/components/cstudio-view-controllers/dependencies.js
@@ -128,104 +128,34 @@
         var optionSelected = $(me.getComponent('.dependencies-option')).val();
         var $parentRow = $(agent.get('ITEM_ROW', element));
         
-        var depsOnCallback = {
-            success: function(response){
-                var item = JSON.parse(response.responseText);
-
-                $.each(item, function(index, dependency){
-                    var elem = {};
-                    elem.uri = dependency.uri;
-                    elem.internalName = dependency.internalName;
-                    elem.scheduledDate = '';
-                    // elem.index = itemDependenciesClass;
-
-                    if (dependency.uri.indexOf(".ftl") == -1
-                        && dependency.uri.indexOf(".css") == -1
-                        && dependency.uri.indexOf(".js") == -1
-                        && dependency.uri.indexOf(".groovy") == -1
-                        && dependency.uri.indexOf(".txt") == -1
-                        && dependency.uri.indexOf(".html") == -1
-                        && dependency.uri.indexOf(".hbs") == -1
-                        && dependency.uri.indexOf(".xml") == -1) {
-                        // editLink.hide();
-                        elem.hidden = "hidden";
-                    }
-
-                    var row = agent.get('SUBITEM_ROW', elem);
-                    // var editLink = $(row).find('.editLink');
-                    row = $container.append(row);
-
-                });
-
-                $('.editLink').on('click', function() {
-                    var url = $(this).attr('data-url');
-
-                    CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, url, {
-                        success: function (results) {
-
-                            var isUserAllowed = CStudioAuthoring.Service.isUserAllowed(results.permissions);
-
-                            if (isUserAllowed) {
-                                //add event
-                                var itemUrl = url;
-
-                                var getContentCallback = {
-                                    success: function (contentTO) {
-                                        var contentTO = contentTO.item;
-
-                                        CStudioAuthoring.Operations.editContent(
-                                            contentTO.form,
-                                            CStudioAuthoringContext.siteId,
-                                            contentTO.uri,
-                                            contentTO.nodeRef,
-                                            contentTO.uri,
-                                            false,
-                                            {},
-                                            [{"ontop": true}]);
-                                    },
-
-                                    failure: function () {
-                                        WcmDashboardWidgetCommon.Ajax.enableDashboard();
-                                    }
-                                };
-
-                                CStudioAuthoring.Service.lookupContentItem(CStudioAuthoringContext.site, itemUrl, getContentCallback, false, false);
-                            }
-                        },
-                        failure: function () {
-                            throw new Error('Unable to retrieve user permissions');
-                        }
-                    });
-                });
-            }
-        };
         var depsCallback = {
             success: function(response){
                 var item = JSON.parse(response.responseText);
 
-                $.each(item, function(index, dependency){
-                    var elem = {};
-                    elem.uri = dependency.uri;
-                    elem.internalName = dependency.internalName;
-                    elem.scheduledDate = '';
-                    // elem.index = itemDependenciesClass;
+                $.each(item, function(index, dependency){ 
+                    if(JSON.stringify(me.element) !== JSON.stringify(dependency)){
+                        var elem = {};
+                        elem.uri = dependency.uri;
+                        elem.internalName = dependency.internalName;
+                        elem.scheduledDate = '';
+                        // elem.index = itemDependenciesClass;
 
-                    if (dependency.uri.indexOf(".ftl") == -1
-                        && dependency.uri.indexOf(".css") == -1
-                        && dependency.uri.indexOf(".js") == -1
-                        && dependency.uri.indexOf(".groovy") == -1
-                        && dependency.uri.indexOf(".txt") == -1
-                        && dependency.uri.indexOf(".html") == -1
-                        && dependency.uri.indexOf(".hbs") == -1
-                        && dependency.uri.indexOf(".xml") == -1) {
-                        // editLink.hide();
-                        elem.hidden = "hidden";
+                        if (dependency.uri.indexOf(".ftl") == -1
+                            && dependency.uri.indexOf(".css") == -1
+                            && dependency.uri.indexOf(".js") == -1
+                            && dependency.uri.indexOf(".groovy") == -1
+                            && dependency.uri.indexOf(".txt") == -1
+                            && dependency.uri.indexOf(".html") == -1
+                            && dependency.uri.indexOf(".hbs") == -1
+                            && dependency.uri.indexOf(".xml") == -1) {
+                            // editLink.hide();
+                            elem.hidden = "hidden";
+                        }
+
+                        var row = agent.get('SUBITEM_ROW', elem);
+                        // var editLink = $(row).find('.editLink');
+                        row = $container.append(row);
                     }
-
-                    var row = agent.get('SUBITEM_ROW', elem);
-                    // var editLink = $(row).find('.editLink');
-                    row = $container.append(row);
-
                 });
 
                 $('.editLink').on('click', function() {
@@ -275,7 +205,7 @@
             CStudioAuthoring.Service.loadDependantItems(
                 CStudioAuthoringContext.site,
                 depsItem.uri,
-                depsOnCallback
+                depsCallback
             );
         }else{  //Is referenced by this item - depends-on-me
             CStudioAuthoring.Service.loadDependencies(


### PR DESCRIPTION
[studio] 2.5.x dependencies is referenced by returns the object itself #1819 - Avoid showing itself on dependencies when they come from backend

https://github.com/craftercms/craftercms/issues/1819
