### PR TITLE
[4347] Add support in /api/2/audit for friendly site name

### DIFF
--- a/static-assets/ng-views/audit.html
+++ b/static-assets/ng-views/audit.html
@@ -22,7 +22,7 @@
     <div class="audit-nav">
         <div class="nav-containers">
             <label class="pr5">{{ 'admin.audit.SITE' | translate }}: </label>
-            <span class="pr20" ng-show="audit.currentSiteName">{{ audit.currentSiteName }}</span>
+            <span class="pr20 inline-block" ng-show="audit.currentSiteName" style="padding-top: 6px;">{{ audit.currentSiteName }}</span>
             <div class="btn-group" uib-dropdown is-open="sitesDropdown.isopen" style="margin-right: 5px;" ng-show="!audit.currentSiteName">
                 <button type="button" class="btn btn-default dropdown-toggle text-capitalize" uib-dropdown-toggle title="{{audit.site || 'admin.audit.ALL_SITES' | translate}}" >
                     {{audit.siteLabel || audit.site || 'admin.audit.ALL_SITES' | translate }}  <span class="caret"></span>

--- a/static-assets/scripts/admin.js
+++ b/static-assets/scripts/admin.js
@@ -326,10 +326,9 @@
         };
 
         function getResultsPage(pageNumber) {
-          var dateToUTC, dateFromUTC;
           var params = {};
           if (site) {
-            params.siteName = site;
+            params.siteId = site;
           }
           if (audit.userSelected && audit.userSelected != '') params.user = audit.userSelected;
 

--- a/static-assets/scripts/main.js
+++ b/static-assets/scripts/main.js
@@ -400,7 +400,7 @@
     AUTH_HEADERS: 'AUTH_HEADERS',
     SAML: 'SAML',
     AUDIT_TIMEZONE_COOKIE: 'crafterStudioAuditTimezone',
-    AUDIT_SYSTEM: 'Studio Root'
+    AUDIT_SYSTEM: 'studio_root'
   });
 
   app.service('authService', [


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4347
- Updated API call to send site ids and display site names