### PR TITLE
[3670] Translations that were found missing during testing

### DIFF
--- a/static-assets/components/cstudio-common/resources/en/base.js
+++ b/static-assets/components/cstudio-common/resources/en/base.js
@@ -537,7 +537,7 @@ CStudioAuthoring.Messages.registerBundle("forms", "en", {
     unableLoad: "The system was unable to load ",
     failure: "Failure.",
     loadFormDefError: "Failed to load form definition.",
-    componentsNotSupported: "The drop zone not support this type of Components",
+    componentsNotSupported: "The drop zone does not support this type of component",
     loadModelError: "Failed to load model.",
     controllerError: "No controller found.",
     notExist:" does not exist.",

--- a/static-assets/scripts/admin.js
+++ b/static-assets/scripts/admin.js
@@ -1366,7 +1366,7 @@
         }
 
         $scope.confirmationAction = deleteUser;
-        $scope.confirmationText = "Do you want to delete " + user.username + "?";
+        $scope.confirmationText = `${$translate.instant('common.DELETE_QUESTION')} ${user.username}?`;
 
         $scope.adminModal = $scope.showModal('confirmationModal.html', '', true, "studioMedium");
       };
@@ -1456,7 +1456,7 @@
         }
 
         $scope.confirmationAction = deleteClusterMember;
-        $scope.confirmationText = "Do you want to delete " + clusterMember.gitUrl + "?";
+        $scope.confirmationText = `${$translate.instant('common.DELETE_QUESTION')} ${clusterMember.gitUrl}?`;
 
         $scope.adminModal = $scope.showModal('confirmationModal.html', '', true, "studioMedium");
       };
@@ -1665,7 +1665,7 @@
         };
 
         $scope.confirmationAction = deleteGroup;
-        $scope.confirmationText = "Do you want to delete " + group.name + "?";
+        $scope.confirmationText = `${$translate.instant('common.DELETE_QUESTION')} ${group.name}?`;
 
         $scope.adminModal = $scope.showModal('confirmationModal.html', 'sm', true, "studioMedium");
       };
@@ -1827,7 +1827,7 @@
         };
 
         $scope.confirmationAction = removeUserFromGroup;
-        $scope.confirmationText = "Do you want to delete " + user.username + " from " + group.name + "?";
+        $scope.confirmationText = `${$translate.instant('common.DELETE_QUESTION')} ${user.username} ${$translate.instant('common.FROM')} ${group.name}?`;
 
         $scope.adminModal = $scope.showModal('confirmationModal.html', '', true, "studioMedium");
       };

--- a/static-assets/scripts/resources/locale-de.json
+++ b/static-assets/scripts/resources/locale-de.json
@@ -248,6 +248,7 @@
         "PATHPUBLISH": "Pfad, der publiziert werden soll",
         "PATHEXAMPLE": "(z.B. /site/website/about/index.xml)",
         "PUBLISHINGENVIRONMENT": "Umgebung",
+        "PUBLISHINGSUBMISSIONCOMMENT": "Submission Kommentar",
         "PUBLISH": "Publizieren",
         "PATH":"Pfad",
         "CHANNEL":"Kanal",
@@ -359,6 +360,7 @@
     "EDIT": "Bearbeiten",
     "SAVE": "Speichern",
     "VIEW": "Ansehen",
+    "FROM": "von",
     "IS_REQUIRED_LABEL": "ist notwendig.",
     "REQUIRED_LABEL": "notwendig.",
     "ALL_LABEL": "Alle",
@@ -382,7 +384,7 @@
     "DELETE_QUESTION":"Sind Sie sicher, dass Sie den folgenden Eintrag löschen möchten: ",
     "GLOBAL_MENU": "Globales Menü",
     "MAIN_MENU": "Hauptmenü",
-    "RESET_PASSWORD": "Passwort zurücksetzen"
-
+    "RESET_PASSWORD": "Passwort zurücksetzen",
+    "CLOSE": "Schließen"
   }
 }

--- a/static-assets/scripts/resources/locale-en.json
+++ b/static-assets/scripts/resources/locale-en.json
@@ -362,6 +362,7 @@
     "EDIT": "Edit",
     "SAVE": "Save",
     "VIEW": "view",
+    "FROM": "from",
     "IS_REQUIRED_LABEL": "is required.",
     "REQUIRED_LABEL": "required.",
     "ALL_LABEL": "All",

--- a/static-assets/scripts/resources/locale-es.json
+++ b/static-assets/scripts/resources/locale-es.json
@@ -227,6 +227,7 @@
       "ORDER":"Orden",
       "ALL_ORIGINS":"Todos los orígenes",
       "SORT":"Ordenar",
+      "OPTIONS":"Opciones",
       "COLLAPSE":"Colapso",
       "EXPAND":"Expandir",
       "TIMESTAMP":"Marca de tiempo",
@@ -249,6 +250,7 @@
         "PATHPUBLISH": "Camino a publicar",
         "PATHEXAMPLE": "(e.g. /site/website/about/index.xml)",
         "PUBLISHINGENVIRONMENT": "Ambiente",
+        "PUBLISHINGSUBMISSIONCOMMENT": "Comentario",
         "PUBLISH": "Publicar",
         "PATH":"Ruta",
         "CHANNEL":"Canal",
@@ -360,6 +362,7 @@
     "EDIT": "Modificar",
     "SAVE": "Guardar",
     "VIEW": "view",
+    "FROM": "de",
     "IS_REQUIRED_LABEL": "es requerido.",
     "REQUIRED_LABEL": "requerido.",
     "ALL_LABEL": "Todos",
@@ -385,6 +388,7 @@
     "DELETE_QUESTION":"Quieres borrar",
     "GLOBAL_MENU": "Menu Global",
     "MAIN_MENU": "Menu Principal",
