### PR TITLE
[4394] Content-type form is not saving properties types (for datasources) to form-definition

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -2866,7 +2866,11 @@
           var supportedProperty = supportedProps[i];
           //Assign default value if it exists
           var val = supportedProperty.defaultValue ? supportedProperty.defaultValue : '';
-          newDataSource.properties[newDataSource.properties.length] = { name: supportedProperty.name, value: val };
+          newDataSource.properties[newDataSource.properties.length] = {
+            name: supportedProperty.name,
+            value: val,
+            type: supportedProperty.type
+          };
         }
 
         form.datasources[form.datasources.length] = newDataSource;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4394