### PR TITLE
#3088

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -833,7 +833,7 @@ var nodeOpen = false,
                             }
 
 
-                            dialogue.hide();
+                            dialogue.destroy();
                             eventNS.data = items;
                             eventNS.typeAction = "publish";
                             eventNS.dependencies = self.getGenDependency();


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3088 - [studio-ui] Duplicate dialog is not clickable after publish an item 