### PR TITLE
#2213

### DIFF
--- a/static-assets/components/cstudio-dialogs/new-content-type.js
+++ b/static-assets/components/cstudio-dialogs/new-content-type.js
@@ -140,10 +140,8 @@ CStudioAuthoring.Dialogs.NewContentType = CStudioAuthoring.Dialogs.NewContentTyp
 		YEvent.on("contentTypeDisplayName", "keyup", function() {
                     YAHOO.Bubbling.fire("content-type.values.changed");
 					value = document.getElementById('contentTypeDisplayName').value;
-
-					var find = ' ';
-					var re = new RegExp(find, 'g');
-					value = value.replace(re, '-');
+            
+					value = value.replace(/[^a-z0-9]/gi, '');
 					value = value.toLowerCase();
 
                     document.getElementById('contentTypeName').value = value;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2213 - [studio-ui] create content type should only allow alpha numeric characters #2213
