### PR TITLE
[3979][3.1.x] api/2/configuration/get_configuration_history doesn't work when default environment is set

### DIFF
--- a/static-assets/components/cstudio-admin/base.js
+++ b/static-assets/components/cstudio-admin/base.js
@@ -200,6 +200,8 @@
             CStudioAdminConsole.CommandBar.hide();
           }
 
+          amplify.publish('TOOL_SELECTED');
+
           params.toolbar.selectedEl = self;
           YDom.addClass(self, 'cstudio-admin-console-item-selected');
           params.tool.renderWorkarea();

--- a/static-assets/components/cstudio-admin/mods/admin-configurations.js
+++ b/static-assets/components/cstudio-admin/mods/admin-configurations.js
@@ -152,9 +152,15 @@
 
         this.loadConfigFiles();
 
-        amplify.subscribe('HISTORY_REVERT', function () {
+        const cb = () => {
           self.loadSelectedConfig();
-        });
+        }
+
+        amplify.subscribe('TOOL_SELECTED', () => {
+          amplify.unsubscribe('HISTORY_REVERT', cb);
+        })
+
+        amplify.subscribe('HISTORY_REVERT', cb);
 
         // hide display area by default
         editAreaEl.style.display = 'none';

--- a/static-assets/components/cstudio-admin/mods/admin-configurations.js
+++ b/static-assets/components/cstudio-admin/mods/admin-configurations.js
@@ -156,9 +156,12 @@
           self.loadSelectedConfig();
         }
 
-        amplify.subscribe('TOOL_SELECTED', () => {
+        const handler = () => {
           amplify.unsubscribe('HISTORY_REVERT', cb);
-        })
+          amplify.unsubscribe('TOOL_SELECTED', handler);
+        };
+
+        amplify.subscribe('TOOL_SELECTED', handler);
 
         amplify.subscribe('HISTORY_REVERT', cb);
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3979