### PR TITLE
Additional option to search for images in data-source `img-repository-upload`

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -1047,6 +1047,41 @@ var nodeOpen = false,
                     searchUrl += "&page=1";
                 }
 
+                // Add search filters to url
+                // csf = crafter studio filter
+                // csr = crafter studio range
+                // csrTO = crafter studio range separator in URL
+                if(!jQuery.isEmptyObject( searchContext.filters )) {
+                  $.each(searchContext.filters, function(key, value){
+                    if(typeof value === 'string'){
+                      searchUrl += '&csf_' + key + '=' + value;
+                    } else if( $.isArray(value) ) {
+                      $.each(value, function() {
+                        searchUrl += '&csf_' + key + '=' + this;
+                      })
+                    } else {  //is a range
+                      if (value.date) {
+                        var min = value.min,
+                          max = value.max,
+                          id = value.id;
+                        searchUrl += '&csf_' + key + '=csr_' + min + 'csrTO' + max + 'csrID' + id;
+                      }else{
+                        var min = isNaN(value.min) ? 'null' : value.min,
+                          max = isNaN(value.max) ? 'null' : value.max;
+                        searchUrl += '&csf_' + key + '=csr_' + min + 'csrTO' + max;
+                      }
+
+                    }
+                  })
+                }
+                if (!CStudioAuthoring.Utils.isEmpty(searchContext.mode)) {
+                  searchUrl += "&mode=" + searchContext.mode;
+                }
+
+                if (!CStudioAuthoring.Utils.isEmpty(searchContext.itemsPerPage)) {
+                  searchUrl += "&ipp=" + searchContext.itemsPerPage;
+                }
+
                 var childSearch = null;
 
                 if (!searchId || searchId == null || searchId == "undefined"
@@ -1054,6 +1089,7 @@ var nodeOpen = false,
                     childSearch = CStudioAuthoring.ChildSearchManager.createChildSearchConfig();
                     childSearch.openInSameWindow = openInSameWindow;
                     searchId = CStudioAuthoring.Utils.generateUUID();
+                    searchUrl += "&searchId=" + searchId;
 
                     childSearch.searchId = searchId;
                     childSearch.searchUrl = searchUrl;

--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -1989,7 +1989,7 @@ var nodeOpen = false,
                 });
 
                 $modal.find('.bd').append(template).end().appendTo(parentEl);
-                $modal.find('.studio-ice-container').css('z-index', 100525);
+                $modal.find('.studio-ice-container').css('z-index', 1035);
 
                 parent.iframeOpener = window;
                 window.open(url, name);

