### PR TITLE
[4494] Site config > content types save button changes text to "close upon clicking it"

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -372,10 +372,6 @@
                               cb,
                               xmlFormDef
                             );
-
-                            document.getElementById(
-                              'cstudio-admin-console-command-bar'
-                            ).children[1].value = CMgs.format(langBundle, 'close');
                           }
                         });
                       }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4494


