### PR TITLE
[3908] ContentTypeEditor: Path outside /site used as "repository path of datasource provides no warning and breaks model"

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-type-propsheet/string.js
+++ b/static-assets/components/cstudio-admin/mods/content-type-propsheet/string.js
@@ -26,7 +26,7 @@ YAHOO.extend(
   CStudioAdminConsole.Tool.ContentTypes.PropertyType.String,
   CStudioAdminConsole.Tool.ContentTypes.PropertyType,
   {
-    render: function(value, updateFn) {
+    render: function (value, updateFn, fName, itemId, defaultValue, typeControl, disabled, validations) {
       var containerEl = this.containerEl;
       var valueEl = document.createElement('input');
       containerEl.appendChild(valueEl);
@@ -34,12 +34,29 @@ YAHOO.extend(
       valueEl.fieldName = this.fieldName;
 
       if (updateFn) {
-        var updateFieldFn = function(event, el) {
+        var updateFieldFn = function (event, el) {
+          updateFn(event, el);
+          CStudioAdminConsole.Tool.ContentTypes.visualization.render();
+        };
+
+        var onBlur = function (event, el) {
+          if (!el.value.startsWith(validations.startsWith)) {
+            if (el.value.startsWith('/')) {
+              el.value = validations.startsWith + el.value;
+            } else {
+              el.value = validations.startsWith + '/' + el.value;
+            }
+          }
           updateFn(event, el);
           CStudioAdminConsole.Tool.ContentTypes.visualization.render();
         };
 
         YAHOO.util.Event.on(valueEl, 'keyup', updateFieldFn, valueEl);
+        if (validations) {
+          if (validations.startsWith) {
+            YAHOO.util.Event.on(valueEl, 'blur', onBlur, valueEl);
+          }
+        }
       }
 
       this.valueEl = valueEl;

--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -2343,9 +2343,9 @@
             property.defaultValue,
             property.type,
             sheetEl,
-            function(e, el) {
+            function (e, el) {
               updatePropertyFn(el.fieldName, el.value);
-            }
+            }, null, null, null, null, null, property.validations
           );
         }
       },
@@ -2701,7 +2701,8 @@
         helpTitle,
         helpHTML,
         typeControl,
-        disabled
+        disabled,
+        validations
       ) {
         var itemId = this.itemId;
         var helpIcon = '';
@@ -2769,7 +2770,7 @@
           moduleLoaded: function(moduleName, moduleClass, moduleConfig) {
             try {
               var propControl = new moduleClass(fName, propertyContainerEl, this.self.form, type);
-              propControl.render(value, fn, fName, itemId, defaultValue, typeControl, disabled);
+              propControl.render(value, fn, fName, itemId, defaultValue, typeControl, disabled, validations);
             } catch (e) {}
           },
           self: this

--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -364,7 +364,14 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
         type: 'boolean',
         defaultValue: 'false'
       },
-      { label: CMgs.format(langBundle, 'repositoryPath'), name: 'repoPath', type: 'string' },
+      {
+        label: CMgs.format(langBundle, 'repositoryPath'),
+        name: 'repoPath',
+        type: 'string',
+        validations: {
+          startsWith: '/site'
+        }
+      },
       { label: CMgs.format(langBundle, 'browsePath'), name: 'browsePath', type: 'string' },
       { label: CMgs.format(langBundle, 'defaultType'), name: 'type', type: 'string' }
     ];

--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -368,6 +368,7 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
         label: CMgs.format(langBundle, 'repositoryPath'),
         name: 'repoPath',
         type: 'string',
+        defaultValue: '/site/',
         validations: {
           startsWith: '/site'
         }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3908

### Ticket reference or full description of what's in the PR
