### PR TITLE
[3084] add drag and drop image insertion support to TinyMCE5 

### DIFF
--- a/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
+++ b/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
@@ -380,15 +380,13 @@ CStudioAuthoring.Module.requireModule(
             paste_postprocess: function(plugin, args) {
               // If no text, and external it means that is dragged
               // text validation is because it can be text copied from outside the editor
-              if (args.node.outerText === '' && !args.internal) {
-                if (!_thisControl.editorImageDatasources.length) {
-                  args.preventDefault();
-                  _thisControl.editor.notificationManager.open({
-                    text: _thisControl.formatMessage(_thisControl.messages.noDatasourcesConfigured),
-                    timeout: 3000,
-                    type: 'error'
-                  });
-                }
+              if (args.node.outerText === '' && !args.internal && !_thisControl.editorImageDatasources.length) {
+                args.preventDefault();
+                _thisControl.editor.notificationManager.open({
+                  text: _thisControl.formatMessage(_thisControl.messages.noDatasourcesConfigured),
+                  timeout: 3000,
+                  type: 'error'
+                });
               }
             },
             images_upload_handler: function(blobInfo, success, failure) {

--- a/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
+++ b/static-assets/components/cstudio-forms/controls/rte-tinymce5.js
@@ -378,13 +378,17 @@ CStudioAuthoring.Module.requireModule(
 
             paste_data_images: true,
             paste_postprocess: function(plugin, args) {
-              if (!_thisControl.editorImageDatasources.length) {
-                args.preventDefault();
-                _thisControl.editor.notificationManager.open({
-                  text: _thisControl.formatMessage(_thisControl.messages.noDatasourcesConfigured),
-                  timeout: 3000,
-                  type: 'error'
-                });
+              // If no text, and external it means that is dragged
+              // text validation is because it can be text copied from outside the editor
+              if (args.node.outerText === '' && !args.internal) {
+                if (!_thisControl.editorImageDatasources.length) {
+                  args.preventDefault();
+                  _thisControl.editor.notificationManager.open({
+                    text: _thisControl.formatMessage(_thisControl.messages.noDatasourcesConfigured),
+                    timeout: 3000,
+                    type: 'error'
+                  });
+                }
               }
             },
             images_upload_handler: function(blobInfo, success, failure) {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3084

Tinymce does not differenciate between regular paste of text and drop of images, added validation to avoid doing erroneous actions when pasting regular clipboard text