### PR TITLE
[3959] Create folder in Scripts blocks the use of {} in the name which are used to indicate parametrized portions of the url

### DIFF
--- a/static-assets/components/cstudio-dialogs/new-folder-name-dialog.js
+++ b/static-assets/components/cstudio-dialogs/new-folder-name-dialog.js
@@ -138,7 +138,7 @@ CStudioAuthoring.Dialogs.NewFolderNameDialog = CStudioAuthoring.Dialogs.NewFolde
             // esc
             me.createPopupCancel();
           } else {
-            me.processKey(e, inputEl, eventParams.self.path === '/scripts/rest');
+            me.processKey(e, inputEl, eventParams.self.path.startsWith('/scripts/rest'));
           }
         } else {
           me.createPopupSubmit(e, eventParams);

--- a/static-assets/components/cstudio-dialogs/new-folder-name-dialog.js
+++ b/static-assets/components/cstudio-dialogs/new-folder-name-dialog.js
@@ -138,7 +138,7 @@ CStudioAuthoring.Dialogs.NewFolderNameDialog = CStudioAuthoring.Dialogs.NewFolde
             // esc
             me.createPopupCancel();
           } else {
-            me.processKey(e, inputEl);
+            me.processKey(e, inputEl, eventParams.self.path === '/scripts/rest');
           }
         } else {
           me.createPopupSubmit(e, eventParams);
@@ -157,7 +157,7 @@ CStudioAuthoring.Dialogs.NewFolderNameDialog = CStudioAuthoring.Dialogs.NewFolde
     var contentType = 'folder';
     var newFolderName = document.getElementById('folderNameId').value;
     var serviceUri = CStudioAuthoring.Service.createServiceUri(
-      args.self.serviceUri + '?site=' + args.self.site + '&path=' + args.self.path + '&name=' + newFolderName
+      args.self.serviceUri + '?site=' + args.self.site + '&path=' + args.self.path + '&name=' + encodeURI(newFolderName)
     );
 
     var serviceCallback = {
@@ -191,8 +191,11 @@ CStudioAuthoring.Dialogs.NewFolderNameDialog = CStudioAuthoring.Dialogs.NewFolde
   /**
    * don't allow characters which are invalid for file names and check length
    */
-  processKey: function(evt, el) {
+  processKey: function (evt, el, allowBraces) {
     var invalid = new RegExp('[!@#$%^&*\\(\\)\\+=\\[\\]\\\\\\\'`;,\\.\\/\\{\\}|":<>\\?~ ]', 'g');
+    if (allowBraces) {
+      invalid = new RegExp('[!@#$%^&*\\(\\)\\+=\\[\\]\\\\\\\'`;,\\.\\/|":<>\\?~ ]', 'g');
+    }
     var cursorPosition = el.selectionStart;
     //change url to lower case
     if (el.value != '' && el.value != el.value.toLowerCase()) {

--- a/ui/app/src/components/Dialogs/CreateNewFolderDialog.tsx
+++ b/ui/app/src/components/Dialogs/CreateNewFolderDialog.tsx
@@ -41,6 +41,7 @@ interface CreateNewFolderProps {
   path?: string;
   rename?: boolean;
   value?: string;
+  allowBraces?: boolean;
   onClose(): void;
   onClosed?(): void;
   onCreated?(path: string, name: string, rename: boolean): void;
@@ -78,7 +79,7 @@ interface CreateNewFolderUIProps extends CreateNewFolderProps {
 }
 
 function CreateNewFolderUI(props: CreateNewFolderUIProps) {
-  const { onClosed, onClose, path, submitted, inProgress, setState, onCreated, rename = false, value = '' } = props;
+  const { onClosed, onClose, path, submitted, inProgress, setState, onCreated, rename = false, value = '', allowBraces = false } = props;
   const [name, setName] = useState(value);
   const dispatch = useDispatch();
   const site = useActiveSiteId();
@@ -91,7 +92,7 @@ function CreateNewFolderUI(props: CreateNewFolderUIProps) {
 
     if (name) {
       if (rename) {
-        renameFolder(site, path, name).subscribe(
+        renameFolder(site, path, encodeURI(name)).subscribe(
           (response) => {
             onClose();
             onCreated?.(path, name, rename);
@@ -102,7 +103,7 @@ function CreateNewFolderUI(props: CreateNewFolderUIProps) {
           }
         );
       } else {
-        createNewFolder(site, path, name).subscribe(
+        createNewFolder(site, path, encodeURI(name)).subscribe(
           (resp) => {
             onClose();
             onCreated?.(path, name, rename);
@@ -155,7 +156,7 @@ function CreateNewFolderUI(props: CreateNewFolderUIProps) {
           InputLabelProps={{
             shrink: true
           }}
-          onChange={(event) => setName(event.target.value.replace(/[^a-zA-Z0-9-_]/g, ''))}
+          onChange={(event) => setName(event.target.value.replace(allowBraces ? /[^a-zA-Z0-9-_{}]/g : /[^a-zA-Z0-9-_]/g, ''))}
         />
       </DialogBody>
       <DialogFooter>

--- a/ui/app/src/components/Navigation/PathNavigator/Widget.tsx
+++ b/ui/app/src/components/Navigation/PathNavigator/Widget.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Fragment, useCallback, useEffect, useReducer, useState } from 'react';
+import React, { Fragment, useCallback, useReducer, useState } from 'react';
 import { useIntl } from 'react-intl';
 import TablePagination from '@material-ui/core/TablePagination';
 import {
@@ -40,8 +40,8 @@ import {
   useEnv,
   useLogicResource,
   useMount,
-  useSpreadState,
-  useSiteLocales
+  useSiteLocales,
+  useSpreadState
 } from '../../../utils/hooks';
 import CopyItemsDialog from '../../Dialogs/CopyItemsDialog';
 import ContentLocalizationDialog from '../../Dialogs/ContentLocalizationDialog';
@@ -672,7 +672,8 @@ export default function (props: WidgetProps) {
       }
       case 'newFolder': {
         setNewFolderDialog({
-          path: withoutIndex(menu.activeItem.path)
+          path: withoutIndex(menu.activeItem.path),
+          allowBraces: menu.activeItem.path === '/scripts/rest'
         });
         closeContextMenu();
         break;

--- a/ui/app/src/components/Navigation/PathNavigator/Widget.tsx
+++ b/ui/app/src/components/Navigation/PathNavigator/Widget.tsx
@@ -673,7 +673,7 @@ export default function (props: WidgetProps) {
       case 'newFolder': {
         setNewFolderDialog({
           path: withoutIndex(menu.activeItem.path),
-          allowBraces: menu.activeItem.path === '/scripts/rest'
+          allowBraces: menu.activeItem.path.startsWith('/scripts/rest')
         });
         closeContextMenu();
         break;


### PR DESCRIPTION
Allowing braces when create folder under '/scripts/rest';
https://github.com/craftercms/craftercms/issues/3959

