### PR TITLE
[3983] Parameterize leftActions and rightActions on DialogHeader component

### DIFF
--- a/ui/app/src/components/DialogFooter.tsx
+++ b/ui/app/src/components/DialogFooter.tsx
@@ -24,7 +24,6 @@ const styles = makeStyles(() =>
   createStyles({
     dialogActions: {
       background: palette.white,
-      borderTop: '1px solid rgba(0, 0, 0, 0.12)',
       minHeight: '55px'
     }
   })

--- a/ui/app/src/components/DialogFooter.tsx
+++ b/ui/app/src/components/DialogFooter.tsx
@@ -24,6 +24,7 @@ const styles = makeStyles(() =>
   createStyles({
     dialogActions: {
       background: palette.white,
+      borderTop: '1px solid rgba(0, 0, 0, 0.12)',
       minHeight: '55px'
     }
   })

--- a/ui/app/src/components/DialogHeader.tsx
+++ b/ui/app/src/components/DialogHeader.tsx
@@ -32,20 +32,31 @@ const dialogTitleStyles = makeStyles(() =>
     titleRoot: {
       margin: 0,
       padding: '10px',
+      borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
       background: palette.white
     },
     title: {
       display: 'flex',
       alignItems: 'center'
     },
+    typography: {
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis'
+    },
     subtitle: {
       fontSize: '14px',
       lineHeight: '18px',
       paddingRight: '35px'
     },
+    leftActions: {
+      marginRight: '5px',
+      whiteSpace: 'nowrap'
+    },
     rightActions: {
       paddingLeft: '5px',
-      marginLeft: 'auto'
+      marginLeft: 'auto',
+      whiteSpace: 'nowrap'
     },
     backIcon: {}
   })
@@ -68,29 +79,33 @@ const translations = defineMessages({
 
 function Action(props: any) {
   const { icon: Icon, tooltip, ...rest } = props;
-  return (
-    tooltip ? (
-      <Tooltip title={tooltip}>
-        <IconButton {...rest}>
-          <Icon />
-        </IconButton>
-      </Tooltip>
-    ) : (
+  return tooltip ? (
+    <Tooltip title={tooltip}>
       <IconButton {...rest}>
         <Icon />
       </IconButton>
-    )
+    </Tooltip>
+  ) : (
+    <IconButton {...rest}>
+      <Icon />
+    </IconButton>
   );
 }
 
-export type DialogTitleProps<PrimaryTypographyComponent extends React.ElementType = 'h2',
-  SecondaryTypographyComponent extends React.ElementType = 'p'> = PropsWithChildren<{
+export type DialogTitleProps<
+  PrimaryTypographyComponent extends React.ElementType = 'h2',
+  SecondaryTypographyComponent extends React.ElementType = 'p'
+> = PropsWithChildren<{
   id?: string;
   title: string | JSX.Element;
-  titleTypographyProps?: TypographyProps<PrimaryTypographyComponent,
-    { component?: PrimaryTypographyComponent }>;
-  subtitleTypographyProps?: TypographyProps<SecondaryTypographyComponent,
-    { component?: SecondaryTypographyComponent }>;
+  titleTypographyProps?: TypographyProps<
+    PrimaryTypographyComponent,
+    { component?: PrimaryTypographyComponent }
+  >;
+  subtitleTypographyProps?: TypographyProps<
+    SecondaryTypographyComponent,
+    { component?: SecondaryTypographyComponent }
+  >;
   subtitle?: string;
   leftActions?: DialogHeaderAction[];
   rightActions?: DialogHeaderAction[];
@@ -133,23 +148,32 @@ export default function DialogHeader(props: DialogTitleProps) {
       classes={{ root: clsx(classes.titleRoot, props.classes?.root) }}
     >
       <div className={classes.title}>
-        {onBack && (
-          <Tooltip title={formatMessage(translations.back)}>
-            <IconButton aria-label="close" onClick={onBack} className={classes.backIcon}>
-              <BackIcon />
-            </IconButton>
-          </Tooltip>
+        {(leftActions || onBack) && (
+          <div className={classes.leftActions}>
+            {onBack && (
+              <Tooltip title={formatMessage(translations.back)}>
+                <IconButton aria-label="close" onClick={onBack} className={classes.backIcon}>
+                  <BackIcon />
+                </IconButton>
+              </Tooltip>
+            )}
+            {leftActions?.map(
+              ({ icon, 'aria-label': tooltip, ...rest }: DialogHeaderAction, i: number) => (
+                <Action key={i} icon={icon} tooltip={tooltip} {...rest} />
+              )
+            )}
+          </div>
         )}
-        {leftActions?.map(({ icon, 'aria-label': tooltip, ...rest }: DialogHeaderAction, i: number) => (
-          <Action key={i} icon={icon} tooltip={tooltip} {...rest} />
-        ))}
-        <Typography {...titleTypographyProps}>{title}</Typography>
-        {
-          (rightActions || onDismiss) &&
+        <Typography className={classes.typography} {...titleTypographyProps}>
+          {title}
+        </Typography>
+        {(rightActions || onDismiss) && (
           <div className={classes.rightActions}>
-            {rightActions?.map(({ icon, 'aria-label': tooltip, ...rest }: DialogHeaderAction, i: number) => (
-              <Action key={i} icon={icon} tooltip={tooltip} {...rest} />
-            ))}
+            {rightActions?.map(
+              ({ icon, 'aria-label': tooltip, ...rest }: DialogHeaderAction, i: number) => (
+                <Action key={i} icon={icon} tooltip={tooltip} {...rest} />
+              )
+            )}
             {onDismiss && (
               <Tooltip title={formatMessage(translations.dismiss)}>
                 <IconButton aria-label="close" onClick={onDismiss}>
@@ -158,7 +182,7 @@ export default function DialogHeader(props: DialogTitleProps) {
               </Tooltip>
             )}
           </div>
-        }
+        )}
       </div>
       {subtitle && (
         <Typography className={classes.subtitle} {...subtitleTypographyProps}>

--- a/ui/app/src/components/DialogHeader.tsx
+++ b/ui/app/src/components/DialogHeader.tsx
@@ -31,9 +31,8 @@ const dialogTitleStyles = makeStyles(() =>
   createStyles({
     titleRoot: {
       margin: 0,
-      borderBottom: '1px solid rgba(0, 0, 0, 0.12)'
-      padding: '10px',
       borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+      padding: '10px',
       background: palette.white
     },
     title: {

--- a/ui/app/src/components/DialogHeader.tsx
+++ b/ui/app/src/components/DialogHeader.tsx
@@ -24,14 +24,15 @@ import ArrowBack from '@material-ui/icons/ArrowBackIosRounded';
 import React, { PropsWithChildren } from 'react';
 import createStyles from '@material-ui/styles/createStyles/createStyles';
 import clsx from 'clsx';
+import { Tooltip } from '@material-ui/core';
+import { defineMessages, useIntl } from 'react-intl';
 
 const dialogTitleStyles = makeStyles(() =>
   createStyles({
     titleRoot: {
       margin: 0,
-      padding: '13px 20px 11px',
-      background: palette.white,
-      borderBottom: '1px solid rgba(0, 0, 0, 0.12)'
+      padding: '10px',
+      background: palette.white
     },
     title: {
       display: 'flex',
@@ -42,7 +43,8 @@ const dialogTitleStyles = makeStyles(() =>
       lineHeight: '18px',
       paddingRight: '35px'
     },
-    closeIcon: {
+    rightActions: {
+      paddingLeft: '5px',
       marginLeft: 'auto'
     },
     backIcon: {}
@@ -53,20 +55,42 @@ export interface DialogHeaderAction extends IconButtonProps {
   icon: React.ElementType;
 }
 
-export type DialogTitleProps<
-  PrimaryTypographyComponent extends React.ElementType = 'h2',
-  SecondaryTypographyComponent extends React.ElementType = 'p'
-> = PropsWithChildren<{
+const translations = defineMessages({
+  back: {
+    id: 'words.back',
+    defaultMessage: 'Back'
+  },
+  dismiss: {
+    id: 'words.dismiss',
+    defaultMessage: 'Dismiss'
+  }
+});
+
+function Action(props: any) {
+  const { icon: Icon, tooltip, ...rest } = props;
+  return (
+    tooltip ? (
+      <Tooltip title={tooltip}>
+        <IconButton {...rest}>
+          <Icon />
+        </IconButton>
+      </Tooltip>
+    ) : (
+      <IconButton {...rest}>
+        <Icon />
+      </IconButton>
+    )
+  );
+}
+
+export type DialogTitleProps<PrimaryTypographyComponent extends React.ElementType = 'h2',
+  SecondaryTypographyComponent extends React.ElementType = 'p'> = PropsWithChildren<{
   id?: string;
   title: string | JSX.Element;
-  titleTypographyProps?: TypographyProps<
-    PrimaryTypographyComponent,
-    { component?: PrimaryTypographyComponent }
-  >;
-  subtitleTypographyProps?: TypographyProps<
-    SecondaryTypographyComponent,
-    { component?: SecondaryTypographyComponent }
-  >;
+  titleTypographyProps?: TypographyProps<PrimaryTypographyComponent,
+    { component?: PrimaryTypographyComponent }>;
+  subtitleTypographyProps?: TypographyProps<SecondaryTypographyComponent,
+    { component?: SecondaryTypographyComponent }>;
   subtitle?: string;
   leftActions?: DialogHeaderAction[];
   rightActions?: DialogHeaderAction[];
@@ -81,6 +105,7 @@ export type DialogTitleProps<
 
 export default function DialogHeader(props: DialogTitleProps) {
   const classes = dialogTitleStyles({});
+  const { formatMessage } = useIntl();
   const {
     id,
     onDismiss,
@@ -94,8 +119,7 @@ export default function DialogHeader(props: DialogTitleProps) {
     backIcon: BackIcon = ArrowBack,
     titleTypographyProps = {
       variant: 'h6',
-      component: 'h2',
-      color: 'textSecondary'
+      component: 'h2'
     },
     subtitleTypographyProps = {
       variant: 'subtitle1',
@@ -110,26 +134,31 @@ export default function DialogHeader(props: DialogTitleProps) {
     >
       <div className={classes.title}>
         {onBack && (
-          <IconButton aria-label="close" onClick={onBack} className={classes.backIcon}>
-            <BackIcon />
-          </IconButton>
+          <Tooltip title={formatMessage(translations.back)}>
+            <IconButton aria-label="close" onClick={onBack} className={classes.backIcon}>
+              <BackIcon />
+            </IconButton>
+          </Tooltip>
         )}
-        {leftActions?.map(({ icon: Icon, ...rest }: DialogHeaderAction) => (
-          <IconButton {...rest}>
-            <Icon />
-          </IconButton>
+        {leftActions?.map(({ icon, 'aria-label': tooltip, ...rest }: DialogHeaderAction, i: number) => (
+          <Action key={i} icon={icon} tooltip={tooltip} {...rest} />
         ))}
         <Typography {...titleTypographyProps}>{title}</Typography>
-        {rightActions?.map(({ icon: Icon, ...rest }: DialogHeaderAction) => (
-          <IconButton {...rest}>
-            <Icon />
-          </IconButton>
-        ))}
-        {onDismiss && (
-          <IconButton aria-label="close" onClick={onDismiss} className={classes.closeIcon}>
-            <CloseIcon />
-          </IconButton>
-        )}
+        {
+          (rightActions || onDismiss) &&
+          <div className={classes.rightActions}>
+            {rightActions?.map(({ icon, 'aria-label': tooltip, ...rest }: DialogHeaderAction, i: number) => (
+              <Action key={i} icon={icon} tooltip={tooltip} {...rest} />
+            ))}
+            {onDismiss && (
+              <Tooltip title={formatMessage(translations.dismiss)}>
+                <IconButton aria-label="close" onClick={onDismiss}>
+                  <CloseIcon />
+                </IconButton>
+              </Tooltip>
+            )}
+          </div>
+        }
       </div>
       {subtitle && (
         <Typography className={classes.subtitle} {...subtitleTypographyProps}>

--- a/ui/app/src/components/DialogHeader.tsx
+++ b/ui/app/src/components/DialogHeader.tsx
@@ -31,6 +31,7 @@ const dialogTitleStyles = makeStyles(() =>
   createStyles({
     titleRoot: {
       margin: 0,
+      borderBottom: '1px solid rgba(0, 0, 0, 0.12)'
       padding: '10px',
       background: palette.white
     },


### PR DESCRIPTION
Ticket: https://github.com/craftercms/craftercms/issues/3983
- [x] Right actions end up next to the title, to the left. Right actions and close icon shortcut should both align to the right. Wrap them in a container that does this so they both behave like this.
- [x] Set padding of the dialog header to `10px` (all around)
- [x] Since materials body has the dividers, seems most practical to leave at the body so let's rollback the header/footer having the dividers and use the dialog body's
- [x] Remove the default `color` prop of the titleTypographyProps
- [x] Add key to each action
- [x] Add some margin (~5px) between right actions and the title (spacing should only show up when there are leftActions).