### PR TITLE
[4027] TinyMCE5 should drop below label and center when width is increased

### DIFF
--- a/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
+++ b/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
@@ -289,6 +289,18 @@ CStudioAuthoring.Module.requireModule(
 
           rteStyleOverride = rteConfig.rteStyleOverride ? rteConfig.rteStyleOverride : null;
 
+          const $editorContainer = $(`#${rteId}`).parent(),
+            editorContainerWidth = $editorContainer.width(),
+            editorContainerPL = parseFloat($editorContainer.css('padding-left').replace('px', ''));
+
+          if (_thisControl.rteWidth > editorContainerWidth) {
+            $editorContainer.css('padding-left', 0);
+            $editorContainer.css('float', 'right');
+            if (_thisControl.rteWidth > editorContainerWidth + editorContainerPL) {
+              _thisControl.rteWidth = editorContainerWidth + editorContainerPL;
+            }
+          }
+
           editor = tinymce.init({
             selector: '#' + rteId,
             width: _thisControl.rteWidth,


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4027