### PR TITLE
Bulk upload completion does not refresh the assets tree

### DIFF
--- a/static-assets/components/cstudio-dialogs/bulk-upload.js
+++ b/static-assets/components/cstudio-dialogs/bulk-upload.js
@@ -48,7 +48,7 @@
                 if (e.which === 27) {
                     me.close();
                     window.removeEventListener('keydown', escKeyListener, false);
-                    Self.refreshNodes(oCurrentTextNode,false, false, null, null, true);
+                    CStudioAuthoring.ContextualNav.WcmRootFolder.refreshNodes(oCurrentTextNode,false, false, null, null, true);
                 }
             };
 
@@ -60,7 +60,7 @@
             }, false);
             elem.querySelector('a.close').addEventListener('click', function (e) {
                 me.close();
-                Self.refreshNodes(oCurrentTextNode,false, false, null, null, true);
+                CStudioAuthoring.ContextualNav.WcmRootFolder.refreshNodes(oCurrentTextNode,false, false, null, null, true);
             }, false);
 
             this.id = id;


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
a quick fix bulk upload feature of studio-ui.

## Issue
After files uploaded and click "Done", the left menu tree is not reloaded and console throw an error of `Self` is not defined.

## Solution
Using global variable  `CStudioAuthoring.ContextualNav.WcmRootFolder` instead of `Self`.
Tested on Chrome and Firefox