### PR TITLE
#3228

### DIFF
--- a/static-assets/components/cstudio-forms/controls/date-time.js
+++ b/static-assets/components/cstudio-forms/controls/date-time.js
@@ -1260,8 +1260,11 @@ YAHOO.extend(CStudioForms.Controls.DateTime, CStudioForms.CStudioFormField, {
 	},
 
     setStaticTimezone: function(value, timezone) {
-        var timezoneStr = timezone.substr(0, 3);
-        YDom.get(this.id + "-timezoneCode").innerHTML = timezoneStr;
+        var timezoneElt = $(this.id + "-timezoneCode");
+        if(timezoneElt){
+            var timezoneStr = timezone.substr(0, 3);
+            timezoneElt.html(timezoneStr);
+        }
         this._setValue(value, timezone);
     },
 

--- a/static-assets/components/cstudio-forms/controls/time.js
+++ b/static-assets/components/cstudio-forms/controls/time.js
@@ -1074,8 +1074,11 @@ YAHOO.extend(CStudioForms.Controls.Time, CStudioForms.CStudioFormField, {
 	},
 
     setStaticTimezone: function(value, timezone) {
-        var timezoneStr = timezone.substr(0, 3);
-        YDom.get(this.id + "-timezoneCode").innerHTML = timezoneStr;
+        var timezoneElt = $(this.id + "-timezoneCode");
+        if(timezoneElt){
+            var timezoneStr = timezone.substr(0, 3);
+            timezoneElt.html(timezoneStr);
+        }
         this._setValue(value, timezone);
     },
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3228 - [studio-ui] Date/Time control is not populated with populate expression when creating a new article page in website editorial #3228
