### PR TITLE
Mini-fix: Use correct resource bundle entry in child-content data source

### DIFF
--- a/static-assets/components/cstudio-forms/data-sources/child-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/child-content.js
@@ -261,7 +261,7 @@ YAHOO.extend(CStudioForms.Datasources.ChildContent, CStudioForms.CStudioFormData
 		return [
             { label: CMgs.format(langBundle, "Enable Create New"), name: "enableCreateNew", type: "boolean", defaultValue: "true"  },
             { label: CMgs.format(langBundle, "Enable Browse Existing"), name: "enableBrowseExisting", type: "boolean", defaultValue: "true" },
-			{ label: CMgs.format(langBundle, "repositoryPath"), name: "repoPath", type: "string" },
+			{ label: CMgs.format(langBundle, "repositoryPath"), name: "repositoryPath", type: "string" },
 			{ label: CMgs.format(langBundle, "browsePath"), name: "browsePath", type: "string" },
 			{ label: CMgs.format(langBundle, "defaultType"), name: "type", type: "string" }
 		];


### PR DESCRIPTION
`repoPath` is inexistent.