### PR TITLE
#1848

### DIFF
--- a/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-root-folder.js
+++ b/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-root-folder.js
@@ -1608,7 +1608,7 @@
                         if (curNode) {
                             CStudioAuthoring.Service.lookupSiteContent(CStudioAuthoringContext.site, curNode.data.uri, 1, "default", {
                                 success: function (treeData) {
-                                    if (currentUri == treeData.item.uri) {
+                                    if (currentUri.replace(/ /g,"%20") == treeData.item.uri) {
                                         var style = "",
                                             cont = paramCont ? paramCont : 0,
                                             currentInternalName = (treeData.item.internalName != "" ? treeData.item.internalName  : treeData.item.name),


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/1848 - [studio-ui] Static assets folders are not refreshed after delete an image item when file name contains dots and spaces #1848
