### PR TITLE
[4320][3.1.x] TinyMCE 5 does not escape HTML

### DIFF
--- a/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
+++ b/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
@@ -754,7 +754,7 @@ CStudioAuthoring.Module.requireModule(
          * call this instead of calling editor.save()
          */
         save: function (a) {
-          this.updateModel(this.editor.getContent());
+          this.updateModel(CStudioForms.Util.escapeXml(this.editor.getContent()));
         }
       });
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4320