### PR TITLE
#2196

### DIFF
--- a/static-assets/components/cstudio-forms/controls/dropdown.js
+++ b/static-assets/components/cstudio-forms/controls/dropdown.js
@@ -139,6 +139,14 @@ YAHOO.extend(CStudioForms.Controls.Dropdown, CStudioForms.CStudioFormField, {
 						containerEl.appendChild(descriptionEl);
 					}
 
+                    if(_self.controlWidgetContainerEl.inputEl.options.length <= 0){
+                        var optionElEmpty = document.createElement("option");
+                        optionElEmpty.classList.add("hide");
+                        optionElEmpty.disabled = true;
+                        optionElEmpty.selected = "selected";
+                        _self.controlWidgetContainerEl.inputEl.add(optionElEmpty);
+                    }
+
 					if(keyValueList){
 						for(var j=0; j<keyValueList.length; j++) {
 							var item = keyValueList[j];


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2196 - [studio-ui] Validation is not the correct when all values are provided for creation of New Page-Category Landing page and the category dropdown is left as default #2196
