### PR TITLE
Support customization of component icons/styles in Studio

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -7331,7 +7331,10 @@ var nodeOpen = false,
                     }
 
                 }else{
-                    if(treeNodeTO.isComponent){     //isLevelDescriptor - also component
+                    if(customIcons[treeNodeTO.contentType]){ //support any local overrides for content type styling
+                        mainIconClass = customIcons[treeNodeTO.contentType].class;
+                        customStyle = customIcons[treeNodeTO.contentType].style;
+                    }else if(treeNodeTO.isComponent){     //isLevelDescriptor - also component
                         mainIconClass = defaultIcons.component.class;
                     }else if(treeNodeTO.isPage){
                         if((treeNodeTO.style && treeNodeTO.style.match(/\bfloating\b/)) || treeNodeTO.isFloating || treeNodeTO.floating){

--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -9101,8 +9101,13 @@ CStudioAuthoring.FilesDiff = {
                 key;
 
             if(data && data["mime-type"]){
-                for( var i = 0; i < data["mime-type"].length; i++){
-                    confMimeType = data["mime-type"][i];
+                var mimeTypes = data["mime-type"];
+                if(!Array.isArray(mimeTypes)) {
+                    //support single values coming from SiteServiceImpl#createMap
+                    mimeTypes = [mimeTypes];
+                }
+                for( var i = 0; i < mimeTypes.length; i++){
+                    confMimeType = mimeTypes[i];
                     mimeType = {};
 
                     if(confMimeType.icon){


### PR DESCRIPTION
This change allows you to leverage the existing mime-type.xml configuration to also define styles for content types.

If you create a custom content type **video**, the following configuration will allow you stylize your components in the Crafter Studio sidebar:
`    <mime-type>
        <type>/component/video</type>
        <icon>
            <class>fa-video-camera</class>
        </icon>
    </mime-type>
` 

![image](https://user-images.githubusercontent.com/20078963/60916465-6499c200-a25c-11e9-871d-05c09094e60e.png)
\* _This sample screenshot also uses a custom sidebar.xml folder, but with the logic in this PR, any content type from any wcm-root-folder can be customized._

This PR also provides support for defining a single mime-type value in mime-type.xml, which previously had a logic issue between the SiteServiceImpl parsing for single items and the looping logic in the Javascript code.

If this PR is accepted, I would recommend also updating the comment description in mime-type.xml to something like: 
> \- type: The mime type for assets, or content type for components. This is the target type that will be affected by the new icon/styles defined on the configuration

This change was not included here since those files come from the separate studio repository - please let me know if an additional PR is desired for this.