### PR TITLE
[3959] Create folder in Scripts blocks the use of {} in the name which are used to indicate parametrized portions of the url

### DIFF
--- a/ui/app/src/components/Dialogs/CreateFileDialog.tsx
+++ b/ui/app/src/components/Dialogs/CreateFileDialog.tsx
@@ -98,7 +98,7 @@ function CreateFileUI(props: CreateFileUIProps) {
     setState({ inProgress: true, submitted: true });
 
     if (name) {
-      const fileName = type === 'controller' ? `${encodeURI(name)}.groovy` : `${encodeURI(name)}.ftl`;
+      const fileName = type === 'controller' ? `${encodeURIComponent(name)}.groovy` : `${encodeURIComponent(name)}.ftl`;
       createFile(site, path, fileName).subscribe(
         () => {
           onCreated?.({ path, fileName, type });

--- a/ui/app/src/components/Dialogs/CreateFileDialog.tsx
+++ b/ui/app/src/components/Dialogs/CreateFileDialog.tsx
@@ -35,6 +35,7 @@ interface CreateFileBaseProps {
   open: boolean;
   type: 'controller' | 'template';
   path: string;
+  allowBraces?: boolean;
 }
 
 export type CreateFileProps = PropsWithChildren<
@@ -85,7 +86,7 @@ interface CreateFileUIProps extends CreateFileProps {
 }
 
 function CreateFileUI(props: CreateFileUIProps) {
-  const { onClosed, onClose, submitted, inProgress, setState, onCreated, type, path } = props;
+  const { onClosed, onClose, submitted, inProgress, setState, onCreated, type, path, allowBraces } = props;
   const [name, setName] = useState('');
   const dispatch = useDispatch();
   const site = useActiveSiteId();
@@ -97,7 +98,7 @@ function CreateFileUI(props: CreateFileUIProps) {
     setState({ inProgress: true, submitted: true });
 
     if (name) {
-      const fileName = type === 'controller' ? `${name}.groovy` : `${name}.ftl`;
+      const fileName = type === 'controller' ? `${encodeURI(name)}.groovy` : `${encodeURI(name)}.ftl`;
       createFile(site, path, fileName).subscribe(
         () => {
           onCreated?.({ path, fileName, type });
@@ -155,7 +156,9 @@ function CreateFileUI(props: CreateFileUIProps) {
           InputLabelProps={{
             shrink: true
           }}
-          onChange={(event) => setName(event.target.value.replace(/[^a-zA-Z0-9-_.]/g, ''))}
+          onChange={(event) =>
+            setName(event.target.value.replace(allowBraces ? /[^a-zA-Z0-9-_{}]/g : /[^a-zA-Z0-9-_]/g, ''))
+          }
         />
       </DialogBody>
       <DialogFooter>

--- a/ui/app/src/components/Dialogs/CreateFolderDialog.tsx
+++ b/ui/app/src/components/Dialogs/CreateFolderDialog.tsx
@@ -114,7 +114,7 @@ function CreateFolderUI(props: CreateFolderUIProps) {
 
     if (name) {
       if (rename) {
-        renameFolder(site, path, encodeURI(name)).subscribe(
+        renameFolder(site, path, encodeURIComponent(name)).subscribe(
           (response) => {
             onRenamed?.({ path, name, rename });
             dispatch(emitSystemEvent(folderRenamed({ target: path, oldName: value, newName: name })));
@@ -125,7 +125,7 @@ function CreateFolderUI(props: CreateFolderUIProps) {
           }
         );
       } else {
-        createFolder(site, path, encodeURI(name)).subscribe(
+        createFolder(site, path, encodeURIComponent(name)).subscribe(
           (resp) => {
             onCreated?.({ path, name, rename });
             dispatch(emitSystemEvent(folderCreated({ target: path, name: name })));

--- a/ui/app/src/components/Navigation/PathNavigator/PathNavigator.tsx
+++ b/ui/app/src/components/Navigation/PathNavigator/PathNavigator.tsx
@@ -221,7 +221,20 @@ export default function PathNavigator(props: WidgetProps) {
           }
           break;
         }
-        case folderCreated.type:
+        case folderCreated.type: {
+          if (withoutIndex(payload.target) === withoutIndex(state.currentPath)) {
+            dispatch(pathNavigatorRefresh({ id }));
+          }
+          if (state.leaves.some((path) => withoutIndex(path) === withoutIndex(payload.target))) {
+            dispatch(
+              pathNavigatorUpdate({
+                id,
+                leaves: state.leaves.filter((path) => withoutIndex(path) !== withoutIndex(payload.target))
+              })
+            );
+          }
+          break;
+        }
         case itemsPasted.type: {
           if (payload.clipboard.type === 'COPY') {
             if (withoutIndex(payload.target) === withoutIndex(state.currentPath)) {

--- a/ui/app/src/components/SystemStatus/GlobalDialogManager.tsx
+++ b/ui/app/src/components/SystemStatus/GlobalDialogManager.tsx
@@ -337,6 +337,7 @@ function GlobalDialogManager() {
         open={state.createFile.open}
         path={state.createFile.path}
         type={state.createFile.type}
+        allowBraces={state.createFile.allowBraces}
         onClose={createCallback(state.createFile.onClose, dispatch)}
         onClosed={createCallback(state.createFile.onClosed, dispatch)}
         onCreated={createCallback(state.createFile.onCreated, dispatch)}

--- a/ui/app/src/utils/itemActions.ts
+++ b/ui/app/src/utils/itemActions.ts
@@ -69,6 +69,7 @@ import {
 import { showErrorDialog } from '../state/reducers/dialogs/error';
 import { fetchItemVersions } from '../state/reducers/versions';
 import { popPiece } from './string';
+
 const menuOptions = {
   edit: {
     id: 'edit',
@@ -668,7 +669,8 @@ export const itemActionDispatcher = (
           showCreateFileDialog({
             path: withoutIndex(item.path),
             type: 'controller',
-            onCreated: closeCreateFileDialog()
+            onCreated: closeCreateFileDialog(),
+            allowBraces: item.path.startsWith('/scripts/rest')
           })
         );
         break;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3959

Fixing UI Issues;
Pending work on BE because "/studio/api/1/services/api/1/content/get-items-tree.json" is not returning children