### PR TITLE
[3799] Invalid Unsaved Changes popup when language is changed in Account Settings

### DIFF
--- a/static-assets/scripts/main.js
+++ b/static-assets/scripts/main.js
@@ -1073,6 +1073,8 @@
           // set both cookies, on login (on user) it will get last selected
           localStorage.setItem('crafterStudioLanguage', $scope.langSelected);
           localStorage.setItem($scope.user.username + '_crafterStudioLanguage', $scope.langSelected);
+          $scope.isModified = false;
+
           let loginSuccess = new CustomEvent('setlocale', { 'detail': $scope.langSelected });
           document.dispatchEvent(loginSuccess);
 
@@ -1080,7 +1082,6 @@
             position: 'top left',
             className: 'success'
           });
-          $scope.isModified = false;
         } catch (err) {
           $element.find('.settings-view').notify(formatMessage(profileSettingsMessages.languageSaveFailedWarning), {
             position: 'top left',


### PR DESCRIPTION
Redirection was happening before setting modified variable to false, causing the dialog to show
https://github.com/craftercms/craftercms/issues/3799