### PR TITLE
use fetch api instead of yui2 to POST write-content

### DIFF
--- a/static-assets/components/cstudio-forms/template-editor.js
+++ b/static-assets/components/cstudio-forms/template-editor.js
@@ -561,15 +561,6 @@ CStudioAuthoring.Module.requireModule(
                     cancelEdit();
                   });
 
-									var saveSvcCb = {
-										success: function() {
-											modalEl.parentNode.removeChild(modalEl);
-											onSaveCb.success();
-										},
-										failure: function() {
-										}
-									};
-
 									if(isWrite == true) {
 										var saveEl = document.getElementById('template-editor-update-button');
 										saveEl.onclick = function() {
@@ -585,10 +576,22 @@ CStudioAuthoring.Module.requireModule(
 												"&user=" + CStudioAuthoringContext.user +
 												"&unlock=true";
 
-											YAHOO.util.Connect.setDefaultPostHeader(false);
-											YAHOO.util.Connect.initHeader("Content-Type", "text/pain; charset=utf-8");
-											YAHOO.util.Connect.initHeader(CStudioAuthoringContext.xsrfHeaderName, CrafterCMSNext.util.auth.getRequestForgeryToken());
-											YAHOO.util.Connect.asyncRequest('POST', CStudioAuthoring.Service.createServiceUri(writeServiceUrl), saveSvcCb, value);
+											fetch(CStudioAuthoring.Service.createServiceUri(writeServiceUrl), {
+												method: 'POST',
+												credentials: 'same-origin',
+												headers: {
+													'Content-Type': 'text/plain; charset=utf-8',
+													[CStudioAuthoringContext.xsrfHeaderName]: CrafterCMSNext.util.auth.getRequestForgeryToken(),
+												},
+												body: value,
+											})
+											.then(res => res.json())
+											.then((data) => {
+												if (data && data.result && data.result.success) {
+													modalEl.parentNode.removeChild(modalEl);
+													onSaveCb.success();
+												}
+											});
 										};
 									}
 


### PR DESCRIPTION
The reason is that yui2 seem has a bug on how to set headers.

I’ve tried to modify the `charset=euc-jp` but the real request didn’t update that. 

If I use `fetch`, _POST_ request actually set charset as I defined.