### PR TITLE
Additional option to search for child-content

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -1128,6 +1128,14 @@ var nodeOpen = false,
                     searchUrl += "&page=1";
                 }
 
+                if (!CStudioAuthoring.Utils.isEmpty(searchContext.mode)) {
+                  searchUrl += "&mode=" + searchContext.mode;
+                }
+
+                if (!CStudioAuthoring.Utils.isEmpty(searchContext.itemsPerPage)) {
+                  searchUrl += "&ipp=" + searchContext.itemsPerPage;
+                }
+
                 var childSearch = null;
 
                 if (!searchId || searchId == null || searchId == "undefined"
@@ -1135,6 +1143,7 @@ var nodeOpen = false,
                     childSearch = CStudioAuthoring.ChildSearchManager.createChildSearchConfig();
                     childSearch.openInSameWindow = openInSameWindow;
                     searchId = CStudioAuthoring.Utils.generateUUID();
+                    searchUrl += "&searchId=" + searchId;
 
                     childSearch.searchId = searchId;
                     childSearch.searchUrl = searchUrl;

--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -1136,6 +1136,10 @@ var nodeOpen = false,
                   searchUrl += "&ipp=" + searchContext.itemsPerPage;
                 }
 
+                if (!CStudioAuthoring.Utils.isEmpty(searchContext.query)) {
+                    searchUrl += "&query=" + searchContext.query;
+                }
+
                 var childSearch = null;
 
                 if (!searchId || searchId == null || searchId == "undefined"

--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -2043,7 +2043,7 @@ var nodeOpen = false,
                 });
 
                 $modal.find('.bd').append(template).end().appendTo(parentEl);
-                $modal.find('.studio-ice-container').css('z-index', 100525);
+                $modal.find('.studio-ice-container').css('z-index', 1035);
 
                 parent.iframeOpener = window;
                 window.open(url, name);

