### PR TITLE
[4368][3.1.x] Custom Form Control Plugins are not found in Crafter Studio for use

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -1551,7 +1551,10 @@
         var dd = new DragAndDropDecorator(fieldContainerEl);
         var tar = new YAHOO.util.DDTarget(fieldContainerEl);
 
-        var controlExists = (this.config.controls.control.filter(control => control.name === field.type).length) > 0;
+        const controlExists = (this.config.controls.control.filter(control => {
+          const controlName = control.plugin ? control.plugin.name : control.name;
+          return (controlName === field.type);
+        }).length) > 0;
         if (!controlExists) {
           $(fieldContainerEl)
             .addClass('disabled')


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4368