--- a/static-assets/components/cstudio-common/resources/de/base.js
+++ b/static-assets/components/cstudio-common/resources/de/base.js
@@ -826,6 +826,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "de", {
     inputProfileId: "Eingabeprofil-ID",
     outputProfileId: "Ausgabeprofil-ID",
     postfixes: "Postfixes",
+    useSearch: "Suche verwenden",
 
     /*Restrictions*/
     required: "Erforderlich",

--- a/static-assets/components/cstudio-common/resources/en/base.js
+++ b/static-assets/components/cstudio-common/resources/en/base.js
@@ -827,6 +827,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "en", {
     inputProfileId: "Input Profile Id",
     outputProfileId: "Output Profile Id",
     postfixes: "Postfixes",
+    useSearch: "Use Search",
 
     /*Restrictions*/
     required: "Required",

--- a/static-assets/components/cstudio-common/resources/es/base.js
+++ b/static-assets/components/cstudio-common/resources/es/base.js
@@ -801,6 +801,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "es", {
     inputProfileId: "Id de perfil de entrada",
     outputProfileId: "Id de perfil de salida",
     postfixes: "Postfixes",
+    useSearch: "Usar Búsqueda",
 
     /*Restrictions*/
     required: "Requerido",

--- a/static-assets/components/cstudio-common/resources/kr/base.js
+++ b/static-assets/components/cstudio-common/resources/kr/base.js
@@ -771,6 +771,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "kr", {
     inputProfileId: "입력 프로파일 ID",
     outputProfileId: "출력 프로필 ID",
     postfixes: "포스트 픽스",
+    useSearch: "검색 사용",
 
     /*Restrictions*/
     required: "필요",

--- a/static-assets/components/cstudio-search/search.js
+++ b/static-assets/components/cstudio-search/search.js
@@ -472,13 +472,10 @@
             template = Handlebars.compile(source),
             html,
             editable = true,
-            permissionsKey = CStudioAuthoringContext.user;
+            permissionsKey = CStudioAuthoringContext.user,
+            isInSelectMode = (this.searchContext.mode == "select");
 
-        if(
-            result.type === "Page"
-            || result.type === "Image"
-            || result.type === "Video"
-        ){
+        if( !isInSelectMode && (result.type === "Page" || result.type === "Image" || result.type === "Video")){
             result.previewable = true;
         }
 
@@ -489,33 +486,46 @@
         }
         result.icon = CStudioSearch.typesMap[result.type] ? CStudioSearch.typesMap[result.type].icon : CStudioSearch.typesMap["Other"].icon;
 
-        var permissionsCached = cache.get(permissionsKey),
-            validateAndRender = function(results) {
-                var isWriteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "write"),
-                    isDeleteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "delete");
-                result.editable = isWriteAllowed;
-                // set permissions for edit/delete actions to be (or not) rendered
-                result.permissions = {
-                    edit: isWriteAllowed && editable,
-                    delete: isDeleteAllowed
-                };
-
-                html = template(result);
-                $(html).appendTo($resultsContainer);
+        // when in select mode, dont give option to delete or edit
+        if (isInSelectMode) {
+            result.editable = false;
+            result.permissions = {
+                edit: false,
+                delete: false
             };
 
-        if(permissionsCached){
-            validateAndRender(permissionsCached);
-        }else{
-            CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, result.path, {
-                success: function (results) {
-                    cache.set(permissionsKey, results, CStudioAuthoring.Constants.CACHE_TIME_GET_ROLES);
-                    validateAndRender(results);
-                },
-                failure: function () {
-                    throw new Error('Unable to retrieve user permissions');
-                }
-            });
+            html = template(result);
+            $(html).appendTo($resultsContainer);
+        }
+        else {
+            var permissionsCached = cache.get(permissionsKey),
+                validateAndRender = function(results) {
+                    var isWriteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "write"),
+                        isDeleteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "delete");
+                    result.editable = isWriteAllowed;
+                    // set permissions for edit/delete actions to be (or not) rendered
+                    result.permissions = {
+                        edit: isWriteAllowed && editable,
+                        delete: isDeleteAllowed
+                    };
+
+                    html = template(result);
+                    $(html).appendTo($resultsContainer);
+                };
+
+            if(permissionsCached){
+                validateAndRender(permissionsCached);
+            }else{
+                CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, result.path, {
+                    success: function (results) {
+                        cache.set(permissionsKey, results, CStudioAuthoring.Constants.CACHE_TIME_GET_ROLES);
+                        validateAndRender(results);
+                    },
+                    failure: function () {
+                        throw new Error('Unable to retrieve user permissions');
+                    }
+                });
+            }
         }
     }
 

--- a/static-assets/components/cstudio-search/search.js
+++ b/static-assets/components/cstudio-search/search.js
@@ -38,7 +38,8 @@
         searchInProgress: false,
         view: 'grid',
         lastSelectedFilterSelector: '',
