### PR TITLE
Mini-Bugfix: Replace static label in admin console

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -720,7 +720,7 @@ CStudioAuthoring.Module.requireModule(
 				var divPropertiesEl = document.createElement("div");
 				YDom.addClass(divPropertiesEl, "content-form-link");
 				var linkPropertiesEl = document.createElement("a");
-				linkPropertiesEl.innerHTML = "Basic Content Type Properties";
+				linkPropertiesEl.innerHTML = CMgs.format(langBundle, "basicContentTypeProp");
 				divPropertiesEl.appendChild(linkPropertiesEl);
 				formVisualContainerEl.appendChild(divPropertiesEl);
 


### PR DESCRIPTION
Replace static label in content-type configuration by corresponding entry from resource bundle