### PR TITLE
[3686] TinyMCE5 inline style overrides only work if you first specify a style sheet

### DIFF
--- a/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
+++ b/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
@@ -234,8 +234,7 @@ CStudioAuthoring.Module.requireModule(
 			rteStylesheets = ( rteConfig.rteStylesheets && typeof rteConfig.rteStylesheets === 'object' )
 				? rteConfig.rteStylesheets.link : null;
 
-			rteStyleOverride = ( rteConfig.rteStyleOverride && typeof rteConfig.rteStylesheets === 'object' )
-				? rteConfig.rteStyleOverride : null;
+      rteStyleOverride = rteConfig.rteStyleOverride ? rteConfig.rteStyleOverride : null;
 
 			editor = tinymce.init({
 				selector: '#' + rteId,


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3686