### PR TITLE
#2635

### DIFF
--- a/static-assets/components/cstudio-dashboard-widgets/lib/wcm-dashboardwidget-common.js
+++ b/static-assets/components/cstudio-dashboard-widgets/lib/wcm-dashboardwidget-common.js
@@ -787,6 +787,7 @@ WcmDashboardWidgetCommon.editItem = function (matchedElement, isChecked) {
 
     var editCallback = {
         success: function (contentTO, editorId, name, value, draft) {
+            matchedElement.style.pointerEvents = "auto";
             if(CStudioAuthoringContext.isPreview){
                 try{
                     CStudioAuthoring.Operations.refreshPreview();


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2635 - [studio-ui] edit code item from dashboard leaves edit button disabled after save 
