### PR TITLE
[4152] Add snack for "No receptacles for this component" when a component drag starts from components or browse panels

### DIFF
--- a/ui/app/src/components/Dialogs/CreateNewFileDialog.tsx
+++ b/ui/app/src/components/Dialogs/CreateNewFileDialog.tsx
@@ -46,7 +46,7 @@ export const translations = defineMessages({
 });
 
 export default function (props: CreateNewFileProps) {
-  const { open, onClose, onClosed } = props;
+  const { open, onClose } = props;
   const [state, setState] = useState({
     submitted: null,
     inProgress: null

--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -109,6 +109,10 @@ const guestMessages = defineMessages({
   registerNotFound: {
     id: 'register.notFound',
     defaultMessage: '{name} is not visible or was not registered by developers'
+  },
+  receptaclesNotFound: {
+    id: 'register.receptaclesNotFound',
+    defaultMessage: 'There are no receptacles for {contentType} components'
   }
 });
 

--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -439,7 +439,7 @@ export function PreviewConcierge(props: any) {
         }
         case 'VALIDATION_MESSAGE': {
           enqueueSnackbar(formatMessage(guestMessages[payload.id], payload.values ?? {}), {
-            variant: payload.level === 'required' ? 'error' : 'warning'
+            variant: payload.level === 'required' ? 'error' : payload.level === 'suggestion' ? 'warning' : 'info'
           });
           break;
         }

--- a/ui/app/src/modules/Preview/Tools/BrowseComponentsPanel.tsx
+++ b/ui/app/src/modules/Preview/Tools/BrowseComponentsPanel.tsx
@@ -190,7 +190,10 @@ export default function BrowseComponentsPanel() {
   const onDragStart = (item: ContentInstance) =>
     hostToGuest$.next({
       type: COMPONENT_INSTANCE_DRAG_STARTED,
-      payload: item
+      payload: {
+        instance: item,
+        contentType: contentTypesBranch.byId[item.craftercms.contentTypeId]
+      }
     });
 
   const onDragEnd = () => hostToGuest$.next({ type: COMPONENT_INSTANCE_DRAG_ENDED });

--- a/ui/guest/src/react/Guest.tsx
+++ b/ui/guest/src/react/Guest.tsx
@@ -40,8 +40,8 @@ import {
   COMPONENT_DRAG_STARTED,
   COMPONENT_INSTANCE_DRAG_ENDED,
   COMPONENT_INSTANCE_DRAG_STARTED,
-  CONTENT_TREE_SWITCH_FIELD_INSTANCE,
   CONTENT_TREE_FIELD_SELECTED,
+  CONTENT_TREE_SWITCH_FIELD_INSTANCE,
   CONTENT_TYPE_RECEPTACLES_REQUEST,
   DESKTOP_ASSET_DRAG_ENDED,
   DESKTOP_ASSET_DRAG_STARTED,
@@ -181,7 +181,7 @@ function Guest(props: GuestProps) {
           dragOk(status) && dispatch(action);
           break;
         case COMPONENT_INSTANCE_DRAG_STARTED:
-          dispatch({ type, payload: { instance: payload } });
+          dispatch({ type, payload });
           break;
         case COMPONENT_INSTANCE_DRAG_ENDED:
           dragOk(status) && dispatch(action);

--- a/ui/guest/src/store/epics/root.ts
+++ b/ui/guest/src/store/epics/root.ts
@@ -487,7 +487,7 @@ const epic: Epic<GuestStandardAction, GuestStandardAction, GuestState> = combine
               payload: {
                 id: 'receptaclesNotFound',
                 level: 'info',
-                values: { contentType: state.dragContext.contentType.id }
+                values: { contentType: state.dragContext.contentType.name }
               }
             });
           }
@@ -514,7 +514,7 @@ const epic: Epic<GuestStandardAction, GuestStandardAction, GuestState> = combine
               payload: {
                 id: 'receptaclesNotFound',
                 level: 'info',
-                values: { contentType: state.dragContext.instance.craftercms.contentTypeId }
+                values: { contentType: state.dragContext.contentType.name }
               }
             });
           }

