### PR TITLE
#2091

### DIFF
--- a/static-assets/components/cstudio-forms/controls/date-time.js
+++ b/static-assets/components/cstudio-forms/controls/date-time.js
@@ -1163,7 +1163,8 @@ YAHOO.extend(CStudioForms.Controls.DateTime, CStudioForms.CStudioFormField, {
 		} else {
 			//No value exists yet
 			if (this.populate) {
-                var	adjustedTimeZoneObj = _self.getFormattedDateTimeObject(this.startTzDateTimeStr, true);
+                var changeDate = _self.doDatePopulateExpression( new Date(this.startTzDateTimeStr));
+                var	adjustedTimeZoneObj = _self.getFormattedDateTimeObject(CStudioAuthoring.Utils.formatDateToStudio(changeDate), true);
                 _self.populateDateTime(adjustedTimeZoneObj, _self.dateEl, _self.timeEl, _self.showDate, _self.showTime);
                 _self.validate(null, _self);
             }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2091 - [studio-ui] Setting Populate Expression property on date-time form engine control has no effect #2091
