### PR TITLE
4.0.0/stability

### DIFF
--- a/static-assets/components/cstudio-admin/mods/workflow-states.js
+++ b/static-assets/components/cstudio-admin/mods/workflow-states.js
@@ -43,18 +43,34 @@ YAHOO.extend(CStudioAdminConsole.Tool.WorkflowStates, CStudioAdminConsole.Tool, 
   },
 
   renderJobsList: function() {
-    var actions = [
-      {
-        name: CMgs.format(formsLangBundle, 'setStatedDialogSetStates'),
-        context: this,
-        method: this.setStates
-      }
-    ];
-
-    CStudioAuthoring.ContextualNav.AdminConsoleNav &&
-      CStudioAuthoring.ContextualNav.AdminConsoleNav.initActions(actions);
-
+    this.initActions();
     this.renderStatesTable();
+  },
+
+  initActions: function() {
+    const isEmbedded = $('body').hasClass('embedded');
+
+    if (isEmbedded) {
+      const me = this;
+      const btnLabel = CMgs.format(formsLangBundle, 'setStatedDialogSetStates');
+
+      $(`<button type="button" class="mt35 ml40 btn btn-default">${btnLabel}</button>`)
+        .prependTo('#cstudio-admin-console-workarea')
+        .on('click', function() {
+          me.setStates();
+        });
+    } else {
+      var actions = [
+        {
+          name: CMgs.format(formsLangBundle, 'setStatedDialogSetStates'),
+          context: this,
+          method: this.setStates
+        }
+      ];
+
+      CStudioAuthoring.ContextualNav.AdminConsoleNav &&
+        CStudioAuthoring.ContextualNav.AdminConsoleNav.initActions(actions);
+    }
   },
 
   renderStatesTable: function() {

--- a/ui/app/src/components/Navigation/PathNavigator/PathNavigator.tsx
+++ b/ui/app/src/components/Navigation/PathNavigator/PathNavigator.tsx
@@ -21,7 +21,6 @@ import ContextMenu, { ContextMenuOption } from '../../ContextMenu';
 import {
   useActiveSiteId,
   useEnv,
-  useMount,
   usePreviewState,
   useSelection,
   useSiteLocales,
@@ -50,7 +49,6 @@ import { completeDetailedItem, fetchUserPermissions } from '../../../state/actio
 import { showEditDialog, showPreviewDialog } from '../../../state/actions/dialogs';
 import { getContentXML } from '../../../services/content';
 import { isFolder, isNavigable, isPreviewable } from './utils';
-import LoadingState from '../../SystemStatus/LoadingState';
 import { StateStylingProps } from '../../../models/UiConfig';
 import { getHostToHostBus } from '../../../modules/Preview/previewContext';
 import { debounceTime, filter } from 'rxjs/operators';
@@ -67,6 +65,8 @@ import { getNumOfMenuOptionsForItem } from '../../../utils/content';
 import PathNavigatorUI from './PathNavigatorUI';
 import LookupTable from '../../../models/LookupTable';
 import { ContextMenuOptionDescriptor, toContextMenuOptionsLookup } from '../../../utils/itemActions';
+import PathNavigatorSkeleton from './PathNavigatorSkeleton';
+import GlobalState from '../../../models/GlobalState';
 
 interface Menu {
   path?: string;
@@ -156,14 +156,16 @@ export default function PathNavigator(props: PathNavigatorProps) {
   });
   const [keyword, setKeyword] = useState('');
   const onSearch$ = useSubject<string>();
-
+  const uiConfig = useSelection<GlobalState['uiConfig']>((state) => state.uiConfig);
   const siteLocales = useSiteLocales();
 
-  useMount(() => {
-    if (!state) {
+  useEffect(() => {
+    // Adding uiConfig as means to stop navigator from trying to
+    // initialize with previous state information when switching sites
+    if (!state && uiConfig.currentSite === site) {
       dispatch(pathNavigatorInit({ id, path, locale, excludes, limit }));
     }
-  });
+  }, [dispatch, excludes, id, limit, locale, path, site, state, uiConfig.currentSite]);
 
   useEffect(() => {
     const subscription = onSearch$.pipe(debounceTime(400)).subscribe((keyword) => {
@@ -280,7 +282,7 @@ export default function PathNavigator(props: PathNavigatorProps) {
   const computeActiveItems = useCallback(computeActiveItemsProp ?? (() => []), [computeActiveItemsProp]);
 
   if (!state) {
-    return <LoadingState />;
+    return <PathNavigatorSkeleton showChildrenRail={showChildrenRail} />;
   }
 
   const onPathSelected = (item: DetailedItem) => {

--- a/ui/app/src/components/Navigation/PathNavigator/PathNavigatorSkeleton.tsx
+++ b/ui/app/src/components/Navigation/PathNavigator/PathNavigatorSkeleton.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from 'react';
+import Skeleton from '@material-ui/lab/Skeleton';
+import { rand } from './utils';
+import clsx from 'clsx';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+
+// type PathNavigatorSkeletonClassKey = 'skeletonRoot' | 'skeletonHeader' | 'skeletonBody' | 'skeletonBodyItem' | 'childrenRail';
+
+interface PathNavigatorSkeletonProps {
+  numOfItems?: number;
+  showChildrenRail?: boolean;
+}
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    skeletonRoot: {
+      margin: '10px 0'
+    },
+    skeletonHeader: {
+      display: 'flex',
+      marginBottom: '5px',
+      padding: '0 10px'
+    },
+    skeletonBody: {
+      paddingLeft: '5px'
+    },
+    skeletonBodyItem: { display: 'flex', padding: '5px 5px' },
+    childrenRail: {
+      marginLeft: 10,
+      borderLeft: `3px solid ${theme.palette.divider}`
+    }
+  })
+);
+
+function PathNavigatorSkeleton({ showChildrenRail = true, numOfItems = 5 }: PathNavigatorSkeletonProps) {
+  const classes = useStyles();
+  return (
+    <section className={classes.skeletonRoot}>
+      <header className={classes.skeletonHeader}>
+        <Skeleton variant="rect" width="20px" />
+        <Skeleton variant="text" style={{ margin: '0 10px', width: `${rand(40, 70)}%` }} />
+      </header>
+      <section className={clsx(classes.skeletonBody, showChildrenRail && classes.childrenRail)}>
+        <div className={classes.skeletonBodyItem}>
+          <Skeleton variant="text" style={{ width: `${rand(80, 150)}px` }} />
+        </div>
+        {new Array(numOfItems).fill(null).map((_, index) => (
+          <div className={classes.skeletonBodyItem} key={index}>
+            <Skeleton variant="circle" width="20px" />
+            <Skeleton variant="text" style={{ margin: '0 10px', width: `${rand(60, 95)}%` }} />
+          </div>
+        ))}
+        <div className={classes.skeletonBodyItem}>
+          <Skeleton variant="text" style={{ width: `120px` }} />
+        </div>
+      </section>
+    </section>
+  );
+}
+
+export default PathNavigatorSkeleton;

--- a/ui/app/src/components/PreviewSettingsPanel/PreviewSettingsPanel.tsx
+++ b/ui/app/src/components/PreviewSettingsPanel/PreviewSettingsPanel.tsx
@@ -21,7 +21,6 @@ import { FormControl, FormControlLabel, FormHelperText, FormLabel, Radio, RadioG
 import { EditSwitch } from '../../modules/Preview/ToolBar';
 import { usePreviewState } from '../../utils/hooks';
 import { setHighlightMode, setPreviewEditMode } from '../../state/actions/preview';
-import { useSnackbar } from 'notistack';
 import { useDispatch } from 'react-redux';
 
 const translations = defineMessages({
@@ -48,14 +47,6 @@ const translations = defineMessages({
   highlightMovable: {
     id: 'settingsPanel.highlightMovable',
     defaultMessage: 'Highlight Movable'
-  },
-  editModeOn: {
-    id: 'previewToolbar.editModeOn',
-    defaultMessage: 'Edit mode switched on'
-  },
-  editModeOff: {
-    id: 'previewToolbar.editModeOff',
-    defaultMessage: 'Edit mode switched off'
   }
 });
 
@@ -82,7 +73,6 @@ export default function PreviewSettingsPanel() {
   const classes = useStyles({});
   const { formatMessage } = useIntl();
   const { editMode, highlightMode } = usePreviewState();
-  const { enqueueSnackbar } = useSnackbar();
   const dispatch = useDispatch();
 
   return (
@@ -95,7 +85,6 @@ export default function PreviewSettingsPanel() {
               color="default"
               checked={editMode}
               onChange={(e) => {
-                enqueueSnackbar(formatMessage(e.target.checked ? translations.editModeOn : translations.editModeOff));
                 dispatch(setPreviewEditMode({ editMode: e.target.checked }));
               }}
               edge="end"

--- a/ui/app/src/components/SystemStatus/LoadingState.tsx
+++ b/ui/app/src/components/SystemStatus/LoadingState.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme) =>
       marginBottom: '10px'
     },
     graphic: {
-      width: 150
+      width: 120
     }
   })
 );
@@ -63,7 +63,7 @@ export interface LoadingStateProps {
 export type ConditionalLoadingStateProps = LoadingStateProps & PropsWithChildren<{ isLoading: boolean }>;
 
 export default function LoadingState(props: LoadingStateProps) {
-  const classes = useStyles({});
+  const classes = useStyles();
   const { graphic: Graphic = Gears, classes: propClasses } = props;
   return (
     <div className={clsx(classes.loadingView, propClasses?.root)}>

--- a/ui/app/src/components/SystemStatus/LoginView.tsx
+++ b/ui/app/src/components/SystemStatus/LoginView.tsx
@@ -30,7 +30,6 @@ import {
 } from '../../services/auth';
 import { isBlank } from '../../utils/string';
 import Typography from '@material-ui/core/Typography';
-import { setRequestForgeryToken } from '../../utils/auth';
 import LogInForm from './LoginForm';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -50,8 +49,6 @@ import palette from '../../styles/palette';
 import { buildStoredLanguageKey, dispatchLanguageChange, getCurrentLocale, setStoredLanguage } from '../../utils/i18n';
 import CrafterCMSLogo from '../Icons/CrafterCMSLogo';
 import FormControl from '@material-ui/core/FormControl';
-
-setRequestForgeryToken();
 
 interface SystemLang {
   id: string;
@@ -231,16 +228,15 @@ function LoginView(props: SubViewProps) {
   const [username, setUsername] = useState(() => localStorage.getItem('username') ?? '');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const [storedLangPreferences] = useState(retrieveStoredLangPreferences);
   const username$ = useDebouncedInput(
     useCallback(
       (user: string) => {
         const key = buildStoredLanguageKey(user);
-        if (storedLangPreferences.includes(key)) {
+        if (retrieveStoredLangPreferences().includes(key)) {
           setLanguage(window.localStorage.getItem(key));
         }
       },
-      [setLanguage, storedLangPreferences]
+      [setLanguage]
     ),
     200
   );

--- a/ui/app/src/components/ToolsPanelPage/ToolsPanelPage.tsx
+++ b/ui/app/src/components/ToolsPanelPage/ToolsPanelPage.tsx
@@ -19,7 +19,7 @@ import ToolPanel from '../../modules/Preview/Tools/ToolPanel';
 import { renderWidgets, WidgetDescriptor } from '../Widget';
 import { useDispatch } from 'react-redux';
 import { popToolsPanelPage } from '../../state/actions/preview';
-import { usePossibleTranslation } from '../../utils/hooks';
+import { useActiveSiteId, useActiveUser, usePossibleTranslation } from '../../utils/hooks';
 
 export interface ToolsPanelPageDescriptor {
   widgets: WidgetDescriptor[];
@@ -30,14 +30,12 @@ export interface ToolsPanelPageProps extends ToolsPanelPageDescriptor {}
 
 export default function ToolsPanelPage(props: ToolsPanelPageProps) {
   const dispatch = useDispatch();
-
-  const pop = () => {
-    dispatch(popToolsPanelPage());
-  };
-
+  const site = useActiveSiteId();
+  const { rolesBySite } = useActiveUser();
+  const pop = () => dispatch(popToolsPanelPage());
   return (
     <ToolPanel title={usePossibleTranslation(props.title)} onBack={pop}>
-      {renderWidgets(props.widgets, [])}
+      {renderWidgets(props.widgets, rolesBySite[site])}
     </ToolPanel>
   );
 }

--- a/ui/app/src/components/Widget/Widget.tsx
+++ b/ui/app/src/components/Widget/Widget.tsx
@@ -118,9 +118,11 @@ const Widget = memo(function(props: WidgetProps) {
 
 export { Widget };
 
-export function renderWidgets(widgets, roles: string[]) {
+export function renderWidgets(widgets, userRoles: string[]) {
   return widgets
-    .filter((widget) => (widget.roles ?? []).length === 0 || roles.some((role) => widget.roles.includes(role)))
+    .filter(
+      (widget) => (widget.roles ?? []).length === 0 || (userRoles ?? []).some((role) => widget.roles.includes(role))
+    )
     .map((widget) => <Widget key={widget.uiKey} {...widget} />);
 }
 

--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -203,6 +203,18 @@ export function PreviewConcierge(props: any) {
       dispatch(setHighlightMode({ highlightMode: localHighlightMode }));
     }
 
+    const sub = beginGuestDetection(enqueueSnackbar, closeSnackbar);
+
+    return () => {
+      sub.unsubscribe();
+      contentTypes$.complete();
+      contentTypes$.unsubscribe();
+      document.domain = originalDocDomain;
+    };
+  });
+
+  // Retrieve stored site clipboard, retrieve stored tools panel page.
+  useEffect(() => {
     const localClipboard = getStoredClipboard(site, user.username);
     if (localClipboard) {
       let hours = moment().diff(moment(localClipboard.timestamp), 'hours');
@@ -218,19 +230,11 @@ export function PreviewConcierge(props: any) {
         );
       }
     }
-
-    const sub = beginGuestDetection(enqueueSnackbar, closeSnackbar);
     const storedPage = getStoredPreviewToolsPanelPage(site, user.username);
     if (storedPage) {
       dispatch(pushToolsPanelPage(storedPage));
     }
-    return () => {
-      sub.unsubscribe();
-      contentTypes$.complete();
-      contentTypes$.unsubscribe();
-      document.domain = originalDocDomain;
-    };
-  });
+  }, [dispatch, site, user.username]);
 
   // Post content types
   useEffect(() => {
@@ -723,7 +727,7 @@ export function PreviewConcierge(props: any) {
 
 function beginGuestDetection(enqueueSnackbar, closeSnackbar): Subscription {
   const guestToHost$ = getGuestToHostBus();
-  return interval(2500)
+  return interval(5000)
     .pipe(
       take(1),
       takeUntil(guestToHost$.pipe(filter(({ type }) => type === GUEST_CHECK_IN || type === 'GUEST_SITE_LOAD')))

--- a/ui/app/src/modules/Preview/ToolBar.tsx
+++ b/ui/app/src/modules/Preview/ToolBar.tsx
@@ -49,7 +49,6 @@ import { changeSite } from '../../state/reducers/sites';
 import Switch from '@material-ui/core/Switch';
 import Tooltip from '@material-ui/core/Tooltip';
 import withStyles from '@material-ui/core/styles/withStyles';
-import { useSnackbar } from 'notistack';
 import palette from '../../styles/palette';
 import SingleItemSelector from '../Content/Authoring/SingleItemSelector';
 import { DetailedItem } from '../../models/Item';
@@ -59,6 +58,7 @@ import { generateSingleItemOptions, itemActionDispatcher } from '../../utils/ite
 import ActionsGroup from '../../components/ActionsGroup';
 import Skeleton from '@material-ui/lab/Skeleton';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { setSiteCookie } from '../../utils/auth';
 
 const translations = defineMessages({
   openToolsPanel: {
@@ -72,14 +72,6 @@ const translations = defineMessages({
   toggleSidebarTooltip: {
     id: 'common.toggleSidebarTooltip',
     defaultMessage: 'Toggle sidebar'
-  },
-  editModeOn: {
-    id: 'previewToolbar.editModeOn',
-    defaultMessage: 'Edit mode switched on'
-  },
-  editModeOff: {
-    id: 'previewToolbar.editModeOff',
-    defaultMessage: 'Edit mode switched off'
   },
   reload: {
     id: 'words.reload',
@@ -281,7 +273,8 @@ export default function ToolBar() {
   const models = guest?.models;
   const items = useSelection((state) => state.content.items.byPath);
   const item = items?.[models?.[modelId]?.craftercms.path];
-  const { enqueueSnackbar } = useSnackbar();
+  const { previewChoice } = usePreviewState();
+  const { authoringBase } = useEnv();
 
   // region permissions
   const permissions = usePermissions();
@@ -308,7 +301,6 @@ export default function ToolBar() {
             color="default"
             checked={editMode}
             onChange={(e) => {
-              enqueueSnackbar(formatMessage(e.target.checked ? translations.editModeOn : translations.editModeOff));
               dispatch(setPreviewEditMode({ editMode: e.target.checked }));
             }}
           />
@@ -318,7 +310,14 @@ export default function ToolBar() {
           sites={sites}
           url={computedUrl}
           item={item}
-          onSiteChange={(site) => dispatch(changeSite(site))}
+          onSiteChange={(site) => {
+            if (previewChoice[site] === '2') {
+              dispatch(changeSite(site));
+            } else {
+              setSiteCookie(site);
+              setTimeout(() => (window.location.href = `${authoringBase}/preview`));
+            }
+          }}
           onUrlChange={(url) => dispatch(changeCurrentUrl(url))}
           onRefresh={() => getHostToGuestBus().next({ type: RELOAD_REQUEST })}
         />

--- a/ui/app/src/modules/Preview/ToolsPanel.tsx
+++ b/ui/app/src/modules/Preview/ToolsPanel.tsx
@@ -18,7 +18,7 @@ import React, { useEffect, useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { updateToolsPanelWidth } from '../../state/actions/preview';
 import { useDispatch } from 'react-redux';
-import { useActiveSiteId, useLogicResource, usePreviewState, useSelection } from '../../utils/hooks';
+import { useActiveSiteId, useActiveUser, useLogicResource, usePreviewState, useSelection } from '../../utils/hooks';
 import ResizeableDrawer from './ResizeableDrawer';
 import ToolsPanelEmbeddedAppViewButton from '../../components/ToolsPanelEmbeddedAppViewButton';
 import ToolsPanelPageButton from '../../components/ToolsPanelPageButton';
@@ -69,6 +69,10 @@ const useStyles = makeStyles((theme: Theme) =>
     emptyStateImage: {
       width: '50%',
       marginBottom: theme.spacing(1)
+    },
+    loadingViewRoot: {
+      flex: 1,
+      flexDirection: 'row'
     }
   })
 );
@@ -87,7 +91,7 @@ export default function ToolsPanel() {
     WidgetDescriptor[],
     { pages: WidgetDescriptor[]; uiConfig: GlobalState['uiConfig'] }
   >(
-    useMemo(() => ({ pages, uiConfig }), [pages, uiConfig]),
+    useMemo(() => ({ pages, uiConfig, site }), [pages, uiConfig, site]),
     {
       errorSelector: (source) => source.uiConfig.error,
       resultSelector: (source) =>
@@ -118,6 +122,9 @@ export default function ToolsPanel() {
     >
       <SuspenseWithEmptyState
         resource={resource}
+        loadingStateProps={{
+          classes: { root: classes.loadingViewRoot }
+        }}
         withEmptyStateProps={{
           isEmpty: (widgets) => !site || widgets?.length === 0,
           emptyStateProps: {
@@ -143,7 +150,9 @@ interface ToolsPaneBodyProps {
 
 function ToolsPaneBody(props: ToolsPaneBodyProps) {
   const stack = props.resource.read();
-  return <>{renderWidgets(stack, ['admin'])}</>;
+  const site = useActiveSiteId();
+  const { rolesBySite } = useActiveUser();
+  return <>{renderWidgets(stack, rolesBySite[site])}</>;
 }
 
 // TODO: Move this to a better place.

--- a/ui/app/src/state/epics/translation.ts
+++ b/ui/app/src/state/epics/translation.ts
@@ -18,7 +18,7 @@ import { ofType } from 'redux-observable';
 import { Observable } from 'rxjs';
 import GlobalState from '../../models/GlobalState';
 
-import { map, switchMap, withLatestFrom } from 'rxjs/operators';
+import { exhaustMap, map, withLatestFrom } from 'rxjs/operators';
 import { getSiteLocales } from '../../services/translation';
 import { catchAjaxError } from '../../utils/ajax';
 import { fetchSiteLocales, fetchSiteLocalesComplete, fetchSiteLocalesFailed } from '../actions/translation';
@@ -29,7 +29,7 @@ export default [
     action$.pipe(
       ofType(fetchSiteLocales.type),
       withLatestFrom(state$),
-      switchMap(([, state]) =>
+      exhaustMap(([, state]) =>
         getSiteLocales(state.sites.active).pipe(map(fetchSiteLocalesComplete), catchAjaxError(fetchSiteLocalesFailed))
       )
     )

--- a/ui/app/src/state/reducers/preview.ts
+++ b/ui/app/src/state/reducers/preview.ts
@@ -330,10 +330,10 @@ const reducer = createReducer<GlobalState['preview']>(
     [changeSite.type]: (state, { payload }) => {
       let nextState = {
         ...state,
-        tools: null,
         audiencesPanel: audiencesPanelInitialState,
         components: componentsInitialState,
-        assets: assetsPanelInitialState
+        assets: assetsPanelInitialState,
+        toolsPanelPageStack: []
       };
 
       // TODO: If there's a guest it would have checked out?

--- a/ui/app/src/state/reducers/uiConfig.ts
+++ b/ui/app/src/state/reducers/uiConfig.ts
@@ -17,6 +17,7 @@
 import { GlobalState } from '../../models/GlobalState';
 import { createReducer } from '@reduxjs/toolkit';
 import { fetchSiteUiConfig, fetchSiteUiConfigComplete, fetchSiteUiConfigFailed } from '../actions/configuration';
+import { changeSite } from './sites';
 
 const initialState: GlobalState['uiConfig'] = {
   error: null,
@@ -46,7 +47,8 @@ const reducer = createReducer<GlobalState['uiConfig']>(initialState, {
     error: payload,
     isFetching: false,
     currentSite: null
-  })
+  }),
+  [changeSite.type]: () => initialState
 });
 
 export default reducer;

--- a/ui/app/src/state/store.ts
+++ b/ui/app/src/state/store.ts
@@ -63,13 +63,13 @@ export function getStore(): Observable<CrafterCMSStore> {
           switchMap((store) =>
             fetchStateInitialization().pipe(
               tap((requirements) => {
-                store.dispatch(storeInitialized({ auth, ...requirements }));
                 worker.port.onmessage = (e) => {
                   if (e.data?.type) {
-                    console.log('%c[page] Message received from worker', 'color: #AF52DE');
+                    logWorkerMessage(e);
                     store.dispatch(e.data);
                   }
                 };
+                store.dispatch(storeInitialized({ auth, ...requirements }));
                 store$.next(store);
               })
             )
@@ -94,7 +94,7 @@ function registerSharedWorker(): Observable<ObtainAuthTokenResponse & { worker: 
     });
     return fromEvent<MessageEvent>(worker.port, 'message').pipe(
       tap((e) => {
-        console.log('%c[page] Message received from worker', 'color: #AF52DE');
+        logWorkerMessage(e);
         if (e.data?.type === sharedWorkerUnauthenticated.type) {
           throw new Error('User not authenticated.');
         }
@@ -113,6 +113,10 @@ function registerSharedWorker(): Observable<ObtainAuthTokenResponse & { worker: 
       );
     });
   }
+}
+
+function logWorkerMessage(e) {
+  console.log('%c[page] Message received from worker', 'color: #AF52DE');
 }
 
 export function getStoreSync(): CrafterCMSStore {

--- a/ui/app/src/utils/i18n.ts
+++ b/ui/app/src/utils/i18n.ts
@@ -82,9 +82,7 @@ export function getPossibleTranslation(titleOrDescriptor: string | MessageDescri
 }
 
 export function getCurrentLocale(): string {
-  const username = localStorage.getItem('username');
-  const locale = getStoredLanguage(username);
-  return locale ? locale : 'en';
+  return getStoredLanguage(localStorage.getItem('username')) || 'en';
 }
 
 export function getCurrentIntl(): IntlShape {
@@ -104,10 +102,11 @@ export function getStoredLanguage(username?: string): string {
 }
 
 export function setStoredLanguage(language: string, username?: string): void {
-  if (username) {
-    localStorage.setItem(buildStoredLanguageKey(username), language);
+  // Prevent `null` or `undefined`, or even `"""` from being stored.
+  if (language) {
+    username && localStorage.setItem(buildStoredLanguageKey(username), language);
+    localStorage.setItem('crafterStudioLanguage', language);
   }
-  localStorage.setItem('crafterStudioLanguage', language);
 }
 
 export function dispatchLanguageChange(language: string): void {


### PR DESCRIPTION
Fix roles not being sent to `renderWidgets` from `ToolPanel`, 
rename roles=>userRoles argument in `renderWidgets` for better clarity, 
sidebar loading states enhancements, 
login form bug where the local storage keys may be outdated when trying to sent the language, 
fix bug where nullish value may be stored as the lang setting on local storage, 
fix bug in path navigator where switching sites in preview would leave the navigator in a loading state permanently, 
bugfix with path navigator wrongfully initializing when switching sites

Add 'Set State' button for embedded mode in Workflow States (https://github.com/craftercms/studio-ui/pull/2159)