### PR TITLE
[3766] [studio-ui] Parameter "token" missing from call to /api/1/monitoring/log.json

### DIFF
--- a/static-assets/scripts/admin.js
+++ b/static-assets/scripts/admin.js
@@ -243,7 +243,7 @@
       }
 
       this.getLogPreview = function(data){
-        return $http.get('/api/1/monitoring/log.json', {
+        return $http.get('/studio/engine/api/1/monitoring/log.json', {
           params: data
         });
       }
@@ -753,7 +753,8 @@
         }
 
         if(logType === 'preview') {
-          data.site = $location.search().site
+          data.site = $location.search().site;
+          data.crafterSite = data.site;
         }
 
         logService(data)


### PR DESCRIPTION
Use studio proxy to get preview logs

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/3766