--- a/ui/guest/src/store/epics/root.ts
+++ b/ui/guest/src/store/epics/root.ts
@@ -50,8 +50,8 @@ import {
   COMPONENT_DRAG_STARTED,
   COMPONENT_INSTANCE_DRAG_ENDED,
   COMPONENT_INSTANCE_DRAG_STARTED,
-  CONTENT_TREE_SWITCH_FIELD_INSTANCE,
   CONTENT_TREE_FIELD_SELECTED,
+  CONTENT_TREE_SWITCH_FIELD_INSTANCE,
   CONTENT_TYPE_RECEPTACLES_REQUEST,
   CONTENT_TYPE_RECEPTACLES_RESPONSE,
   DESKTOP_ASSET_DRAG_ENDED,
@@ -481,6 +481,16 @@ const epic: Epic<GuestStandardAction, GuestStandardAction, GuestState> = combine
         if (isNullOrUndefined(contentType.id)) {
           console.error('No contentTypeId found for this drag instance.');
         } else {
+          if (state.dragContext.dropZones.length === 0) {
+            post({
+              type: 'VALIDATION_MESSAGE',
+              payload: {
+                id: 'receptaclesNotFound',
+                level: 'suggestion',
+                values: { contentType: state.dragContext.contentType.id }
+              }
+            });
+          }
           return initializeDragSubjects(state$);
         }
         return NEVER;
@@ -498,6 +508,16 @@ const epic: Epic<GuestStandardAction, GuestStandardAction, GuestState> = combine
         if (isNullOrUndefined(state.dragContext.instance.craftercms.contentTypeId)) {
           console.error('No contentTypeId found for this drag instance.');
         } else {
+          if (state.dragContext.dropZones.length === 0) {
+            post({
+              type: 'VALIDATION_MESSAGE',
+              payload: {
+                id: 'receptaclesNotFound',
+                level: 'suggestion',
+                values: { contentType: state.dragContext.instance.craftercms.contentTypeId }
+              }
+            });
+          }
           return initializeDragSubjects(state$);
         }
         return NEVER;

--- a/ui/guest/src/store/epics/root.ts
+++ b/ui/guest/src/store/epics/root.ts
@@ -486,7 +486,7 @@ const epic: Epic<GuestStandardAction, GuestStandardAction, GuestState> = combine
               type: 'VALIDATION_MESSAGE',
               payload: {
                 id: 'receptaclesNotFound',
-                level: 'suggestion',
+                level: 'info',
                 values: { contentType: state.dragContext.contentType.id }
               }
             });
@@ -513,7 +513,7 @@ const epic: Epic<GuestStandardAction, GuestStandardAction, GuestState> = combine
               type: 'VALIDATION_MESSAGE',
               payload: {
                 id: 'receptaclesNotFound',
-                level: 'suggestion',
+                level: 'info',
                 values: { contentType: state.dragContext.instance.craftercms.contentTypeId }
               }
             });

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -38,8 +38,8 @@ import {
   COMPONENT_DRAG_STARTED,
   COMPONENT_INSTANCE_DRAG_ENDED,
   COMPONENT_INSTANCE_DRAG_STARTED,
-  CONTENT_TREE_SWITCH_FIELD_INSTANCE,
   CONTENT_TREE_FIELD_SELECTED,
+  CONTENT_TREE_SWITCH_FIELD_INSTANCE,
   CONTENT_TYPE_RECEPTACLES_REQUEST,
   DESKTOP_ASSET_DRAG_ENDED,
   DESKTOP_ASSET_DRAG_STARTED,
@@ -121,7 +121,8 @@ const host_component_drag_started: GuestReducer = (state, action) => {
 // region host_instance_drag_started
 // TODO: Not pure.
 const host_instance_drag_started: GuestReducer = (state, action) => {
-  const { instance } = action.payload;
+  const { instance, contentType } = action.payload;
+
   if (notNullOrUndefined(instance)) {
     const receptacles = iceRegistry.getContentTypeReceptacles(instance.craftercms.contentTypeId);
     const validationsLookup = iceRegistry.runReceptaclesValidations(receptacles);
@@ -139,6 +140,7 @@ const host_instance_drag_started: GuestReducer = (state, action) => {
         dropZones,
         containers,
         instance,
+        contentType,
         inZone: false,
         targetIndex: null,
         dragged: null


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4152