### PR TITLE
2843, 2844

### DIFF
--- a/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
+++ b/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
@@ -96,6 +96,13 @@ CStudioAuthoring.Module.requireModule(
 		 */
 		setValue: function(value) {
 			this.value = value;
+
+			try {
+				tinymce.activeEditor.setContent(value, {format: 'raw'});
+			}
+			catch(err) {
+			};
+
 			this.updateModel(value);
 			this.edited = false;
 		},
@@ -219,6 +226,9 @@ CStudioAuthoring.Module.requireModule(
 				toolbar4: toolbarConfig4,
 				image_advtab: true,
 				encoding: 'xml',
+				relative_urls : false,
+				remove_script_host : false,
+				convert_urls : true,
 				readonly: _thisControl.readonly,
 				force_p_newlines: forcePTags,
 				force_br_newlines: forceBRTags,


### PR DESCRIPTION
[studio-ui] Images inserted through RTE (TinyMCE 5) in Articles are not rendered in preview #2844
[studio-ui] Existing RTE content disappears when clicking on "Add Another" in Articles using RTE (TinyMCE 5) #2843