### PR TITLE
Enable batched action dispatching

### DIFF
--- a/ui/app/src/components/SystemStatus/GlobalDialogManager.tsx
+++ b/ui/app/src/components/SystemStatus/GlobalDialogManager.tsx
@@ -41,17 +41,23 @@ function createCallback(
   action: StandardAction,
   dispatch: Dispatch
 ): (output?: unknown) => void {
-  return action
-    ? (output) => dispatch({
+  return action ? (output) => {
+    const hasPayload = Boolean(action.payload);
+    const hasOutput = Boolean(output) && isPlainObject(output);
+    const payload = hasPayload && !hasOutput
+      ? action.payload
+      : !hasPayload && hasOutput
+        ? output
+        // We're using objects for all our payloads - I think - but this
+        // could fail with literal native values such as strings or numbers
+        : hasPayload && hasOutput
+          ? Object.assign(action.payload, { output })
+          : false;
+    dispatch({
       type: action.type,
-      ...(isPlainObject(output) || Boolean(action.payload) ? {
-        payload: {
-          ...action.payload,
-          ...(isPlainObject(output) ? { output } : {})
-        }
-      } : {})
-    })
-    : null;
+      ...(payload ? { payload } : {})
+    });
+  } : null;
 }
 
 export const useStyles = makeStyles(() =>

--- a/ui/app/src/state/actions/misc.ts
+++ b/ui/app/src/state/actions/misc.ts
@@ -14,32 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function forEach<T = any>(
-  array: T[],
-  fn: (item: T, index: number, array: T[]) => any,
-  emptyReturnValue: any = undefined
-): any {
-  if ((emptyReturnValue != null) && (array?.length === 0)) {
-    return emptyReturnValue;
-  }
-  for (let i = 0, l = array.length; i < l; i++) {
-    const result = fn(array[i], i, array);
-    if (result === 'continue') {
+import { createAction } from '@reduxjs/toolkit';
+import StandardAction from '../../models/StandardAction';
 
-    } else if (result === 'break') {
-      break;
-    } else if (result !== undefined) {
-      return result;
-    }
-  }
-  return emptyReturnValue;
-}
-
-export function asArray<T = unknown>(value: T): T[] {
-  return Array.isArray(value) ? value : [value];
-}
-
-export default {
-  forEach,
-  asArray
-};
+export const batchActions = createAction<StandardAction[]>('BATCH_ACTIONS');

--- a/ui/app/src/state/epics/root.ts
+++ b/ui/app/src/state/epics/root.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { combineEpics } from 'redux-observable';
+import { combineEpics, ofType } from 'redux-observable';
 import auth from './auth';
 import sites from './sites';
 import contentTypes from './contentTypes';
@@ -24,8 +24,15 @@ import dialogs from './dialogs';
 import preview from './preview';
 import legacy from './legacy';
 import versions from './versions';
+import { switchMap } from 'rxjs/operators';
+import { batchActions } from '../actions/misc';
 
 const epic: any[] = combineEpics.apply(this, [
+  (action$) =>
+    action$.pipe(
+      ofType(batchActions.type),
+      switchMap(({ payload }) => payload)
+    ),
   ...auth,
   ...sites,
   ...contentTypes,


### PR DESCRIPTION
## Sample Usage
```js
import { fetchPubishingChannels, fetchPublishingConfig, showPublishDialog, closePublishDialog } from '../state/actionCreators';
import { batchActions } from '../state/actions/misc';
...
  dispatch(
    // Can be used in a normal dispatch
    batchActions([
      fetchPubishingChannels(),
      fetchPublishingConfig(),
      showPublishDialog({
        onClose: closePublishDialog(
          // Can be used as the onClose payload too
          batchActions([
            clearPubishingChannels(),
            clearPubishingConfig(),
            updateItems()
          ])
        )
      })
    ])
  );
```