### PR TITLE
[3594] Firefox: When History dialog is full it can't be scrolled

### DIFF
--- a/ui/scss/_cstudio-view.scss
+++ b/ui/scss/_cstudio-view.scss
@@ -199,6 +199,7 @@
           table.item-listing {
             width: 100%;
             height: 100%;
+            display: block;
 
             thead, tbody {
               tr {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3594