-        selectionState: {}
+        selectionState: {},
+        mode: "default"              // possible mode values: [default|select]
     };
 
     CStudioSearch.typesMap = {
@@ -74,8 +75,24 @@
     }
 
     CStudioSearch.init = function() {
+
+        CStudioAuthoring.OverlayRequiredResources.loadRequiredResources();
+        CStudioAuthoring.OverlayRequiredResources.loadContextNavCss();
+
         var searchContext = this.determineSearchContextFromUrl();
         this.searchContext = searchContext;
+
+        $('section.cstudio-search').addClass(this.searchContext.mode);
+
+        // arrange iframe according to search mode
+        if (this.searchContext.mode != "select") {
+          CStudioAuthoring.Events.contextNavLoaded.subscribe(function() {
+            CStudioAuthoring.ContextualNav.hookNavOverlayFromAuthoring();
+            CStudioAuthoring.InContextEdit.autoInitializeEditRegions();
+          });
+        }
+        else
+          this.renderFormControls();
 
         CStudioAuthoring.Operations.translateContent(langBundle, null, 'data-trans');
         this.performSearch();
@@ -124,10 +141,26 @@
             $('input[type="checkbox"][data-url="' + path + '"]').prop('checked', selected);
 
             // if all checkboxes are selected/unselected -> update select all checkbox
+            var currentlySelected = $('input[type="checkbox"].search-select-item:checked').length;
+            allSelected = currentlySelected == $('input[type="checkbox"].search-select-item').length;
+
+            $('#formSaveButton').prop("disabled",currentlySelected == 0);
+            $('#searchSelectAll').prop('checked', allSelected);
+
+
             allSelected = $('input[type="checkbox"].search-select-item:checked').length == $('input[type="checkbox"].search-select-item').length;
             $('#searchSelectAll').prop('checked', allSelected);
 
             CStudioSearch.changeSelectStatus(path, selected);
+        });
+
+        $('#cstudio-command-controls').on('click', '#formSaveButton', function(){
+          CStudioSearch.saveContent();
+        });
+
+        $('#cstudio-command-controls').on('click', '#formCancelButton', function(){
+          window.close();
+          $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
         });
 
         // Select all results
@@ -322,6 +355,7 @@
         var page = CStudioAuthoring.Utils.getQueryVariable(queryString, "page");
         var sortBy = CStudioAuthoring.Utils.getQueryVariable(queryString, "sortBy");
         var view = CStudioAuthoring.Utils.getQueryVariable(queryString, "view");
+        var mode = CStudioAuthoring.Utils.getQueryVariable(queryString, "mode");
 
         searchContext.keywords = (keywords) ? keywords : searchContext.keywords;
         searchContext.searchId = (searchId) ? searchId : null;
@@ -329,6 +363,7 @@
         searchContext.sortBy = (sortBy) ? sortBy : searchContext.sortBy;
         searchContext.view = (view) ? view : searchContext.view;
         searchContext.itemsPerPage = (itemsPerPage) ? itemsPerPage : searchContext.itemsPerPage;
