### PR TITLE
Use min-width of OK and cancel buttons on content type popup window

### DIFF
--- a/static-assets/themes/cstudioTheme/css/global.css
+++ b/static-assets/themes/cstudioTheme/css/global.css
@@ -3009,7 +3009,7 @@ li.list2 {
 
 
 .contentTypePopupBtn .ok, .contentTypePopupBtn .cancel{
-  width: 72px; }
+  min-width: 72px; }
 
 /* yui calendar/datepicker global styles*/
 


### PR DESCRIPTION
In case of longer labels, button width must be increased

![screenshot](https://user-images.githubusercontent.com/1357798/50634039-a19f9780-0f4d-11e9-8eaf-d32ea9a54890.png)
