### PR TITLE
[studio-ui] Removing redundant DialogAction components on various dialogs

### DIFF
--- a/ui/app/src/components/Dialogs/ConfirmDialog.tsx
+++ b/ui/app/src/components/Dialogs/ConfirmDialog.tsx
@@ -18,7 +18,6 @@ import DialogHeader from './DialogHeader';
 import DialogBody from './DialogBody';
 import DialogFooter from './DialogFooter';
 import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
 import React, { PropsWithChildren } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
@@ -99,18 +98,16 @@ function ConfirmDialogWrapper(props: ConfirmDialogProps) {
         {children}
       </DialogBody>
       <DialogFooter>
-        <DialogActions>
-          {onCancel && (
-            <Button onClick={onCancel} variant="outlined">
-              {formatMessage(messages.cancel)}
-            </Button>
-          )}
-          {onOk && (
-            <Button onClick={onOk} variant="contained" color="primary" autoFocus>
-              {formatMessage(messages.ok)}
-            </Button>
-          )}
-        </DialogActions>
+        {onCancel && (
+          <Button onClick={onCancel} variant="outlined">
+            {formatMessage(messages.cancel)}
+          </Button>
+        )}
+        {onOk && (
+          <Button onClick={onOk} variant="contained" color="primary" autoFocus>
+            {formatMessage(messages.ok)}
+          </Button>
+        )}
       </DialogFooter>
     </>
   );

--- a/ui/app/src/components/Dialogs/CreateNewFileDialog.tsx
+++ b/ui/app/src/components/Dialogs/CreateNewFileDialog.tsx
@@ -20,7 +20,6 @@ import DialogHeader from './DialogHeader';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import DialogBody from './DialogBody';
 import DialogFooter from './DialogFooter';
-import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import { createNewFile } from '../../services/content';
@@ -149,21 +148,19 @@ function CreateNewFileUI(props: CreateNewFileUIProps) {
         />
       </DialogBody>
       <DialogFooter>
-        <DialogActions>
-          <Button onClick={onClose} variant="outlined" disabled={inProgress}>
-            <FormattedMessage id="words.close" defaultMessage="Close" />
-          </Button>
-          <Button
-            onClick={() => onOk()} variant="contained" color="primary" autoFocus
-            disabled={inProgress}
-          >
-            {
-              inProgress &&
-              <CircularProgress size={15} style={{ marginRight: '5px' }} />
-            }
-            <FormattedMessage id="words.create" defaultMessage="Create" />
-          </Button>
-        </DialogActions>
+        <Button onClick={onClose} variant="outlined" disabled={inProgress}>
+          <FormattedMessage id="words.close" defaultMessage="Close" />
+        </Button>
+        <Button
+          onClick={() => onOk()} variant="contained" color="primary" autoFocus
+          disabled={inProgress}
+        >
+          {
+            inProgress &&
+            <CircularProgress size={15} style={{ marginRight: '5px' }} />
+          }
+          <FormattedMessage id="words.create" defaultMessage="Create" />
+        </Button>
       </DialogFooter>
     </>
   );

--- a/ui/app/src/components/Dialogs/CreateNewFolderDialog.tsx
+++ b/ui/app/src/components/Dialogs/CreateNewFolderDialog.tsx
@@ -20,7 +20,6 @@ import DialogHeader from './DialogHeader';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import DialogBody from './DialogBody';
 import DialogFooter from './DialogFooter';
-import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import { createNewFolder, renameFolder } from '../../services/content';
@@ -160,26 +159,24 @@ function CreateNewFolderUI(props: CreateNewFolderUIProps) {
         />
       </DialogBody>
       <DialogFooter>
-        <DialogActions>
-          <Button onClick={onClose} variant="outlined" disabled={inProgress}>
-            <FormattedMessage id="words.close" defaultMessage="Close" />
-          </Button>
-          <Button
-            onClick={() => onOk()} variant="contained" color="primary" autoFocus
-            disabled={inProgress}
-          >
-            {
-              inProgress &&
-              <CircularProgress size={15} style={{ marginRight: '5px' }} />
-            }
-            {
-              rename
-                ? <FormattedMessage id="words.rename" defaultMessage="Rename" />
-                : <FormattedMessage id="words.create" defaultMessage="Create" />
-            }
+        <Button onClick={onClose} variant="outlined" disabled={inProgress}>
+          <FormattedMessage id="words.close" defaultMessage="Close" />
+        </Button>
+        <Button
+          onClick={() => onOk()} variant="contained" color="primary" autoFocus
+          disabled={inProgress}
+        >
+          {
+            inProgress &&
+            <CircularProgress size={15} style={{ marginRight: '5px' }} />
+          }
+          {
+            rename
+              ? <FormattedMessage id="words.rename" defaultMessage="Rename" />
+              : <FormattedMessage id="words.create" defaultMessage="Create" />
+          }
 
-          </Button>
-        </DialogActions>
+        </Button>
       </DialogFooter>
     </>
   );