+        searchContext.mode = (mode) ? mode : searchContext.mode;
 
         $.each(urlParams, function(key, value){
             var processedKey,
@@ -419,6 +454,16 @@
         $.each(results.items, function(index, result){
             CStudioSearch.renderResult(result);
         });
+    }
+
+    CStudioSearch.renderFormControls = function(result) {
+        var $formControlContainer = $('#cstudio-command-controls-container'),
+            source = $("#hb-command-controls").html(),
+            template = Handlebars.compile(source),
+            html;
+
+        html = template(result);
+        $(html).appendTo($formControlContainer);
     }
 
     CStudioSearch.renderResult = function(result) {
@@ -792,6 +837,85 @@
         CStudioAuthoring.Service.lookupContentItem(CStudioAuthoringContext.site, path, callback, false, false);
     }
 
+    CStudioSearch.saveContent = function() {
+        var searchId = this.searchContext ? this.searchContext.searchId : "" ;
+        var crossServerAccess = false;
+        var opener = window.opener ? window.opener : parent.iframeOpener;
+
+        try {
+            // unfortunately we cannot signal a form close across servers
+            // our preview is in one server
+            // our authoring is in another
+            // in this case we just close the window, no way to pass back details which is ok in some cases
+            if(opener.CStudioAuthoring) { }
+        }
+        catch(crossServerAccessErr) {
+            crossServerAccess = true;
+        }
+        if(opener && !crossServerAccess) {
+
+            if(opener.CStudioAuthoring) {
+                var openerChildSearchMgr = opener.CStudioAuthoring.ChildSearchManager;
+
+                if(openerChildSearchMgr) {
+                    var searchConfig = openerChildSearchMgr.searches[searchId];
+                    if(searchConfig) {
+                        var callback = searchConfig.saveCallback;
+                        if(callback) {
+                            var selectedContentTOs = CStudioAuthoring.SelectedContent.getSelectedContent();
+                            console.log(selectedContentTOs);
+                            openerChildSearchMgr.signalSearchClose(searchId, selectedContentTOs);
+                      }
+                      else {
+                          //TODO PUT THIS BACK
+                          //alert("no success callback provided for seach: " + searchId);
+                      }
+
+                      window.close();
+                      $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+
+                    }
+                    else {
+                        CStudioAuthoring.Operations.showSimpleDialog(
+                          "lookUpChildError-dialog",
+                          CStudioAuthoring.Operations.simpleDialogTypeINFO,
+                          CMgs.format(langBundle, "notification"),
+                          CMgs.format(langBundle, "lookUpChildError") + searchId,
+                          [{ text: "OK",  handler:function(){
+                              this.hide();
+                              window.close();
+                              $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+                            }, isDefault:false }],
+                          YAHOO.widget.SimpleDialog.ICON_BLOCK,
+                          "studioDialog"
+                        );
+                    }
+                }
+                else {
+                    CStudioAuthoring.Operations.showSimpleDialog(
+                        "lookUpParentError-dialog",
+                        CStudioAuthoring.Operations.simpleDialogTypeINFO,
+                        CMgs.format(langBundle, "notification"),
+                        CMgs.format(langBundle, "lookUpParentError") + searchId,
+                        [{ text: "OK",  handler:function(){
+                            this.hide();
+                            window.close();
+                            $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+                          }, isDefault:false }],
+                        YAHOO.widget.SimpleDialog.ICON_BLOCK,
+                        "studioDialog"
+                    );
+                }
+            }
+        }
+        else {
+            // no window opening context or cross server call
+            // the only thing we can do is close the window
+            window.close();
+            $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+        }
+    }
+
     CStudioSearch.editElement = function(path){
         var editCallback = {
                 success: function(){
@@ -853,6 +977,7 @@
         newUrl += '&page=' + searchContext.currentPage;
         newUrl += '&sortBy=' + searchContext.sortBy;
         newUrl += '&view=' + searchContext.view;
+        newUrl += '&mode=' + searchContext.mode;
 
         // Add search filters to url
         // csf = crafter studio filter

--- a/static-assets/components/cstudio-search/search.js
+++ b/static-assets/components/cstudio-search/search.js
@@ -486,46 +486,34 @@
         }
         result.icon = CStudioSearch.typesMap[result.type] ? CStudioSearch.typesMap[result.type].icon : CStudioSearch.typesMap["Other"].icon;
 
-        // when in select mode, dont give option to delete or edit
-        if (isInSelectMode) {
-            result.editable = false;
-            result.permissions = {
-                edit: false,
-                delete: false
-            };
-
-            html = template(result);
-            $(html).appendTo($resultsContainer);
-        }
-        else {
-            var permissionsCached = cache.get(permissionsKey),
-                validateAndRender = function(results) {
-                    var isWriteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "write"),
-                        isDeleteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "delete");
-                    result.editable = isWriteAllowed;
-                    // set permissions for edit/delete actions to be (or not) rendered
-                    result.permissions = {
-                        edit: isWriteAllowed && editable,
-                        delete: isDeleteAllowed
-                    };
-
-                    html = template(result);
-                    $(html).appendTo($resultsContainer);
+        var permissionsCached = cache.get(permissionsKey),
+            validateAndRender = function(results) {
+                var isWriteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "write"),
+                    isDeleteAllowed = CStudioAuthoring.Service.validatePermission(results.permissions, "delete");
+                result.editable = isWriteAllowed;
+                // set permissions for edit/delete actions to be (or not) rendered
+                // when in select mode, dont give option to delete or edit
+                result.permissions = {
+                    edit: isWriteAllowed && editable,
+                    delete: isDeleteAllowed && !isInSelectMode
                 };
 
-            if(permissionsCached){
-                validateAndRender(permissionsCached);
-            }else{
-                CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, result.path, {
-                    success: function (results) {
-                        cache.set(permissionsKey, results, CStudioAuthoring.Constants.CACHE_TIME_GET_ROLES);
-                        validateAndRender(results);
-                    },
-                    failure: function () {
-                        throw new Error('Unable to retrieve user permissions');
-                    }
-                });
-            }
+                html = template(result);
+                $(html).appendTo($resultsContainer);
+            };
+
+        if(permissionsCached){
+            validateAndRender(permissionsCached);
+        }else{
+            CStudioAuthoring.Service.getUserPermissions(CStudioAuthoringContext.site, result.path, {
+                success: function (results) {
+                    cache.set(permissionsKey, results, CStudioAuthoring.Constants.CACHE_TIME_GET_ROLES);
+                    validateAndRender(results);
+                },
+                failure: function () {
+                    throw new Error('Unable to retrieve user permissions');
+                }
+            });
         }
     }
 