-    "RESET_PASSWORD": "Restablecer la contraseña"
+    "RESET_PASSWORD": "Restablecer la contraseña",
+    "CLOSE": "Cerrar"
   }
 }

--- a/static-assets/scripts/resources/locale-kr.json
+++ b/static-assets/scripts/resources/locale-kr.json
@@ -227,6 +227,7 @@
       "ORDER":"주문",
       "ALL_ORIGINS":"모든 근원",
       "SORT":"종류",
+      "OPTIONS":"옵션",
       "COLLAPSE":"무너짐",
       "EXPAND":"넓히다",
       "TIMESTAMP":"타임 스탬프",
@@ -249,6 +250,7 @@
         "PATHPUBLISH": "게시 경로",
         "PATHEXAMPLE": "(e.g. /site/website/about/index.xml)",
         "PUBLISHINGENVIRONMENT": "환경",
+        "PUBLISHINGSUBMISSIONCOMMENT": "제출 코멘트",
         "PUBLISH": "게시",
         "PATH":"통로",
         "CHANNEL":"채널",
@@ -360,6 +362,7 @@
     "EDIT": "편집하다",
     "SAVE": "구하다",
     "VIEW": "view",
+    "FROM": "...에서",
     "IS_REQUIRED_LABEL": "필요하다",
     "REQUIRED_LABEL": "필수",
     "ALL_LABEL": "모든",
@@ -383,6 +386,7 @@
     "DELETE_QUESTION":"삭제 하시겠습니까",
     "GLOBAL_MENU": "글로벌 메뉴",
     "MAIN_MENU": "기본 메뉴",
-    "RESET_PASSWORD": "암호를 재설정"
+    "RESET_PASSWORD": "암호를 재설정",
+    "CLOSE": "닫기"
   }
 }

--- a/static-assets/themes/cstudioTheme/css/template-editor.css
+++ b/static-assets/themes/cstudioTheme/css/template-editor.css
@@ -107,7 +107,8 @@
 
 #template-editor-button-container .edit-buttons-container{
   margin: 12px auto 0 auto;
-  width: 150px;
+  width: 400px;
+  text-align: center;
 }
 
 #template-editor-button-container .edit-buttons-container.viewer{

--- a/ui/app/src/components/CrafterCMSNextBridge.tsx
+++ b/ui/app/src/components/CrafterCMSNextBridge.tsx
@@ -31,7 +31,8 @@ const Locales: any = {
   en,
   es,
   de,
-  ko
+  ko,
+  kr: ko // TODO: Currently studio uses the wrong code for korean
 };
 
 export let intl = getIntl(getCurrentLocale());

--- a/ui/app/src/translations/locales/de.json
+++ b/ui/app/src/translations/locales/de.json
@@ -195,7 +195,7 @@
   "publishingDashboard.filters": "Filter",
   "publishingDashboard.noPackagesSubtitle": "Versuchen Sie, Ihre Abfrage zu ändern",
   "publishingDashboard.noPackagesTitle": "Keine Pakete gefunden",
-  "publishingDashboard.packagesSelected": "{count, plural, one {{count} Package selected} other {{count} Packages selected}}",
+  "publishingDashboard.packagesSelected": "{count, plural, one {{count} Paket ausgewählt} other {{count} Pakete ausgewählt}}",
   "publishingDashboard.pathExpression": "Pfadausdruck",
   "publishingDashboard.scheduled": "Geplant für <b>{schedule, date, medium} {schedule, time, short}</b> von <b>{approver}</b>",
   "publishingDashboard.selectAll": "Alles auf dieser Seite auswählen",

--- a/ui/app/src/translations/locales/es.json
+++ b/ui/app/src/translations/locales/es.json
@@ -195,7 +195,7 @@
   "publishingDashboard.filters": "Filtros",
   "publishingDashboard.noPackagesSubtitle": "Intenta cambiar tu consulta",
   "publishingDashboard.noPackagesTitle": "No hay paquetes donde se encuentran",
-  "publishingDashboard.packagesSelected": "{count, plural, one {{count} Package selected} other {{count} Packages selected}}",
+  "publishingDashboard.packagesSelected": "{count, plural, one {{count} Paquete seleccionado} other {{count} Paquetes seleccionados}}",
   "publishingDashboard.pathExpression": "Expresión de ruta",
   "publishingDashboard.scheduled": "Programado para <b>{schedule, date, medium} {schedule, time, short}</b> por <b>{approver}</b>",
   "publishingDashboard.selectAll": "Seleccionar todo en esta página",

--- a/ui/app/src/translations/locales/ko.json
+++ b/ui/app/src/translations/locales/ko.json
@@ -195,7 +195,7 @@
   "publishingDashboard.filters": "필터",
   "publishingDashboard.noPackagesSubtitle": "검색어를 변경해보십시오",
   "publishingDashboard.noPackagesTitle": "패키지가없는 곳",
-  "publishingDashboard.packagesSelected": "{count, plural, one {{count} Package selected} other {{count} Packages selected}}",
+  "publishingDashboard.packagesSelected": "{count, plural, one {{count} 선택된 패키지} other {{count} 선택된 패키지}}",
   "publishingDashboard.pathExpression": "경로 표현",
   "publishingDashboard.scheduled": "<b>{approver}</b>에 의해 <b>{schedule, date, medium} {schedule, time, short}</b> 에 예약",
   "publishingDashboard.selectAll": "이 페이지에서 모두 선택",


### PR DESCRIPTION
Translations that were found missing during yac's testing.
Style to address difference in space occupied by translated rendered text in template editor

**This is for 3.1.4 release**