### PR TITLE
#2149

### DIFF
--- a/static-assets/components/cstudio-browse/browse.js
+++ b/static-assets/components/cstudio-browse/browse.js
@@ -547,7 +547,9 @@
 
             if(results){
                 var filesPresent = false;
-                results = results.item.children;
+                var currentResults = results.item.children;
+                currentResults.unshift(results.item);
+                results = currentResults;
 
                 var pathLabel = path.replace(/\//g, ' / ');
                 $('.current-folder .path').html(pathLabel);

--- a/templates/web/browse.ftl
+++ b/templates/web/browse.ftl
@@ -136,7 +136,13 @@
                 {{#if showUrl}}
                 <span class="cstudio-search-component cstudio-search-component-url">
                   <span class="component-title bold">{{labelUrl}}:</span>
-                  <a href="{{browserUri}}" target="_blank">{{browserUri}}</a>
+                  <a href="{{#if browserUri}}{{browserUri}}{{else}}/{{/if}}" target="_blank">
+                      {{#if browserUri}}
+                        {{browserUri}}
+                      {{else}}
+                        /
+                      {{/if}}
+                  </a>
                 </span>
                 {{/if}}
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2149 - [studio-ui] User is not able to select root page (index) of a given path with item form selector in browse mode #2149
