### PR TITLE
#2524

### DIFF
--- a/static-assets/scripts/admin.js
+++ b/static-assets/scripts/admin.js
@@ -822,7 +822,7 @@
 
                         $scope.notification('\''+ user.username + '\' deleted.','',"studioMedium");
                     }).error(function (data) {
-                        $scope.error = data.message;
+                        $scope.error = data.result.response.message;
                         $scope.adminModal = $scope.showModal('deleteUserError.html', 'md', true);
                     });
                 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2524 - [studio-ui] no error text is displayed when user try to delete the admin user on the notification. #2524
