### PR TITLE
[39E] Fixes session renewal dialog showing underneath other modals and multiple dialogs showing up when embedded views are present

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -582,8 +582,8 @@ var nodeOpen = false,
 
                     //set z-index to 101 so that dialog will display over context nav bar
                     if (setZIndex && dialogue.element && dialogue.element.style.zIndex != "") {
-                        dialogue.element.style.zIndex = "102000";
-                        dialogue.mask.style.zIndex = "101000";
+                        dialogue.element.style.zIndex = "1020";
+                        dialogue.mask.style.zIndex = "1010";
                     }
                 };
                 var params = ["component-dialogue"];

--- a/ui/app/src/styles/theme.tsx
+++ b/ui/app/src/styles/theme.tsx
@@ -42,14 +42,6 @@ export const theme = createMuiTheme({
       secondary: '#828282'
     }
   },
-  zIndex: {
-    mobileStepper: 770,
-    appBar: 847,
-    drawer: 924,
-    modal: 1000,
-    snackbar: 1078,
-    tooltip: 1155
-  },
   overrides: {
     MuiFormLabel: {
       root: {


### PR DESCRIPTION
Item missed during https://github.com/craftercms/studio-ui/pull/1570