### PR TITLE
#1884

### DIFF
--- a/static-assets/themes/cstudioTheme/css/console.css
+++ b/static-assets/themes/cstudioTheme/css/console.css
@@ -110,7 +110,8 @@ body,tbody {
     position: fixed;
     right: 0;
     top: 0;
-    width: 32%;
+    /*width: 32%;*/
+    width: calc(calc(100% - 239px) * 0.38);
     padding-top: 32px;
     margin-top: 19px;
     font-size: 11.5px;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/1884 - [Studio-UI] The delete icon is cut off in content types page. #1884