--- a/templates/web/search.ftl
+++ b/templates/web/search.ftl
@@ -39,7 +39,6 @@
     <script src="${path}momentjs/moment-timezone-with-data-2012-2022.min.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
 
     <#include "/templates/web/common/page-fragments/studio-context.ftl" />
-    <#include "/templates/web/common/page-fragments/context-nav.ftl" />
 
     <script src="/studio/static-assets/scripts/crafter.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
     <script src="/studio/static-assets/scripts/animator.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
@@ -150,6 +149,8 @@
         </div>
 
     </section>
+
+    <div id="cstudio-command-controls-container"></div>
 
     <script id="hb-search-result" type="text/x-handlebars-template">
         <div class="result-container">
@@ -264,6 +265,15 @@
                 </div>
             </div>
         </div>
+    </script>
+
+    <script id="hb-command-controls" type="text/x-handlebars-template">
+      <div id="cstudio-command-controls">
+        <div id="submission-controls" class="cstudio-form-controls-button-container">
+          <input id="formSaveButton" type="button" class="cstudio-search-btn cstudio-button btn btn-primary" disabled="" value="Add Selection">
+          <input id="formCancelButton" type="button" class="cstudio-search-btn cstudio-button btn btn-default" value="Cancel">
+        </div>
+      </div>
     </script>
 
     <script type="text/javascript">

--- a/ui/scss/_studio-view.scss
+++ b/ui/scss/_studio-view.scss
@@ -437,7 +437,7 @@ table.scroll-body {
     right: 0;
     bottom: 0;
     background-color: rgba(0, 0, 0, 0.65);
-    z-index: 3000;
+    z-index: 1035;
   }
 
   .studio-ice-dialog {

--- a/ui/scss/search.scss
+++ b/ui/scss/search.scss
@@ -425,4 +425,24 @@
         padding: 10px;
         font-weight: bold;
     }
+
+    // select mode
+    &.select {
+        top: 0;
+        left: 0;
+
+        .pagination-container {
+            margin-bottom: 100px;
+        }
+    }
+}
+
+#cstudio-command-controls {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    background: #f8f8f8;
+    padding: 15px 0;
+    border-top: 1px solid #e7e7e7;
+    z-index: 5;
 }


### PR DESCRIPTION
Old feature request: craftercms/craftercms#256

We extended the data-source img-repository-upload with an option to use search instead of browse for images.

**Detailed description**
Similar to https://github.com/craftercms/studio-ui/pull/1323, we have added an option to use search functionality instead of “Browse for uploaded image”.
<img width="1874" alt="img-repository-upload" src="https://user-images.githubusercontent.com/1357798/66342114-f2af4280-e948-11e9-9582-9066d99c1874.png">
Search screen is extended by a select mode:
<img width="1868" alt="Bildschirmfoto 2019-10-07 um 21 39 12" src="https://user-images.githubusercontent.com/1357798/66342991-f348d880-e94a-11e9-9752-947172375d85.png">

