### PR TITLE
[3741] Studio search should use descending order by default

### DIFF
--- a/ui/app/src/modules/Search/FilterSearchDropdown.tsx
+++ b/ui/app/src/modules/Search/FilterSearchDropdown.tsx
@@ -165,12 +165,12 @@ const messages: any = defineMessages({
     id: 'searchFilter.desc',
     defaultMessage: 'Descending'
   },
-  moreRelevance: {
-    id: 'searchFilter.moreRelevance',
+  moreRelevantFirst: {
+    id: 'searchFilter.moreRelevantFirst',
     defaultMessage: 'Most relevant first'
   },
-  lessRelevance: {
-    id: 'searchFilter.lessRelevance',
+  lessRelevantFirst: {
+    id: 'searchFilter.lessRelevantFirst',
     defaultMessage: 'Less relevant first'
   },
   apply: {
@@ -550,7 +550,16 @@ function SortOrder(props: SortOrderProps) {
   const { queryParams, handleFilterChange } = props;
   // queryParams['sortBy'] === undefined: this means the current filter is the default === _score
   const isRelevance = (queryParams['sortBy'] === '_score' || queryParams['sortBy'] === undefined);
-  let options = [
+  const options = isRelevance ? [
+    {
+      name: formatMessage(messages.moreRelevance),
+      value: 'desc'
+    },
+    {
+      name: formatMessage(messages.lessRelevance),
+      value: 'asc'
+    },
+  ] : [
     {
       name: formatMessage(messages.asc),
       value: 'asc'
@@ -560,12 +569,6 @@ function SortOrder(props: SortOrderProps) {
       value: 'desc'
     },
   ];
-  if (isRelevance) {
-    options[0].name = formatMessage(messages.moreRelevance);
-    options[0].value = 'desc';
-    options[1].name = formatMessage(messages.lessRelevance);
-    options[1].value = 'asc';
-  }
   return (
     <Select
       value={queryParams['sortOrder'] || 'desc'}

--- a/ui/app/src/modules/Search/FilterSearchDropdown.tsx
+++ b/ui/app/src/modules/Search/FilterSearchDropdown.tsx
@@ -166,11 +166,11 @@ const messages: any = defineMessages({
     defaultMessage: 'Descending'
   },
   moreRelevantFirst: {
-    id: 'searchFilter.moreRelevantFirst',
+    id: 'searchFilter.byRelevanceDescMessage',
     defaultMessage: 'Most relevant first'
   },
   lessRelevantFirst: {
-    id: 'searchFilter.lessRelevantFirst',
+    id: 'searchFilter.byRelevanceAscMessage',
     defaultMessage: 'Less relevant first'
   },
   apply: {

--- a/ui/app/src/modules/Search/FilterSearchDropdown.tsx
+++ b/ui/app/src/modules/Search/FilterSearchDropdown.tsx
@@ -125,9 +125,9 @@ const messages: any = defineMessages({
     id: 'searchFilter.sortBy',
     defaultMessage: 'Sort By'
   },
-  revelance: {
-    id: 'searchFilter.revelance',
-    defaultMessage: 'Revelance'
+  relevance: {
+    id: 'searchFilter.relevance',
+    defaultMessage: 'Relevance'
   },
   internalName: {
     id: 'searchFilter.internalName',
@@ -164,6 +164,14 @@ const messages: any = defineMessages({
   desc: {
     id: 'searchFilter.desc',
     defaultMessage: 'Descending'
+  },
+  moreRelevance: {
+    id: 'searchFilter.moreRelevance',
+    defaultMessage: 'Most relevant first'
+  },
+  lessRelevance: {
+    id: 'searchFilter.lessRelevance',
+    defaultMessage: 'Less relevant first'
   },
   apply: {
     id: 'searchFilter.apply',
@@ -519,7 +527,7 @@ function SortBy(props: SortByProps) {
       className={classes.Select}
       onChange={(event) => handleFilterChange({ name: 'sortBy', value: event.target.value })}
     >
-      <MenuItem value='_score'>{formatMessage(messages.revelance)}</MenuItem>
+      <MenuItem value='_score'>{formatMessage(messages.relevance)}</MenuItem>
       <MenuItem value='internalName'>{formatMessage(messages.internalName)}</MenuItem>
       {
         filterKeys.map((name: string, i: number) => {
@@ -540,14 +548,32 @@ function SortOrder(props: SortOrderProps) {
   const classes = useStyles({});
   const { formatMessage } = useIntl();
   const { queryParams, handleFilterChange } = props;
+  // queryParams['sortBy'] === undefined: this means the current filter is the default === _score
+  const isRelevance = (queryParams['sortBy'] === '_score' || queryParams['sortBy'] === undefined);
+  let options = [
+    {
+      name: formatMessage(messages.asc),
+      value: 'asc'
+    },
+    {
+      name: formatMessage(messages.desc),
+      value: 'desc'
+    },
+  ];
+  if (isRelevance) {
+    options[0].name = formatMessage(messages.moreRelevance);
+    options[0].value = 'desc';
+    options[1].name = formatMessage(messages.lessRelevance);
+    options[1].value = 'asc';
+  }
   return (
     <Select
-      value={queryParams['sortOrder'] || 'asc'}
+      value={queryParams['sortOrder'] || 'desc'}
       className={clsx(classes.Select, 'last')}
       onChange={(event) => handleFilterChange({ name: 'sortOrder', value: event.target.value })}
     >
-      <MenuItem value="asc">{formatMessage(messages.asc)}</MenuItem>
-      <MenuItem value="desc">{formatMessage(messages.desc)}</MenuItem>
+      <MenuItem value={options[0].value}>{options[0].name}</MenuItem>
+      <MenuItem value={options[1].value}>{options[1].name}</MenuItem>
     </Select>
   )
 }

--- a/ui/app/src/modules/Search/FilterSearchDropdown.tsx
+++ b/ui/app/src/modules/Search/FilterSearchDropdown.tsx
@@ -552,11 +552,11 @@ function SortOrder(props: SortOrderProps) {
   const isRelevance = (queryParams['sortBy'] === '_score' || queryParams['sortBy'] === undefined);
   const options = isRelevance ? [
     {
-      name: formatMessage(messages.moreRelevance),
+      name: formatMessage(messages.moreRelevantFirst),
       value: 'desc'
     },
     {
-      name: formatMessage(messages.lessRelevance),
+      name: formatMessage(messages.lessRelevantFirst),
       value: 'asc'
     },
   ] : [

--- a/ui/app/src/modules/Search/Search.tsx
+++ b/ui/app/src/modules/Search/Search.tsx
@@ -149,7 +149,7 @@ const initialSearchParameters: ElasticParams = {
   offset: 0,
   limit: 21,
   sortBy: '_score',
-  sortOrder: 'asc',
+  sortOrder: 'desc',
   filters: {}
 };
 
@@ -344,7 +344,14 @@ function Search(props: SearchProps) {
       if (queryParams.filters === '{}') {
         queryParams.filters = undefined;
       }
-      newFilters = {...queryParams, [filter.name]: filter.value};
+      // queryParams['sortBy'] === undefined: this means the current filter is the default === _score
+      if (filter.name === 'sortBy' && (queryParams['sortBy'] === '_score' || queryParams['sortBy'] === undefined) && filter.value !== '_score') {
+        newFilters = { ...queryParams, [filter.name]: filter.value, sortOrder: 'asc' };
+      } else if (filter.name === 'sortBy' && queryParams['sortBy'] !== '_score' && filter.value === '_score') {
+        newFilters = { ...queryParams, [filter.name]: filter.value, sortOrder: 'desc' };
+      } else {
+        newFilters = { ...queryParams, [filter.name]: filter.value };
+      }
     }
     return queryString.stringify(newFilters);
   }


### PR DESCRIPTION
when the selected "sort by" is "Relevance" change the labels of the sort order selector to read "Most relevant first" (i.e. descending) and "Less relevant first" (i.e. ascending). As requested, make descending the default for "relevance".

https://github.com/craftercms/craftercms/issues/3741
