### PR TITLE
#2181

### DIFF
--- a/static-assets/components/cstudio-dialogs-templates/delete.html
+++ b/static-assets/components/cstudio-dialogs-templates/delete.html
@@ -89,7 +89,7 @@
     </div>
 
     <div class="action-wrapper">
-        <input id="deleteBtn" type="submit" class="do-delete btn btn-primary" value="Delete" />
+        <input id="deleteBtn" type="submit" class="do-delete btn btn-primary" disabled value="Delete" />
         <input id="cancelBtn" type="submit" class="cancel btn btn-default" value="Cancel" />
     </div>
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2181 - [studio-ui] Do not enable the Delete button until all item dependencies/items to be deleted are displayed/ready #2181
