### PR TITLE
[studio-ui] RTE (TinyMCE 5) unsaved content edits disappear when you click on the options for repeating control #2992

### DIFF
--- a/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
+++ b/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
@@ -270,6 +270,7 @@ CStudioAuthoring.Module.requireModule(
 					});
 
 					editor.on('keyup paste', function (e){
+						_thisControl.save();
 						_thisControl._onChangeVal(null, _thisControl);
 					});
 				}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2992