### PR TITLE
[3663] Inconsistent naming for "Global Configuration"

### DIFF
--- a/ui/app/src/utils/i18n-legacy.ts
+++ b/ui/app/src/utils/i18n-legacy.ts
@@ -408,7 +408,7 @@ const codeEditorMessages = defineMessages( {
 const globalConfigMessages = defineMessages( {
   title: {
     id: 'globalConfig.title',
-    defaultMessage: 'Global Configuration'
+    defaultMessage: 'Global Config'
   },
   viewSample: {
     id: 'globalConfig.viewSample',


### PR DESCRIPTION
quickChange on globalConfig.title

https://github.com/craftercms/craftercms/issues/3663