### PR TITLE
[4377] Show only supported actions in the History dialog

### DIFF
--- a/ui/app/src/modules/Content/History/HistoryDialog.tsx
+++ b/ui/app/src/modules/Content/History/HistoryDialog.tsx
@@ -257,7 +257,9 @@ function HistoryDialogBody(props: HistoryDialogProps) {
       if (count > 1) {
         if (hasOptions) {
           if (initialCommit) {
-            sections.push([menuOptions.compareTo]);
+            sections.push([menuOptions.compareTo, menuOptions.compareToCurrent]);
+          } else if (isCurrent) {
+            sections.push([menuOptions.compareTo, menuOptions.compareToPrevious]);
           } else {
             sections.push([menuOptions.compareTo, menuOptions.compareToCurrent, menuOptions.compareToPrevious]);
           }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4377

Fixing History Options;

