### PR TITLE
Fix #3281: [studio-ui] Cannot add users to group when there are more …

### DIFF
--- a/static-assets/scripts/admin.js
+++ b/static-assets/scripts/admin.js
@@ -1521,7 +1521,9 @@
             };
 
             groups.getUsersAutocomplete = function() {
-                adminService.getUsers().success(function(data){
+                var params = {};
+                params.limit = -1;
+                adminService.getUsers(params).success(function(data){
                     groups.usersAutocomplete = [];
 
                     data.users.forEach(function(user){


### PR DESCRIPTION
Fix https://github.com/craftercms/craftercms/issues/3281: [studio-ui] Cannot add users to group when there are more than 10 users available

Overrule default limit parameter when requesting Studios getAllUsers() API endpoint

