### PR TITLE
#3126

### DIFF
--- a/static-assets/themes/cstudioTheme/css/global.css
+++ b/static-assets/themes/cstudioTheme/css/global.css
@@ -152,6 +152,10 @@ sup {
   min-width: 1000px;
   width: 100%; }
 
+#header.cstudio-form-field-container{
+    min-width: auto;
+}
+
 #container {
   padding: 53px 30px 30px 30px; }
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3126 - [studio-ui] Helper text for Header field in Page - Article does not wrap when the browser is narrow #3126