### PR TITLE
Fix typo in error logging to console.

### DIFF
--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1642,7 +1642,7 @@ var CStudioForms = CStudioForms || function() {
                                 .done(onDone)
                                 .fail((function(datasourceDef){
                                     return function(jqxhr, settings, exception){
-                                        console.log(exeption);
+                                        console.log(exception);
                                         notLoaded.push(datasourceDef.type);
                                         releaseCallback();
                                     }


### PR DESCRIPTION
Catch `Uncaught ReferenceError: exeption is not defined`
