### PR TITLE
[4394][3.1.x] Content-type form is not saving properties types (for datasources) to form-definition

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -3056,7 +3056,8 @@
           var val = supportedProperty.defaultValue ? supportedProperty.defaultValue : '';
           newDataSource.properties[newDataSource.properties.length] = {
             name: supportedProperty.name,
-            value: val
+            value: val,
+            type: supportedProperty.type
           };
         }
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4394