--- a/static-assets/components/cstudio-common/resources/de/base.js
+++ b/static-assets/components/cstudio-common/resources/de/base.js
@@ -819,6 +819,9 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "de", {
     inputProfileId: "Eingabeprofil-ID",
     outputProfileId: "Ausgabeprofil-ID",
     postfixes: "Postfixes",
+    enableCreateNew: "Zeige 'Neu anlegen'",
+    enableBrowseExisting: "Zeige 'Auswählen'",
+    enableSearchExisting: "Zeige 'Suchen'",
 
     /*Restrictions*/
     required: "Erforderlich",
@@ -970,6 +973,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "de", {
     edit: "Bearbeiten",
     createNew: "Neu Anlegen",
     browseExisting: "Auswählen",
+    searchExisting: "Suchen",
 
     /*help popover*/
     pattern: "Muster",

--- a/static-assets/components/cstudio-common/resources/en/base.js
+++ b/static-assets/components/cstudio-common/resources/en/base.js
@@ -820,6 +820,9 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "en", {
     inputProfileId: "Input Profile Id",
     outputProfileId: "Output Profile Id",
     postfixes: "Postfixes",
+    enableCreateNew: "Enable Create New",
+    enableBrowseExisting: "Enable Browse Existing",
+    enableSearchExisting: "Enable Search Existing",
 
     /*Restrictions*/
     required: "Required",
@@ -971,6 +974,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "en", {
     edit: "Edit",
     createNew: "Create New",
     browseExisting: "Browse for Existing",
+    searchExisting: "Search for Existing",
 
     /*help popover*/
     pattern: "Pattern",

--- a/static-assets/components/cstudio-common/resources/es/base.js
+++ b/static-assets/components/cstudio-common/resources/es/base.js
@@ -794,6 +794,9 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "es", {
     inputProfileId: "Id de perfil de entrada",
     outputProfileId: "Id de perfil de salida",
     postfixes: "Postfixes",
+    enableCreateNew: "Mostrar 'Crear nuevo'",
+    enableBrowseExisting: "Mostrar 'Seleccionar Existentes'",
+    enableSearchExisting: "Mostrar 'Buscar Existentes'",
 
     /*Restrictions*/
     required: "Requerido",
@@ -926,6 +929,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "es", {
     edit: "Editar",
     createNew: "Crear Nuevo",
     browseExisting: "Buscar Existentes",
+    searchExisting: "Buscar Existentes",
 
     /*help popover*/
     pattern: "Patrón",

--- a/static-assets/components/cstudio-common/resources/kr/base.js
+++ b/static-assets/components/cstudio-common/resources/kr/base.js
@@ -764,6 +764,9 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "kr", {
     inputProfileId: "입력 프로파일 ID",
     outputProfileId: "출력 프로필 ID",
     postfixes: "포스트 픽스",
+    enableCreateNew: "쇼 새로 만들기",
+    enableBrowseExisting: "쇼 기존 항목 찾아보기",
+    enableSearchExisting: "쇼 기존 검색",
 
     /*Restrictions*/
     required: "필요",
@@ -892,6 +895,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "kr", {
     edit: "편집하다",
     createNew: "새로 만들기",
     browseExisting: "기존 항목 찾아보기",
+    searchExisting: "기존 검색",
 
     /*help popover*/
     pattern: "무늬",

--- a/static-assets/components/cstudio-forms/data-sources/child-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/child-content.js
@@ -160,6 +160,14 @@ YAHOO.extend(CStudioForms.Datasources.ChildContent, CStudioForms.CStudioFormData
       mode: "select"              // open search not in default but in select mode
     };
 
+    // use browsePath for querying content under that folder only
+    if (_self.browsePath != undefined && _self.browsePath != '') {
+      var browsePath =  _self.browsePath.replace(/\//gi, "\\/");
+      browsePath = "localId:" + browsePath + "*";
+      browsePath = encodeURI(browsePath);
+      searchContext.query = browsePath;
+    }
+
     CStudioAuthoring.Operations.openSearch(searchContext, true, {
       success: function (searchId, selectedTOs) {
         for (var i = 0; i < selectedTOs.length; i++) {

--- a/static-assets/components/cstudio-forms/data-sources/child-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/child-content.js
@@ -144,8 +144,22 @@ YAHOO.extend(CStudioForms.Datasources.ChildContent, CStudioForms.CStudioFormData
       control.containerEl.removeChild(addContainerEl);
     }
 
-    var searchContext = CStudioAuthoring.Service.createSearchContext();
-    searchContext.keywords = encodeURIComponent("");
+    var searchContext = {
+      searchId: null,
+      itemsPerPage: 12,
+      keywords: "",
+      filters: {},
+      sortBy: "internalName",      // sortBy has value by default, so numFilters starts at 1
+      sortOrder: "asc",
+      numFilters: 1,
+      filtersShowing: 10,
+      currentPage: 1,
+      searchInProgress: false,
+      view: 'grid',
+      lastSelectedFilterSelector: '',
+      mode: "select"              // open search not in default but in select mode
+    };
+
     CStudioAuthoring.Operations.openSearch(searchContext, true, {
       success: function (searchId, selectedTOs) {
         for (var i = 0; i < selectedTOs.length; i++) {
@@ -157,7 +171,7 @@ YAHOO.extend(CStudioForms.Datasources.ChildContent, CStudioForms.CStudioFormData
       },
       failure: function () {
       }
-    }, null);
+    }, searchContext.searchId);
   },
 
   add: function(control, onlyAppend) {

--- a/static-assets/components/cstudio-search/search.js
+++ b/static-assets/components/cstudio-search/search.js
@@ -472,10 +472,11 @@
             template = Handlebars.compile(source),
             html,
             editable = true,
-            permissionsKey = CStudioAuthoringContext.user;
+            permissionsKey = CStudioAuthoringContext.user,
+            isInSelectMode = (this.searchContext.mode == "select");
 
         if(
-            result.type === "Page"
+            (result.type === "Page" && !isInSelectMode)
             || result.type === "Image"
             || result.type === "Video"
         ){
@@ -489,33 +490,46 @@
         }
         result.icon = CStudioSearch.typesMap[result.type] ? CStudioSearch.typesMap[result.type].icon : CStudioSearch.typesMap["Other"].icon;
 
-        var permissionsCached = cache.get(permissionsKey),
-            validateAndRender = function(results) {
-                var isWriteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "write"),
-                    isDeleteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "delete");
-                result.editable = isWriteAllowed;
-                // set permissions for edit/delete actions to be (or not) rendered
-                result.permissions = {
-                    edit: isWriteAllowed && editable,
-                    delete: isDeleteAllowed
-                };
-
-                html = template(result);
-                $(html).appendTo($resultsContainer);
+        // when in select mode, dont give option to delete or edit
+        if (isInSelectMode) {
+            result.editable = false;
+            result.permissions = {
+                edit: false,
+                delete: false
             };
 
-        if(permissionsCached){
-            validateAndRender(permissionsCached);
-        }else{
-            CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, result.path, {
-                success: function (results) {
-                    cache.set(permissionsKey, results, CStudioAuthoring.Constants.CACHE_TIME_GET_ROLES);
-                    validateAndRender(results);
-                },
-                failure: function () {
-                    throw new Error('Unable to retrieve user permissions');
-                }
-            });
+            html = template(result);
+            $(html).appendTo($resultsContainer);
+        }
+        else {
+            var permissionsCached = cache.get(permissionsKey),
+                validateAndRender = function(results) {
+                    var isWriteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "write"),
+                        isDeleteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "delete");
+                    result.editable = isWriteAllowed;
+                    // set permissions for edit/delete actions to be (or not) rendered
+                    result.permissions = {
+                        edit: isWriteAllowed && editable,
+                        delete: isDeleteAllowed
+                    };
+
+                    html = template(result);
+                    $(html).appendTo($resultsContainer);
+                };
+
+            if(permissionsCached){
+                validateAndRender(permissionsCached);
+            }else{
+                CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, result.path, {
+                    success: function (results) {
+                        cache.set(permissionsKey, results, CStudioAuthoring.Constants.CACHE_TIME_GET_ROLES);
+                        validateAndRender(results);
+                    },
+                    failure: function () {
+                        throw new Error('Unable to retrieve user permissions');
+                    }
+                });
+            }
         }
     }
 

--- a/static-assets/components/cstudio-search/search.js
+++ b/static-assets/components/cstudio-search/search.js
@@ -26,6 +26,7 @@
 
     /* default search context */
     CStudioSearch.searchContext = {
+        query: "",
         searchId: null,
         itemsPerPage: 20,
         keywords: "",
@@ -356,6 +357,7 @@
         var sortBy = CStudioAuthoring.Utils.getQueryVariable(queryString, "sortBy");
         var view = CStudioAuthoring.Utils.getQueryVariable(queryString, "view");
         var mode = CStudioAuthoring.Utils.getQueryVariable(queryString, "mode");
+        var query = CStudioAuthoring.Utils.getQueryVariable(queryString, "query");
 
         searchContext.keywords = (keywords) ? keywords : searchContext.keywords;
         searchContext.searchId = (searchId) ? searchId : null;
@@ -364,6 +366,7 @@
         searchContext.view = (view) ? view : searchContext.view;
         searchContext.itemsPerPage = (itemsPerPage) ? itemsPerPage : searchContext.itemsPerPage;
         searchContext.mode = (mode) ? mode : searchContext.mode;
+        searchContext.query = (query) ? query : searchContext.query;
 
         $.each(urlParams, function(key, value){
             var processedKey,
@@ -525,6 +528,7 @@
     CStudioSearch.createSearchQuery = function() {
         var searchContext = this.searchContext;
         var query = {
+            "query": searchContext.query,
             "keywords": searchContext.keywords,
             "offset": (searchContext.currentPage - 1) * searchContext.itemsPerPage,
             "limit": searchContext.itemsPerPage,
@@ -980,6 +984,7 @@
         newUrl += '&sortBy=' + searchContext.sortBy;
         newUrl += '&view=' + searchContext.view;
         newUrl += '&mode=' + searchContext.mode;
+        newUrl += '&query=' + searchContext.query;
 
         // Add search filters to url
         // csf = crafter studio filter

--- a/static-assets/components/cstudio-search/search.js
+++ b/static-assets/components/cstudio-search/search.js
@@ -38,7 +38,8 @@
         searchInProgress: false,
         view: 'grid',
         lastSelectedFilterSelector: '',
-        selectionState: {}
+        selectionState: {},
+        mode: "default"              // possible mode values: [default|select]
     };
 
     CStudioSearch.typesMap = {
@@ -74,8 +75,24 @@
     }
 
     CStudioSearch.init = function() {
+
+        CStudioAuthoring.OverlayRequiredResources.loadRequiredResources();
+        CStudioAuthoring.OverlayRequiredResources.loadContextNavCss();
+
         var searchContext = this.determineSearchContextFromUrl();
         this.searchContext = searchContext;
+
+        $('section.cstudio-search').addClass(this.searchContext.mode);
+
+        // arrange iframe according to search mode
+        if (this.searchContext.mode != "select") {
+          CStudioAuthoring.Events.contextNavLoaded.subscribe(function() {
+            CStudioAuthoring.ContextualNav.hookNavOverlayFromAuthoring();
+            CStudioAuthoring.InContextEdit.autoInitializeEditRegions();
+          });
+        }
+        else
+          this.renderFormControls();
 
         CStudioAuthoring.Operations.translateContent(langBundle, null, 'data-trans');
         this.performSearch();
@@ -124,10 +141,26 @@
             $('input[type="checkbox"][data-url="' + path + '"]').prop('checked', selected);
 
             // if all checkboxes are selected/unselected -> update select all checkbox
+            var currentlySelected = $('input[type="checkbox"].search-select-item:checked').length;
+            allSelected = currentlySelected == $('input[type="checkbox"].search-select-item').length;
+
+            $('#formSaveButton').prop("disabled",currentlySelected == 0);
+            $('#searchSelectAll').prop('checked', allSelected);
+
+
             allSelected = $('input[type="checkbox"].search-select-item:checked').length == $('input[type="checkbox"].search-select-item').length;
             $('#searchSelectAll').prop('checked', allSelected);
 
             CStudioSearch.changeSelectStatus(path, selected);
+        });
+
+        $('#cstudio-command-controls').on('click', '#formSaveButton', function(){
+          CStudioSearch.saveContent();
+        });
+
+        $('#cstudio-command-controls').on('click', '#formCancelButton', function(){
+          window.close();
+          $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
         });
 
         // Select all results
@@ -322,6 +355,7 @@
         var page = CStudioAuthoring.Utils.getQueryVariable(queryString, "page");
         var sortBy = CStudioAuthoring.Utils.getQueryVariable(queryString, "sortBy");
         var view = CStudioAuthoring.Utils.getQueryVariable(queryString, "view");
+        var mode = CStudioAuthoring.Utils.getQueryVariable(queryString, "mode");
 
         searchContext.keywords = (keywords) ? keywords : searchContext.keywords;
         searchContext.searchId = (searchId) ? searchId : null;
@@ -329,6 +363,7 @@
         searchContext.sortBy = (sortBy) ? sortBy : searchContext.sortBy;
         searchContext.view = (view) ? view : searchContext.view;
         searchContext.itemsPerPage = (itemsPerPage) ? itemsPerPage : searchContext.itemsPerPage;
+        searchContext.mode = (mode) ? mode : searchContext.mode;
 
         $.each(urlParams, function(key, value){
             var processedKey,
@@ -419,6 +454,16 @@
         $.each(results.items, function(index, result){
             CStudioSearch.renderResult(result);
         });
+    }
+
+    CStudioSearch.renderFormControls = function(result) {
+        var $formControlContainer = $('#cstudio-command-controls-container'),
+            source = $("#hb-command-controls").html(),
+            template = Handlebars.compile(source),
+            html;
+
+        html = template(result);
+        $(html).appendTo($formControlContainer);
     }
 
     CStudioSearch.renderResult = function(result) {
@@ -792,6 +837,85 @@
         CStudioAuthoring.Service.lookupContentItem(CStudioAuthoringContext.site, path, callback, false, false);
     }
 
+    CStudioSearch.saveContent = function() {
+        var searchId = this.searchContext ? this.searchContext.searchId : "" ;
+        var crossServerAccess = false;
+        var opener = window.opener ? window.opener : parent.iframeOpener;
+
+        try {
+            // unfortunately we cannot signal a form close across servers
+            // our preview is in one server
+            // our authoring is in another
+            // in this case we just close the window, no way to pass back details which is ok in some cases
+            if(opener.CStudioAuthoring) { }
+        }
+        catch(crossServerAccessErr) {
+            crossServerAccess = true;
+        }
+        if(opener && !crossServerAccess) {
+
+            if(opener.CStudioAuthoring) {
+                var openerChildSearchMgr = opener.CStudioAuthoring.ChildSearchManager;
+
+                if(openerChildSearchMgr) {
+                    var searchConfig = openerChildSearchMgr.searches[searchId];
+                    if(searchConfig) {
+                        var callback = searchConfig.saveCallback;
+                        if(callback) {
+                            var selectedContentTOs = CStudioAuthoring.SelectedContent.getSelectedContent();
+                            console.log(selectedContentTOs);
+                            openerChildSearchMgr.signalSearchClose(searchId, selectedContentTOs);
+                      }
+                      else {
+                          //TODO PUT THIS BACK
+                          //alert("no success callback provided for seach: " + searchId);
+                      }
+
+                      window.close();
+                      $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+
+                    }
+                    else {
+                        CStudioAuthoring.Operations.showSimpleDialog(
+                          "lookUpChildError-dialog",
+                          CStudioAuthoring.Operations.simpleDialogTypeINFO,
+                          CMgs.format(langBundle, "notification"),
+                          CMgs.format(langBundle, "lookUpChildError") + searchId,
+                          [{ text: "OK",  handler:function(){
+                              this.hide();
+                              window.close();
+                              $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+                            }, isDefault:false }],
+                          YAHOO.widget.SimpleDialog.ICON_BLOCK,
+                          "studioDialog"
+                        );
+                    }
+                }
+                else {
+                    CStudioAuthoring.Operations.showSimpleDialog(
+                        "lookUpParentError-dialog",
+                        CStudioAuthoring.Operations.simpleDialogTypeINFO,
+                        CMgs.format(langBundle, "notification"),
+                        CMgs.format(langBundle, "lookUpParentError") + searchId,
+                        [{ text: "OK",  handler:function(){
+                            this.hide();
+                            window.close();
+                            $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+                          }, isDefault:false }],
+                        YAHOO.widget.SimpleDialog.ICON_BLOCK,
+                        "studioDialog"
+                    );
+                }
+            }
+        }
+        else {
+            // no window opening context or cross server call
+            // the only thing we can do is close the window
+            window.close();
+            $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+        }
+    }
+
     CStudioSearch.editElement = function(path){
         var editCallback = {
                 success: function(){
@@ -853,6 +977,7 @@
         newUrl += '&page=' + searchContext.currentPage;
         newUrl += '&sortBy=' + searchContext.sortBy;
         newUrl += '&view=' + searchContext.view;
+        newUrl += '&mode=' + searchContext.mode;
 
         // Add search filters to url
         // csf = crafter studio filter

--- a/static-assets/components/cstudio-search/search.js
+++ b/static-assets/components/cstudio-search/search.js
@@ -490,46 +490,34 @@
         }
         result.icon = CStudioSearch.typesMap[result.type] ? CStudioSearch.typesMap[result.type].icon : CStudioSearch.typesMap["Other"].icon;
 
-        // when in select mode, dont give option to delete or edit
-        if (isInSelectMode) {
-            result.editable = false;
-            result.permissions = {
-                edit: false,
-                delete: false
-            };
-
-            html = template(result);
-            $(html).appendTo($resultsContainer);
-        }
-        else {
-            var permissionsCached = cache.get(permissionsKey),
-                validateAndRender = function(results) {
-                    var isWriteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "write"),
-                        isDeleteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "delete");
-                    result.editable = isWriteAllowed;
-                    // set permissions for edit/delete actions to be (or not) rendered
-                    result.permissions = {
-                        edit: isWriteAllowed && editable,
-                        delete: isDeleteAllowed
-                    };
-
-                    html = template(result);
-                    $(html).appendTo($resultsContainer);
+        var permissionsCached = cache.get(permissionsKey),
+            validateAndRender = function(results) {
+                var isWriteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "write"),
+                    isDeleteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "delete");
+                result.editable = isWriteAllowed;
+                // set permissions for edit/delete actions to be (or not) rendered
+                // when in select mode, dont give option to delete or edit
+                result.permissions = {
+                    edit: isWriteAllowed && editable,
+                    delete: isDeleteAllowed && !isInSelectMode
                 };
 
-            if(permissionsCached){
-                validateAndRender(permissionsCached);
-            }else{
-                CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, result.path, {
-                    success: function (results) {
-                        cache.set(permissionsKey, results, CStudioAuthoring.Constants.CACHE_TIME_GET_ROLES);
-                        validateAndRender(results);
-                    },
-                    failure: function () {
-                        throw new Error('Unable to retrieve user permissions');
-                    }
-                });
-            }
+                html = template(result);
+                $(html).appendTo($resultsContainer);
+            };
+
+        if(permissionsCached){
+            validateAndRender(permissionsCached);
+        }else{
+            CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, result.path, {
+                success: function (results) {
+                    cache.set(permissionsKey, results, CStudioAuthoring.Constants.CACHE_TIME_GET_ROLES);
+                    validateAndRender(results);
+                },
+                failure: function () {
+                    throw new Error('Unable to retrieve user permissions');
+                }
+            });
         }
     }
 

--- a/templates/web/search.ftl
+++ b/templates/web/search.ftl
@@ -39,7 +39,6 @@
     <script src="${path}momentjs/moment-timezone-with-data-2012-2022.min.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
 
     <#include "/templates/web/common/page-fragments/studio-context.ftl" />
-    <#include "/templates/web/common/page-fragments/context-nav.ftl" />
 
     <script src="/studio/static-assets/scripts/crafter.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
     <script src="/studio/static-assets/scripts/animator.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
@@ -150,6 +149,8 @@
         </div>
 
     </section>
+
+    <div id="cstudio-command-controls-container"></div>
 
     <script id="hb-search-result" type="text/x-handlebars-template">
         <div class="result-container">
@@ -264,6 +265,15 @@
                 </div>
             </div>
         </div>
+    </script>
+
+    <script id="hb-command-controls" type="text/x-handlebars-template">
+      <div id="cstudio-command-controls">
+        <div id="submission-controls" class="cstudio-form-controls-button-container">
+          <input id="formSaveButton" type="button" class="cstudio-search-btn cstudio-button btn btn-primary" disabled="" value="Add Selection">
+          <input id="formCancelButton" type="button" class="cstudio-search-btn cstudio-button btn btn-default" value="Cancel">
+        </div>
+      </div>
     </script>
 
     <script type="text/javascript">

--- a/ui/scss/_studio-view.scss
+++ b/ui/scss/_studio-view.scss
@@ -437,7 +437,7 @@ table.scroll-body {
     right: 0;
     bottom: 0;
     background-color: rgba(0, 0, 0, 0.65);
-    z-index: 3000;
+    z-index: 1035;
   }
 
   .studio-ice-dialog {

--- a/ui/scss/search.scss
+++ b/ui/scss/search.scss
@@ -425,4 +425,24 @@
         padding: 10px;
         font-weight: bold;
     }
+
+    // select mode
+    &.select {
+        top: 0;
+        left: 0;
+
+        .pagination-container {
+            margin-bottom: 100px;
+        }
+    }
+}
+
+#cstudio-command-controls {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    background: #f8f8f8;
+    padding: 15px 0;
+    border-top: 1px solid #e7e7e7;
+    z-index: 5;
 }


### PR DESCRIPTION
Old feature request: https://github.com/craftercms/craftercms/issues/256

We extended the data-source child-content for an option to use search instead of browse.

**Detailed description**
Basically, in our crafter site we have page assets with slots to contain components. Components are reused on different pages and different tenants. A "slot" is managed by a datasource of type child-content. We already have a lot of components, which caused problems because all components were created in a couple of folders only. That’s why we introduced [macros](https://docs.craftercms.org/en/3.1/developers/content-modeling.html#macros-for-data-sources) for automated organizing components in folders like ‘/site/components/{yyyy}/{mm}/{dd}’
By doing so, folders are “small” enough, but now content editors had problems trying to find existing components in the child-content datasource. In order to use the browse functionality, they would need to know the exact day, when a component has been created... and content editors never know :slightly_smiling_face:
That’s why we have added an option to use search functionality in addition or instead of “Browse for existing”.
<img width="1873" alt="child-content" src="https://user-images.githubusercontent.com/1357798/65887602-8196ea80-e39e-11e9-8118-9fe09e5d0d04.png">

We've extended Search in Crafter by a _select_ mode and use 'browsePath' property as search folder:
<img width="1855" alt="search" src="https://user-images.githubusercontent.com/1357798/65887714-b30fb600-e39e-11e9-858a-4ad19b2b25f6.png">
