### PR TITLE
Extend data-sources shared-content and img-repository-upload with an option to use search

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -1994,7 +1994,7 @@ var nodeOpen = false,
                 });
 
                 $modal.find('.bd').append(template).end().appendTo(parentEl);
-                $modal.find('.studio-ice-container').css('z-index', 100525);
+                $modal.find('.studio-ice-container').css('z-index', 1035);
 
                 parent.iframeOpener = window;
                 window.open(url, name);

--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -1048,6 +1048,45 @@ var nodeOpen = false,
                     searchUrl += "&page=1";
                 }
 
+                if (!CStudioAuthoring.Utils.isEmpty(searchContext.mode)) {
+                  searchUrl += "&mode=" + searchContext.mode;
+                }
+
+                if (!CStudioAuthoring.Utils.isEmpty(searchContext.itemsPerPage)) {
+                  searchUrl += "&ipp=" + searchContext.itemsPerPage;
+                }
+
+                if (!CStudioAuthoring.Utils.isEmpty(searchContext.query)) {
+                  searchUrl += "&query=" + searchContext.query;
+                }
+
+                // Add search filters to url
+                // csf = crafter studio filter
+                // csr = crafter studio range
+                // csrTO = crafter studio range separator in URL
+                if (!jQuery.isEmptyObject(searchContext.filters)) {
+                  $.each(searchContext.filters, function(key, value) {
+                    if (typeof value === 'string') {
+                      searchUrl += '&csf_' + key + '=' + value;
+                    } else if ($.isArray(value)) {
+                      $.each(value, function() {
+                        searchUrl += '&csf_' + key + '=' + this;
+                      })
+                    } else {  //is a range
+                      if (value.date) {
+                        var min = value.min,
+                            max = value.max,
+                            id = value.id;
+                        searchUrl += '&csf_' + key + '=csr_' + min + 'csrTO' + max + 'csrID' + id;
+                      } else {
+                        var min = isNaN(value.min) ? 'null' : value.min,
+                            max = isNaN(value.max) ? 'null' : value.max;
+                        searchUrl += '&csf_' + key + '=csr_' + min + 'csrTO' + max;
+                      }
+                    }
+                  })
+                }
+
                 var childSearch = null;
 
                 if (!searchId || searchId == null || searchId == "undefined"
@@ -1055,6 +1094,7 @@ var nodeOpen = false,
                     childSearch = CStudioAuthoring.ChildSearchManager.createChildSearchConfig();
                     childSearch.openInSameWindow = openInSameWindow;
                     searchId = CStudioAuthoring.Utils.generateUUID();
+                    searchUrl += "&searchId=" + searchId;
 
                     childSearch.searchId = searchId;
                     childSearch.searchUrl = searchUrl;

--- a/static-assets/components/cstudio-common/resources/de/base.js
+++ b/static-assets/components/cstudio-common/resources/de/base.js
@@ -829,6 +829,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "de", {
     enableCreateNew: "Zeige 'Neu anlegen'",
     enableBrowseExisting: "Zeige 'Auswählen'",
     enableSearchExisting: "Zeige 'Suchen'",
+    useSearch: "Suche verwenden",
 
     /*Restrictions*/
     required: "Erforderlich",

--- a/static-assets/components/cstudio-common/resources/de/base.js
+++ b/static-assets/components/cstudio-common/resources/de/base.js
@@ -826,6 +826,9 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "de", {
     inputProfileId: "Eingabeprofil-ID",
     outputProfileId: "Ausgabeprofil-ID",
     postfixes: "Postfixes",
+    enableCreateNew: "Zeige 'Neu anlegen'",
+    enableBrowseExisting: "Zeige 'Auswählen'",
+    enableSearchExisting: "Zeige 'Suchen'",
 
     /*Restrictions*/
     required: "Erforderlich",
@@ -977,6 +980,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "de", {
     edit: "Bearbeiten",
     createNew: "Neu Anlegen",
     browseExisting: "Auswählen",
+    searchExisting: "Suchen",
 
     /*help popover*/
     pattern: "Muster",

--- a/static-assets/components/cstudio-common/resources/en/base.js
+++ b/static-assets/components/cstudio-common/resources/en/base.js
@@ -830,6 +830,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "en", {
     enableCreateNew: "Enable Create New",
     enableBrowseExisting: "Enable Browse Existing",
     enableSearchExisting: "Enable Search Existing",
+    useSearch: "Use Search",
 
     /*Restrictions*/
     required: "Required",

--- a/static-assets/components/cstudio-common/resources/en/base.js
+++ b/static-assets/components/cstudio-common/resources/en/base.js
@@ -827,6 +827,9 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "en", {
     inputProfileId: "Input Profile Id",
     outputProfileId: "Output Profile Id",
     postfixes: "Postfixes",
+    enableCreateNew: "Enable Create New",
+    enableBrowseExisting: "Enable Browse Existing",
+    enableSearchExisting: "Enable Search Existing",
 
     /*Restrictions*/
     required: "Required",
@@ -978,6 +981,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "en", {
     edit: "Edit",
     createNew: "Create New",
     browseExisting: "Browse for Existing",
+    searchExisting: "Search for Existing",
 
     /*help popover*/
     pattern: "Pattern",

--- a/static-assets/components/cstudio-common/resources/es/base.js
+++ b/static-assets/components/cstudio-common/resources/es/base.js
@@ -804,6 +804,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "es", {
     enableCreateNew: "Mostrar 'Crear nuevo'",
     enableBrowseExisting: "Mostrar 'Seleccionar Existentes'",
     enableSearchExisting: "Mostrar 'Buscar Existentes'",
+    useSearch: "Usar Búsqueda",
 
     /*Restrictions*/
     required: "Requerido",

--- a/static-assets/components/cstudio-common/resources/es/base.js
+++ b/static-assets/components/cstudio-common/resources/es/base.js
@@ -801,6 +801,9 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "es", {
     inputProfileId: "Id de perfil de entrada",
     outputProfileId: "Id de perfil de salida",
     postfixes: "Postfixes",
+    enableCreateNew: "Mostrar 'Crear nuevo'",
+    enableBrowseExisting: "Mostrar 'Seleccionar Existentes'",
+    enableSearchExisting: "Mostrar 'Buscar Existentes'",
 
     /*Restrictions*/
     required: "Requerido",
@@ -933,6 +936,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "es", {
     edit: "Editar",
     createNew: "Crear Nuevo",
     browseExisting: "Buscar Existentes",
+    searchExisting: "Buscar Existentes",
 
     /*help popover*/
     pattern: "Patrón",

--- a/static-assets/components/cstudio-common/resources/kr/base.js
+++ b/static-assets/components/cstudio-common/resources/kr/base.js
@@ -774,6 +774,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "kr", {
     enableCreateNew: "쇼 새로 만들기",
     enableBrowseExisting: "쇼 기존 항목 찾아보기",
     enableSearchExisting: "쇼 기존 검색",
+    useSearch: "검색 사용",
 
     /*Restrictions*/
     required: "필요",

--- a/static-assets/components/cstudio-common/resources/kr/base.js
+++ b/static-assets/components/cstudio-common/resources/kr/base.js
@@ -771,6 +771,9 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "kr", {
     inputProfileId: "입력 프로파일 ID",
     outputProfileId: "출력 프로필 ID",
     postfixes: "포스트 픽스",
+    enableCreateNew: "쇼 새로 만들기",
+    enableBrowseExisting: "쇼 기존 항목 찾아보기",
+    enableSearchExisting: "쇼 기존 검색",
 
     /*Restrictions*/
     required: "필요",
@@ -899,6 +902,7 @@ CStudioAuthoring.Messages.registerBundle("contentTypes", "kr", {
     edit: "편집하다",
     createNew: "새로 만들기",
     browseExisting: "기존 항목 찾아보기",
+    searchExisting: "기존 검색",
 
     /*help popover*/
     pattern: "무늬",

--- a/static-assets/components/cstudio-forms/data-sources/img-repository-upload.js
+++ b/static-assets/components/cstudio-forms/data-sources/img-repository-upload.js
@@ -17,10 +17,10 @@
 
 CStudioForms.Datasources.ImgRepoUpload = CStudioForms.Datasources.ImgRepoUpload ||
 function(id, form, properties, constraints)  {
-   	this.id = id;
-   	this.form = form;
-   	this.properties = properties;
-   	this.constraints = constraints;
+    this.id = id;
+    this.form = form;
+    this.properties = properties;
+    this.constraints = constraints;
     this.useSearch = false;
 
     var _self = this;
@@ -33,18 +33,18 @@ function(id, form, properties, constraints)  {
     });
 
 	return this;
-}
+};
 
 YAHOO.extend(CStudioForms.Datasources.ImgRepoUpload, CStudioForms.CStudioFormDatasource, {
 
-    getLabel: function() {
+    getLabel() {
         return CMgs.format(langBundle, "imageFromRepository");
     },
     
     /**
      * action called when user clicks insert image
      */
-    insertImageAction: function(insertCb) {
+    insertImageAction(insertCb) {
         var _self = this;
 
         if (this.useSearch) {
@@ -65,7 +65,7 @@ YAHOO.extend(CStudioForms.Datasources.ImgRepoUpload, CStudioForms.CStudioFormDat
             };
 
             CStudioAuthoring.Operations.openSearch(searchContext, true, {
-              success: function (searchId, selectedTOs) {
+              success(searchId, selectedTOs) {
                 var imageData = {};
                 var path = selectedTOs[0].uri;
                 var url = this.context.createPreviewUrl(path);
@@ -75,15 +75,13 @@ YAHOO.extend(CStudioForms.Datasources.ImgRepoUpload, CStudioForms.CStudioFormDat
 
                 insertCb.success(imageData, true);
               },
-              failure: function () {
-
-              },
+              failure() {},
               context: _self
             }, null);
 
         } else {
             CStudioAuthoring.Operations.openBrowse("", _self.processPathsForMacros(_self.repoPath), "1", "select", true, {
-              success: function (searchId, selectedTOs) {
+              success(searchId, selectedTOs) {
                 var imageData = {};
                 var path = selectedTOs[0].uri;
                 var url = this.context.createPreviewUrl(path);
@@ -93,62 +91,59 @@ YAHOO.extend(CStudioForms.Datasources.ImgRepoUpload, CStudioForms.CStudioFormDat
 
                 insertCb.success(imageData, true);
               },
-              failure: function () {
-
-              },
+              failure() {},
               context: _self
             });
         }
     },
-	
-	/**
-	 * create preview URL
-	 */
-	createPreviewUrl: function(imagePath) {
-		return CStudioAuthoringContext.previewAppBaseUri + imagePath + "";
-	},
-	
-	/**
-	 * clean up preview URL so that URL is canonical
-	 */
-	cleanPreviewUrl: function(previewUrl) {
-		var url = previewUrl;
-		
-		if(previewUrl.indexOf(CStudioAuthoringContext.previewAppBaseUri) != -1) {
-			url =  previewUrl.substring(CStudioAuthoringContext.previewAppBaseUri.length);
-			
-			if(url.substring(0,1) != "/") {
-				url = "/" + url;
-			}
-		}
-		
-		return url;	
-	},
 
-	deleteImage : function(path) {
+    /**
+     * create preview URL
+     */
+    createPreviewUrl(imagePath) {
+        return CStudioAuthoringContext.previewAppBaseUri + imagePath + "";
+    },
 
-	},
+    /**
+     * clean up preview URL so that URL is canonical
+     */
+    cleanPreviewUrl(previewUrl) {
+        var url = previewUrl;
 
-   	getInterface: function() {
-   		return "image";
-   	},
+        if (previewUrl.indexOf(CStudioAuthoringContext.previewAppBaseUri) !== -1) {
+            url =  previewUrl.substring(CStudioAuthoringContext.previewAppBaseUri.length);
 
-	getName: function() {
-		return "img-repository-upload";
-	},
-	
-	getSupportedProperties: function() {
-		return [
-			{ label: CMgs.format(langBundle, "repositoryPath"), name: "repoPath", type: "string" },
-			{ label: CMgs.format(langBundle, "useSearch"), name: "useSearch", type: "boolean", defaultValue: "false" }
-		];
-	},
+            if (url.substring(0,1) !== "/") {
+                url = "/" + url;
+            }
+        }
+        return url;
+    },
 
-	getSupportedConstraints: function() {
-		return [
-			{ label: CMgs.format(langBundle, "required"), name: "required", type: "boolean" },
-		];
-	}
+    deleteImage(path) {
+
+    },
+
+    getInterface() {
+        return "image";
+    },
+
+    getName() {
+        return "img-repository-upload";
+    },
+
+    getSupportedProperties() {
+        return [
+            { label: CMgs.format(langBundle, "repositoryPath"), name: "repoPath", type: "string" },
+            { label: CMgs.format(langBundle, "useSearch"), name: "useSearch", type: "boolean", defaultValue: "false" }
+        ];
+    },
+
+    getSupportedConstraints() {
+        return [
+            { label: CMgs.format(langBundle, "required"), name: "required", type: "boolean" },
+        ];
+    }
 
 });
 

--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -54,10 +54,10 @@ CStudioForms.Datasources.SharedContent = function (id, form, properties, constra
       properties[i].value === 'true' ? this.countOptions++ : null;
     }
 
-    if (properties[i].name === "enableSearchExisting") {
+    if (properties[i].name === 'enableSearchExisting') {
       this.enableSearchExisting = properties[i].value === "true" ? true : false;
       this.defaultEnableSearchExisting = false;
-      properties[i].value === "true" ? this.countOptions++ : null;
+      properties[i].value === 'true' ? this.countOptions++ : null;
     }
   }
 
@@ -165,13 +165,12 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
     };
 
     CStudioAuthoring.Operations.openSearch(searchContext, true, {
-      success: function(searchId, selectedTOs) {
-        for (var i = 0; i < selectedTOs.length; i++) {
-          var item = selectedTOs[i];
-          var value = (item.internalName && item.internalName != "") ? item.internalName : item.uri;
+      success(searchId, selectedTOs) {
+        selectedTOs.forEach (function(item) {
+          var value = (item.internalName && item.internalName !== "") ? item.internalName : item.uri;
           control.insertItem(item.uri, value, null, null, _self.id);
           control._renderItems();
-        }
+        });
       },
       failure: function () {
       }
@@ -184,7 +183,7 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
 
     var _self = this;
 
-		var addContainerEl = control.addContainerEl ? control.addContainerEl : null;
+    var addContainerEl = control.addContainerEl ? control.addContainerEl : null;
 
     var datasourceDef = this.form.definition.datasources,
       newElTitle = '';

--- a/static-assets/components/cstudio-search/search.js
+++ b/static-assets/components/cstudio-search/search.js
@@ -27,6 +27,7 @@
     /* default search context */
     CStudioSearch.searchContext = {
         searchId: null,
+        query: "",
         itemsPerPage: 20,
         keywords: "",
         filters: {},
@@ -38,7 +39,8 @@
         searchInProgress: false,
         view: 'grid',
         lastSelectedFilterSelector: '',
-        selectionState: {}
+        selectionState: {},
+        mode: "default"              // possible mode values: [default|select]
     };
 
     CStudioSearch.typesMap = {
@@ -74,8 +76,23 @@
     }
 
     CStudioSearch.init = function() {
+
+        CStudioAuthoring.OverlayRequiredResources.loadRequiredResources();
+        CStudioAuthoring.OverlayRequiredResources.loadContextNavCss();
+
         var searchContext = this.determineSearchContextFromUrl();
         this.searchContext = searchContext;
+
+        $('section.cstudio-search').addClass(this.searchContext.mode);
+
+        // arrange iframe according to search mode
+        if (this.searchContext.mode != "select") {
+            CStudioAuthoring.Events.contextNavLoaded.subscribe(function() {
+              CStudioAuthoring.ContextualNav.hookNavOverlayFromAuthoring();
+              CStudioAuthoring.InContextEdit.autoInitializeEditRegions();
+            });
+        } else
+            this.renderFormControls();
 
         CStudioAuthoring.Operations.translateContent(langBundle, null, 'data-trans');
         this.performSearch();
@@ -124,10 +141,25 @@
             $('input[type="checkbox"][data-url="' + path + '"]').prop('checked', selected);
 
             // if all checkboxes are selected/unselected -> update select all checkbox
+            var currentlySelected = $('input[type="checkbox"].search-select-item:checked').length;
+            allSelected = currentlySelected == $('input[type="checkbox"].search-select-item').length;
+
+            $('#formSaveButton').prop("disabled",currentlySelected == 0);
+            $('#searchSelectAll').prop('checked', allSelected);
+
             allSelected = $('input[type="checkbox"].search-select-item:checked').length == $('input[type="checkbox"].search-select-item').length;
             $('#searchSelectAll').prop('checked', allSelected);
 
             CStudioSearch.changeSelectStatus(path, selected);
+        });
+
+        $('#cstudio-command-controls').on('click', '#formSaveButton', function(){
+            CStudioSearch.saveContent();
+        });
+
+        $('#cstudio-command-controls').on('click', '#formCancelButton', function(){
+            window.close();
+            $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
         });
 
         // Select all results
@@ -322,6 +354,8 @@
         var page = CStudioAuthoring.Utils.getQueryVariable(queryString, "page");
         var sortBy = CStudioAuthoring.Utils.getQueryVariable(queryString, "sortBy");
         var view = CStudioAuthoring.Utils.getQueryVariable(queryString, "view");
+        var mode = CStudioAuthoring.Utils.getQueryVariable(queryString, "mode");
+        var query = CStudioAuthoring.Utils.getQueryVariable(queryString, "query");
 
         searchContext.keywords = (keywords) ? keywords : searchContext.keywords;
         searchContext.searchId = (searchId) ? searchId : null;
@@ -329,6 +363,8 @@
         searchContext.sortBy = (sortBy) ? sortBy : searchContext.sortBy;
         searchContext.view = (view) ? view : searchContext.view;
         searchContext.itemsPerPage = (itemsPerPage) ? itemsPerPage : searchContext.itemsPerPage;
+        searchContext.mode = (mode) ? mode : searchContext.mode;
+        searchContext.query = (query) ? query : searchContext.query;
 
         $.each(urlParams, function(key, value){
             var processedKey,
@@ -421,6 +457,16 @@
         });
     }
 
+    CStudioSearch.renderFormControls = function(result) {
+        var $formControlContainer = $('#cstudio-command-controls-container'),
+            source = $("#hb-command-controls").html(),
+            template = Handlebars.compile(source),
+            html;
+
+        html = template(result);
+        $(html).appendTo($formControlContainer);
+    }
+
     CStudioSearch.renderResult = function(result) {
         var $resultsContainer = $('.cstudio-search .results'),
             source = $("#hb-search-result").html(),
@@ -478,6 +524,7 @@
     CStudioSearch.createSearchQuery = function() {
         var searchContext = this.searchContext;
         var query = {
+            "query": searchContext.query,
             "keywords": searchContext.keywords,
             "offset": (searchContext.currentPage - 1) * searchContext.itemsPerPage,
             "limit": searchContext.itemsPerPage,
@@ -792,6 +839,79 @@
         CStudioAuthoring.Service.lookupContentItem(CStudioAuthoringContext.site, path, callback, false, false);
     }
 
+    CStudioSearch.saveContent = function() {
+        var searchId = this.searchContext ? this.searchContext.searchId : "" ;
+        var crossServerAccess = false;
+        var opener = window.opener ? window.opener : parent.iframeOpener;
+
+        try {
+            // unfortunately we cannot signal a form close across servers
+            // our preview is in one server
+            // our authoring is in another
+            // in this case we just close the window, no way to pass back details which is ok in some cases
+            if(opener.CStudioAuthoring) {}
+        } catch (crossServerAccessErr) {
+            crossServerAccess = true;
+        }
+        if (opener && !crossServerAccess) {
+
+            if (opener.CStudioAuthoring) {
+                var openerChildSearchMgr = opener.CStudioAuthoring.ChildSearchManager;
+
+                if (openerChildSearchMgr) {
+                    var searchConfig = openerChildSearchMgr.searches[searchId];
+                    if (searchConfig) {
+                        var callback = searchConfig.saveCallback;
+                        if (callback) {
+                            var selectedContentTOs = CStudioAuthoring.SelectedContent.getSelectedContent();
+                            openerChildSearchMgr.signalSearchClose(searchId, selectedContentTOs);
+                      } else {
+                          //TODO PUT THIS BACK
+                          //alert("no success callback provided for seach: " + searchId);
+                      }
+
+                      window.close();
+                      $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+
+                    } else {
+                        CStudioAuthoring.Operations.showSimpleDialog(
+                          "lookUpChildError-dialog",
+                          CStudioAuthoring.Operations.simpleDialogTypeINFO,
+                          CMgs.format(langBundle, "notification"),
+                          CMgs.format(langBundle, "lookUpChildError") + searchId,
+                          [{ text: "OK",  handler:function(){
+                              this.hide();
+                              window.close();
+                              $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+                            }, isDefault:false }],
+                          YAHOO.widget.SimpleDialog.ICON_BLOCK,
+                          "studioDialog"
+                        );
+                    }
+                } else {
+                    CStudioAuthoring.Operations.showSimpleDialog(
+                      "lookUpParentError-dialog",
+                      CStudioAuthoring.Operations.simpleDialogTypeINFO,
+                      CMgs.format(langBundle, "notification"),
+                      CMgs.format(langBundle, "lookUpParentError") + searchId,
+                      [{ text: "OK",  handler:function(){
+                          this.hide();
+                          window.close();
+                          $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+                        }, isDefault:false }],
+                      YAHOO.widget.SimpleDialog.ICON_BLOCK,
+                      "studioDialog"
+                    );
+                }
+            }
+        } else {
+            // no window opening context or cross server call
+            // the only thing we can do is close the window
+            window.close();
+            $(window.frameElement.parentElement).closest('.studio-ice-dialog').parent().remove(); //TODO: find a better way
+        }
+    }
+
     CStudioSearch.editElement = function(path){
         var editCallback = {
                 success: function(){
@@ -853,6 +973,8 @@
         newUrl += '&page=' + searchContext.currentPage;
         newUrl += '&sortBy=' + searchContext.sortBy;
         newUrl += '&view=' + searchContext.view;
+        newUrl += '&mode=' + searchContext.mode;
+        newUrl += '&query=' + searchContext.query;
 
         // Add search filters to url
         // csf = crafter studio filter

--- a/templates/web/search.ftl
+++ b/templates/web/search.ftl
@@ -39,7 +39,6 @@
     <script src="${path}momentjs/moment-timezone-with-data-2012-2022.min.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
 
     <#include "/templates/web/common/page-fragments/studio-context.ftl" />
-    <#include "/templates/web/common/page-fragments/context-nav.ftl" />
 
     <script src="/studio/static-assets/scripts/crafter.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
     <script src="/studio/static-assets/scripts/animator.js?version=${UIBuildId!.now?string('Mddyyyy')}"></script>
@@ -150,6 +149,8 @@
         </div>
 
     </section>
+
+    <div id="cstudio-command-controls-container"></div>
 
     <script id="hb-search-result" type="text/x-handlebars-template">
         <div class="result-container">
@@ -264,6 +265,15 @@
                 </div>
             </div>
         </div>
+    </script>
+
+    <script id="hb-command-controls" type="text/x-handlebars-template">
+      <div id="cstudio-command-controls">
+        <div id="submission-controls" class="cstudio-form-controls-button-container">
+          <input id="formSaveButton" type="button" class="cstudio-search-btn cstudio-button btn btn-primary" disabled="" value="Add Selection">
+          <input id="formCancelButton" type="button" class="cstudio-search-btn cstudio-button btn btn-default" value="Cancel">
+        </div>
+      </div>
     </script>
 
     <script type="text/javascript">

--- a/ui/scss/_studio-view.scss
+++ b/ui/scss/_studio-view.scss
@@ -437,7 +437,7 @@ table.scroll-body {
     right: 0;
     bottom: 0;
     background-color: rgba(0, 0, 0, 0.65);
-    z-index: 3000;
+    z-index: 1035;
   }
 
   .studio-ice-dialog {

--- a/ui/scss/search.scss
+++ b/ui/scss/search.scss
@@ -425,4 +425,24 @@
         padding: 10px;
         font-weight: bold;
     }
+
+    // select mode
+    &.select {
+        top: 0;
+        left: 0;
+
+        .pagination-container {
+            margin-bottom: 100px;
+        }
+    }
+}
+
+#cstudio-command-controls {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    background: #f8f8f8;
+    padding: 15px 0;
+    border-top: 1px solid #e7e7e7;
+    z-index: 5;
 }


### PR DESCRIPTION
Old feature request: https://github.com/craftercms/craftercms/issues/256
This combines https://github.com/craftercms/studio-ui/pull/1323 and https://github.com/craftercms/studio-ui/pull/1329

We extended the data-sources `shared-content` and `img-repository-upload` with an option to use search instead of browse.

**Detailed description**
Basically, in our crafter site we have page assets with slots to contain components. Components are reused on different pages and different tenants. A "slot" is managed by a datasource of type child-content. We already have a lot of components, which caused problems because all components were created in a couple of folders only. That’s why we introduced [macros](https://docs.craftercms.org/en/3.1/developers/content-modeling.html#macros-for-data-sources) for automated organizing components in folders like ‘/site/components/{yyyy}/{mm}/{dd}’
By doing so, folders are “small” enough, but now content editors had problems trying to find existing components in the child-content datasource. In order to use the browse functionality, they would need to know the exact day, when a component has been created... and content editors never know :slightly_smiling_face:
That’s why we have added an option to use search functionality in addition or instead of “Browse for existing”.
<img width="1873" alt="child-content" src="https://user-images.githubusercontent.com/1357798/65887602-8196ea80-e39e-11e9-8118-9fe09e5d0d04.png">

We've extended Search in Crafter by a _select_ mode and use 'browsePath' property as search folder:
<img width="1855" alt="search" src="https://user-images.githubusercontent.com/1357798/65887714-b30fb600-e39e-11e9-858a-4ad19b2b25f6.png">
