### PR TITLE
#2940

### DIFF
--- a/static-assets/ng-views/audit.html
+++ b/static-assets/ng-views/audit.html
@@ -188,7 +188,7 @@
 
              <div class="mb10 btn-group col-xs-6  col-sm-4 col-md-4">
                  <label>{{ 'admin.audit.TIMEZONE' | translate }}: </label>
-                 <select class="form-control" id="auditTimezone" ng-init="audit.timeZone" ng-options="value for value in audit.allTimeZones" ng-model="audit.timeZone"></select>
+                 <select class="form-control" id="auditTimezone" ng-init="audit.timeZone" ng-options="value for value in audit.allTimeZones" ng-model="audit.timeZone" ng-change="audit.newTimezone();" ></select>
              </div>
 
          </div>

--- a/static-assets/scripts/admin.js
+++ b/static-assets/scripts/admin.js
@@ -361,14 +361,14 @@
 
             var delayTimer;
 
-            if($cookies.get(Constants.AUDITTIMEZONECOOKIE)){
-                audit.timeZone = $cookies.get(Constants.AUDITTIMEZONECOOKIE);
+            if($cookies.get(Constants.AUDIT_TIMEZONE_COOKIE)){
+                audit.timeZone = $cookies.get(Constants.AUDIT_TIMEZONE_COOKIE);
             }else{
                 audit.timeZone = moment.tz.guess();
             }
 
             audit.newTimezone = function() {
-                $cookies.put(Constants.AUDITTIMEZONECOOKIE, audit.timeZone);
+                $cookies.put(Constants.AUDIT_TIMEZONE_COOKIE, audit.timeZone);
             };
 
             var getUsers = function(site) {

--- a/static-assets/scripts/admin.js
+++ b/static-assets/scripts/admin.js
@@ -343,9 +343,9 @@
 
     app.controller('AuditCtrl', [
         '$scope', '$state', '$window', '$sce', 'adminService', '$timeout',
-        '$stateParams', '$translate', '$location', 'moment', 'sitesService',
+        '$stateParams', '$translate', '$location', 'moment', 'sitesService', '$cookies', 'Constants',
         function ($scope, $state, $window, $sce, adminService, $timeout,
-                  $stateParams, $translate, $location, moment, sitesService) {
+                  $stateParams, $translate, $location, moment, sitesService, $cookies, Constants) {
 
             $scope.audit = {};
             $scope.isCollapsed = true;
@@ -361,16 +361,15 @@
 
             var delayTimer;
 
-            if(audit.site){
-                adminService.getTimeZone({
-                    "site" : audit.site,
-                    "path" : "/site-config.xml"
-                }).success(function (data) {
-                    audit.timeZone = data["default-timezone"];
-                });
+            if($cookies.get(Constants.AUDITTIMEZONECOOKIE)){
+                audit.timeZone = $cookies.get(Constants.AUDITTIMEZONECOOKIE);
             }else{
                 audit.timeZone = moment.tz.guess();
             }
+
+            audit.newTimezone = function() {
+                $cookies.put(Constants.AUDITTIMEZONECOOKIE, audit.timeZone);
+            };
 
             var getUsers = function(site) {
                 adminService.getUsers(site)

--- a/static-assets/scripts/main.js
+++ b/static-assets/scripts/main.js
@@ -384,7 +384,7 @@
         BULK_ENVIRONMENT: 'Live',
         HEADERS: 'headers',
         AUTH_HEADERS: "AUTH_HEADERS",
-        AUDITTIMEZONECOOKIE:"crafterStudioAuditTimezone"
+        AUDIT_TIMEZONE_COOKIE:"crafterStudioAuditTimezone"
     });
 
     app.service('authService', [

--- a/static-assets/scripts/main.js
+++ b/static-assets/scripts/main.js
@@ -383,7 +383,8 @@
         SHOW_LOADER: 'show-loader',
         BULK_ENVIRONMENT: 'Live',
         HEADERS: 'headers',
-        AUTH_HEADERS: "AUTH_HEADERS"
+        AUTH_HEADERS: "AUTH_HEADERS",
+        AUDITTIMEZONECOOKIE:"crafterStudioAuditTimezone"
     });
 
     app.service('authService', [


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2940 - [studio-ui] It would be nice to have consistent time zones for global and site audit log entries #2940
