### PR TITLE
[4521] Fix mask on top of dialog when using upload in browse dialog

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -2487,21 +2487,24 @@ var nodeOpen = false,
         CSA.Operations.getWorkflowAffectedFiles(params, {
           success: function (content) {
             if (content && content.length) {
-              CSA.Operations._showDialogueView({
-                controller: 'viewcontroller-cancel-workflow',
-                fn: function (oAjaxCfg) {
-                  // because _showDialogueView was designed to load the body from a
-                  // webscript, must simulate the ajax process here
-                  oAjaxCfg.success({ responseText: '' });
+              CSA.Operations._showDialogueView(
+                {
+                  controller: 'viewcontroller-cancel-workflow',
+                  fn: function (oAjaxCfg) {
+                    // because _showDialogueView was designed to load the body from a
+                    // webscript, must simulate the ajax process here
+                    oAjaxCfg.success({ responseText: '' });
+                  },
+                  callback: function () {
+                    var view = this;
+                    view.setContent(content);
+                    view.on('continue', function () {
+                      doEdit();
+                    });
+                  }
                 },
-                callback: function () {
-                  var view = this;
-                  view.setContent(content);
-                  view.on('continue', function () {
-                    doEdit();
-                  });
-                }
-              });
+                true
+              );
             } else {
               doEdit();
             }

--- a/static-assets/components/cstudio-dialogs/upload-asset-dialog.js
+++ b/static-assets/components/cstudio-dialogs/upload-asset-dialog.js
@@ -134,12 +134,7 @@ CStudioAuthoring.Dialogs.UploadDialog = CStudioAuthoring.Dialogs.UploadDialog ||
       modal: true,
       close: false,
       constraintoviewport: true,
-      underlay: 'none',
-      // It looks like when in browse, the .yui-dialog { z-index: 1040 } rule is missing so the dialog
-      // shows below the mask; however, to avoid potential z-index issues breaking out due to adding this rule
-      // to this location, preferring a localized fix. These dialogs need to go away in favour of next ui dialogs
-      // in any case.
-      zIndex: window.location.href.indexOf('/studio/browse') === -1 ? void 0 : 1032
+      underlay: 'none'
     });
 
     // Render the Dialog

--- a/static-assets/themes/cstudioTheme/css/contextNav.css
+++ b/static-assets/themes/cstudioTheme/css/contextNav.css
@@ -137,7 +137,7 @@
 body .mask {
   background-color: rgb(68, 68, 68) !important;
   opacity: 0.5 !important;
-  z-index: 1031 !important;
+  z-index: 1031;
 }
 
 .yui-dialog.inc-zindex {


### PR DESCRIPTION
Found source of bug (1b0f4e7), reverted the change and fixed in a more localized way. Reverted the prior fix to the current bug (7bae5b9) as it isn't required anymore.