--- a/ui/app/src/components/Dialogs/RejectDialog.tsx
+++ b/ui/app/src/components/Dialogs/RejectDialog.tsx
@@ -33,7 +33,6 @@ import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Checkbox from '@material-ui/core/Checkbox';
 import DialogFooter from './DialogFooter';
-import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
@@ -150,7 +149,7 @@ function RejectDialogContentUI(props: RejectDialogContentUIProps) {
                   color="primary"
                 />
               </ListItemIcon>
-              <ListItemText primary={item.label} secondary={item.path} id={labelId}/>
+              <ListItemText primary={item.label} secondary={item.path} id={labelId} />
             </ListItem>
           );
         })
@@ -273,24 +272,22 @@ function RejectDialogUI(props: RejectDialogUIProps) {
         </Grid>
       </DialogBody>
       <DialogFooter>
-        <DialogActions>
-          {onClose && (
-            <Button onClick={onClose} variant="contained">
-              <FormattedMessage id="rejectDialog.cancel" defaultMessage="Cancel" />
-            </Button>
-          )}
-          {onReject && (
-            <Button
-              onClick={onReject}
-              variant="contained"
-              color="primary"
-              autoFocus
-              disabled={checkedItems.length === 0 || rejectionComment === '' || rejectionReason === ''}
-            >
-              <FormattedMessage id="rejectDialog.continue" defaultMessage="Reject" />
-            </Button>
-          )}
-        </DialogActions>
+        {onClose && (
+          <Button onClick={onClose} variant="contained">
+            <FormattedMessage id="rejectDialog.cancel" defaultMessage="Cancel" />
+          </Button>
+        )}
+        {onReject && (
+          <Button
+            onClick={onReject}
+            variant="contained"
+            color="primary"
+            autoFocus
+            disabled={checkedItems.length === 0 || rejectionComment === '' || rejectionReason === ''}
+          >
+            <FormattedMessage id="rejectDialog.continue" defaultMessage="Reject" />
+          </Button>
+        )}
       </DialogFooter>
     </>
   );
@@ -349,9 +346,9 @@ function RejectDialogWrapper(props: RejectDialogProps) {
         (message) => {
           setRejectionComment(message);
         }
-      )
+      );
     }
-  }, [rejectionReason, setRejectionComment, currentLocale, siteId])
+  }, [rejectionReason, setRejectionComment, currentLocale, siteId]);
 
   const updateChecked = (value) => {
     const itemExist = checkedItems.includes(value);

--- a/ui/app/src/components/Dialogs/WorkflowCancellationDialog.tsx
+++ b/ui/app/src/components/Dialogs/WorkflowCancellationDialog.tsx
@@ -21,7 +21,6 @@ import { useLogicResource, useUnmount } from '../../utils/hooks';
 import DialogHeader from './DialogHeader';
 import DialogBody from './DialogBody';
 import DialogFooter from './DialogFooter';
-import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
 import { FormattedMessage } from 'react-intl';
 import { SuspenseWithEmptyState } from '../SystemStatus/Suspencified';
@@ -160,18 +159,16 @@ function WorkflowCancellationDialogUI(props: WorkflowCancellationDialogUIProps) 
         </SuspenseWithEmptyState>
       </DialogBody>
       <DialogFooter>
-        <DialogActions>
-          {onClose && (
-            <Button onClick={onClose} variant="contained">
-              <FormattedMessage id="workflowCancellation.cancel" defaultMessage="Cancel" />
-            </Button>
-          )}
-          {onContinue && (
-            <Button onClick={onContinue} variant="contained" color="primary" autoFocus>
-              <FormattedMessage id="workflowCancellation.continue" defaultMessage="Continue" />
-            </Button>
-          )}
-        </DialogActions>
+        {onClose && (
+          <Button onClick={onClose} variant="contained">
+            <FormattedMessage id="workflowCancellation.cancel" defaultMessage="Cancel" />
+          </Button>
+        )}
+        {onContinue && (
+          <Button onClick={onContinue} variant="contained" color="primary" autoFocus>
+            <FormattedMessage id="workflowCancellation.continue" defaultMessage="Continue" />
+          </Button>
+        )}
       </DialogFooter>
     </>
   );


### PR DESCRIPTION
Various dialogs were including DialogActions inside the DialogFooter. The DialogFooter already has the DialogActions so using it on the consumer component is redundant and has unintended styling issues. Removed redundant use.