### PR TITLE
Mini-Bugfix: Add missing entry "thumbnailHeight" to english resource bundle

### DIFF
--- a/static-assets/components/cstudio-common/resources/en/base.js
+++ b/static-assets/components/cstudio-common/resources/en/base.js
@@ -697,6 +697,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "en", {
     showSelectAll: 'Show "Select All"',
     allowEmptyValue: "Allow Empty Value",
     thumbnailWidth: "Thumbnail Width",
+    thumbnailHeight: "Thumbnail Height",
     displaySize: "Display Size",
     text: "Text",
     minSize: "Min Size",


### PR DESCRIPTION
The entry is used in the image-picker properties.