### PR TITLE
[3567]  Organize codebase next files into submodule packages

### DIFF
--- a/ui/app/src/modules/Content/Dependencies/DependencySelection.tsx
+++ b/ui/app/src/modules/Content/Dependencies/DependencySelection.tsx
@@ -16,11 +16,11 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Item } from '../models/Item';
-import '../styles/dependency-selection.scss';
+import { Item } from '../../../models/Item';
+import '../../../styles/dependency-selection.scss';
 import { withStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import { get } from '../utils/ajax';
+import { get } from '../../../utils/ajax';
 import { FormattedMessage } from 'react-intl';
 import Checkbox from '@material-ui/core/Checkbox';
 

--- a/ui/app/src/utils/codebase-bridge.tsx
+++ b/ui/app/src/utils/codebase-bridge.tsx
@@ -94,9 +94,9 @@ export function createCodebaseBridge() {
       AsyncVideoPlayer: lazy(() => import('../components/AsyncVideoPlayer')),
       GraphiQL: lazy(() => import('../components/GraphiQL')),
       SingleFileUpload: lazy(() => import('../components/SingleFileUpload')),
-      DependencySelection: lazy(() => import('../components/DependencySelection')),
+      DependencySelection: lazy(() => import('../modules/Content/Dependencies/DependencySelection')),
       DependecySelectionDelete: lazy(() => (
-        import('../components/DependencySelection')
+        import('../modules/Content/Dependencies/DependencySelection')
           .then(module => ({
             default: module.DependencySelectionDelete
           }))


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3567 - [studio-ui] Organize codebase next files into submodule packages #3567 - Dependecy Selection
