### PR TITLE
Fix odd freemarker behaviour

### DIFF
--- a/templates/web/plugin.ftl
+++ b/templates/web/plugin.ftl
@@ -14,15 +14,15 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<#assign site = RequestParameters.site!''>
-<#assign type = RequestParameters.type!''>
-<#assign name = RequestParameters.name!''>
-<#assign file = RequestParameters.file!'index.js'>
-<#if site?? && type?? && name?? && file?ends_with('.html')>
+<#assign pSite = RequestParameters.site!''>
+<#assign pType = RequestParameters.type!''>
+<#assign pName = RequestParameters.name!''>
+<#assign pFile = RequestParameters.file!'index.js'>
+<#if pSite?? && pType?? && pName?? && pFile?ends_with('.html')>
   <#assign html = applicationContext.configurationService.getConfigurationAsString(
-      site,
+      pSite,
       "studio",
-      "/plugins/${type}/${name}/${file}",
+      "/plugins/${pType}/${pName}/${pFile}",
       ""
     )!"CONTENT_NOT_FOUND"
   />
@@ -54,7 +54,7 @@
   ${html}
   </#if>
 <#else>
-  <@layout title="${name?replace('-', ' ')?cap_first} - ${contentModel['common-title']!''}">
+  <@layout title="${pName?replace('-', ' ')?cap_first} - ${contentModel['common-title']!''}">
     <script>
       window.CRAFTER_CMS_PLUGIN_PAGE = true;
       (function () {
@@ -64,7 +64,7 @@
 
         const script = document.createElement('script');
 
-        script.src = '/studio/api/2/plugin/file?siteId=${site}&type=${type}&name=${name}&filename=${file}';
+        script.src = '/studio/api/2/plugin/file?siteId=${pSite}&type=${pType}&name=${pName}&filename=${pFile}';
 
         script.onload = function () {
           if (['yes', 'true', 'enable', '1'].includes(qs.monitor)) {
@@ -87,8 +87,8 @@
               code: '',
               message: 'Unable to render the requested plugin.',
               remedialAction: (
-                      'Please check that the url has all the necessary params (site, type, name and file), ' +
-                      'that these values are correct and that you\'ve committed all your work to the site repo.'
+                'Please check that the url has all the necessary params (site, type, name and file), ' +
+                'that these values are correct and that you\'ve committed all your work to the site repo.'
               )
             }
           });

--- a/templates/web/plugin.ftl
+++ b/templates/web/plugin.ftl
@@ -128,8 +128,6 @@
     </style>
   </head>
   <body>
-  <script src="/studio/static-assets/libs/jquery/dist/jquery.js"></script>
-  <#include "/templates/web/common/page-fragments/studio-context.ftl" />
   <#include "/templates/web/common/js-next-scripts.ftl" />
   <#nested />
   </body>


### PR DESCRIPTION
Something changed on free marker and there's some context on the macro(s) on this file that was overriding local variables.

```
http://localhost:8080/studio/plugin?site=editorial&type=apps&name=modern
```

```freemarker
<#assign site = RequestParameters.site!''>
<#assign type = RequestParameters.type!''>
<#assign name = RequestParameters.name!''>
<#assign file = RequestParameters.file!'index.js'>

script.src = '/studio/api/2/plugin/file?siteId=${site}&type=${type}&name=${name}&filename=${file}';
```

Printed:

```js
script.src = '/studio/api/2/plugin/file?siteId=wordify&type=apps&name=Crafter Studio&filename=/Users/rart/Workspace/craftercms-develop/src/studio/pom.xml';
```

Notice `${file}` shows some pom.xml, `${name}` shows "Crafter Studio" and `${site}` has the active site (the one on the cookie) value. Before, all those showed what the variables where, which came from the request parameters.

Before recent forking, it all worked.