### PR TITLE
4.0.0/stability

### DIFF
--- a/static-assets/ng-views/globalMenu.html
+++ b/static-assets/ng-views/globalMenu.html
@@ -17,13 +17,7 @@
 <div class="global-menu--root admin-console-view mainContainer">
   <div class="row mt30">
     <div class="col-sm-3">
-      <ul class="nav nav-tabs nav-stacked nav-pills" role="tablist">
-        <li class="global-menu--item" ng-repeat="entity in entities" ui-sref-active="global-menu--item__active">
-          <a class="global-menu--item-link" ui-sref={{entity.id}} href="">
-            <span class="nav-icon global-menu--nav-icon fa {{entity.icon}}"></span> {{entity.label}}
-          </a>
-        </li>
-      </ul>
+      <div id="globalNavElement"></div>
     </div>
     <div class="col-sm-9">
       <div class="tab-content">
@@ -32,4 +26,3 @@
     </div>
   </div>
 </div>
-

--- a/static-assets/ng-views/sites.html
+++ b/static-assets/ng-views/sites.html
@@ -36,6 +36,7 @@
         <thead>
           <tr>
             <th><span class="sr-only">{{ 'dashboard.sites.SITE_NAME' | translate }}</span></th>
+            <th><span class="sr-only">Site Id</span></th>
             <th><span class="sr-only">{{ 'common.EDIT' | translate }}</span></th>
             <th><span class="sr-only">{{ 'common.REMOVE_LABEL' | translate }}</span></th>
           </tr>

--- a/static-assets/ng-views/sites.html
+++ b/static-assets/ng-views/sites.html
@@ -36,10 +36,6 @@
         <thead>
           <tr>
             <th><span class="sr-only">{{ 'dashboard.sites.SITE_NAME' | translate }}</span></th>
-            <th>
-              <span class="sr-only">{{ 'dashboard.sites.SITE_DASHBOARD_LINK' | translate }}</span>
-            </th>
-            <th><span class="sr-only">{{ 'dashboard.sites.PREVIEW_LINK' | translate }}</span></th>
             <th><span class="sr-only">{{ 'common.EDIT' | translate }}</span></th>
             <th><span class="sr-only">{{ 'common.REMOVE_LABEL' | translate }}</span></th>
           </tr>
@@ -47,23 +43,32 @@
         <tbody>
           <tr
             id="site-row-{{site.id}}"
+            ng-click="editSite(site)"
             dir-paginate="site in sites | filter:q | itemsPerPage: sitesPag.sitesPerPage"
             current-page="pagination"
             total-items="totalSites"
+            style="cursor: pointer"
           >
             <td class="name site-name trim" title="{{site.name ? site.name : site.id}}">
-              {{site.name ? site.name : site.id }}
+              <a ng-click="editSite(site)">{{site.name ? site.name : site.id}} &raquo;</a>
+              <div
+                ng-if="site.description"
+                ng-bind="site.description"
+                ng-attr-title="{{site.description}}"
+                style="overflow: hidden; text-overflow: ellipsis"
+              ></div>
             </td>
-            <td class="preview">
-              <a ng-click="editSite(site)">{{ 'dashboard.sites.PREVIEW' | translate }} &raquo;</a>
-            </td>
-            <td class="dashboard">
-              <a ng-click="goToDashboard(site)">{{ 'dashboard.sites.DASHBOARD' | translate }} &raquo;</a>
+            <td class="name site-name trim">
+              <div
+                ng-bind="site.id"
+                ng-attr-title="{{site.id}}"
+                style="overflow: hidden; text-overflow: ellipsis"
+              ></div>
             </td>
             <td class="remove">
               <a
                 ng-show="site.edit"
-                ng-click="editSiteData(site)"
+                ng-click="editSiteData(site, $event)"
                 class="btn btn-sm"
                 tooltip-placement="bottom"
                 uib-tooltip="Edit"
@@ -74,7 +79,7 @@
             <td class="remove">
               <a
                 ng-show="site.remove"
-                ng-click="removeSiteSites(site)"
+                ng-click="removeSiteSites(site, $event)"
                 class="btn btn-sm"
                 tooltip-placement="bottom"
                 uib-tooltip="{{'common.REMOVE_LABEL' | translate}}"

--- a/static-assets/scripts/main.js
+++ b/static-assets/scripts/main.js
@@ -1121,11 +1121,27 @@
             defaultView = currentView;
           }
           $state.go(defaultView);
-        } else {
-          if ($scope.entities.length > 0) {
-            $state.go((data[0] || data.menuItems[0]).id.replace('globalMenu.', ''));
-          }
+        } else if ($scope.entities.length > 0) {
+          $state.go((data[0] || data.menuItems[0]).id);
         }
+        CrafterCMSNext.render('#globalNavElement', 'LauncherGlobalNav', {
+          title: '',
+          onTileClicked() {},
+          tileStyles: {
+            tile: {
+              width: '100%',
+              height: 'auto',
+              flexDirection: 'row',
+              justifyContent: 'left',
+              margin: '0 0 5px'
+            },
+            iconAvatar: {
+              width: '25px',
+              height: '25px',
+              margin: '5px 10px'
+            }
+          }
+        });
       }
 
       document.addEventListener(

--- a/static-assets/scripts/main.js
+++ b/static-assets/scripts/main.js
@@ -1166,14 +1166,14 @@
 
       $scope.editSite = sitesService.editSite;
 
-      $scope.editSiteData = function(site) {
+      $scope.editSiteData = function(site, $event) {
+        $event.stopPropagation();
         const onEditSuccess = () => {
           CrafterCMSNext.system.store.dispatch({
             type: 'CLOSE_EDIT_SITE_DIALOG'
           });
           getSites();
         };
-
         sitesService.editSiteData(site, onEditSuccess);
       };
 
@@ -1250,7 +1250,8 @@
         getResultsPage(1);
       });
 
-      $scope.removeSiteSites = function(site) {
+      $scope.removeSiteSites = function(site, $event) {
+        $event.stopPropagation();
         var modalInstance = $uibModal.open({
           templateUrl: 'removeConfirmation.html',
           controller: 'RemoveSiteCtrl',
@@ -1263,7 +1264,6 @@
             }
           }
         });
-
         modalInstance.result.then(function() {
           getResultsPage(1);
         });

--- a/ui/app/src/assets/uiConfigDefaults.ts
+++ b/ui/app/src/assets/uiConfigDefaults.ts
@@ -26,6 +26,10 @@ const messages = defineMessages({
     id: 'siteTools.title',
     defaultMessage: 'Site Tools'
   },
+  siteDashboard: {
+    id: 'siteDashboard.title',
+    defaultMessage: 'Site Dashboard'
+  },
   configuration: {
     id: 'words.configuration',
     defaultMessage: 'Configuration'
@@ -49,10 +53,6 @@ const messages = defineMessages({
   site: {
     id: 'launcher.siteSectionTitle',
     defaultMessage: 'Site <muted>• {siteName}</muted>'
-  },
-  global: {
-    id: 'words.global',
-    defaultMessage: 'Global'
   }
 });
 
@@ -607,7 +607,7 @@ const uiConfigDefaults: Pick<GlobalState['uiConfig'], 'preview' | 'launcher'> = 
     siteCardMenuLinks: [
       {
         systemLinkId: 'siteDashboard',
-        title: messages.siteTools
+        title: messages.siteDashboard
       },
       {
         systemLinkId: 'preview',
@@ -679,13 +679,6 @@ const uiConfigDefaults: Pick<GlobalState['uiConfig'], 'preview' | 'launcher'> = 
               uiKey: count++
             }
           ]
-        }
-      },
-      {
-        id: 'craftercms.components.LauncherGlobalNav',
-        uiKey: count++,
-        configuration: {
-          title: messages.global
         }
       }
     ]

--- a/ui/app/src/assets/uiConfigDefaults.ts
+++ b/ui/app/src/assets/uiConfigDefaults.ts
@@ -27,8 +27,8 @@ const messages = defineMessages({
     defaultMessage: 'Site Tools'
   },
   siteDashboard: {
-    id: 'siteDashboard.title',
-    defaultMessage: 'Site Dashboard'
+    id: 'words.dashboard',
+    defaultMessage: 'Dashboard'
   },
   configuration: {
     id: 'words.configuration',

--- a/ui/app/src/components/Icons/SitesRounded.tsx
+++ b/ui/app/src/components/Icons/SitesRounded.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { createSvgIcon } from '@material-ui/core/utils';
+
+export default createSvgIcon(
+  <>
+    <path d="M21 2H3C1.9 2 1 2.9 1 4V16C1 17.1 1.9 18 3 18H10V20H9C8.45 20 8 20.45 8 21C8 21.55 8.45 22 9 22H15C15.55 22 16 21.55 16 21C16 20.45 15.55 20 15 20H14V18H21C22.1 18 23 17.1 23 16V4C23 2.9 22.1 2 21 2ZM20 16H4C3.45 16 3 15.55 3 15V5C3 4.45 3.45 4 4 4H20C20.55 4 21 4.45 21 5V15C21 15.55 20.55 16 20 16Z" />
+    <path d="M4 15H8V5H4V15ZM10 15H14V11H10V15ZM16 5V9H20V5H16ZM10 9H14V5H10V9ZM16 15H20V11H16V15Z" />
+  </>,
+  'SitesRounded'
+);

--- a/ui/app/src/components/Launcher/Launcher.tsx
+++ b/ui/app/src/components/Launcher/Launcher.tsx
@@ -43,7 +43,7 @@ import Avatar from '@material-ui/core/Avatar';
 import ExitToAppRoundedIcon from '@material-ui/icons/ExitToAppRounded';
 import Card from '@material-ui/core/Card/Card';
 import CardHeader from '@material-ui/core/CardHeader';
-import SettingsRoundedIcon from '@material-ui/icons/SettingsRounded';
+import AccountCircleRounded from '@material-ui/icons/AccountCircleRounded';
 import { Site } from '../../models/Site';
 import EmptyState from '../SystemStatus/EmptyState';
 import { setSiteCookie } from '../../utils/auth';
@@ -67,6 +67,16 @@ import LauncherLinkTile from '../LauncherLinkTile';
 import LauncherSection, { getSystemLink } from '../LauncherSection';
 import LauncherGlobalNav from '../LauncherGlobalNav';
 import GlobalState from '../../models/GlobalState';
+import SitesRounded from '../Icons/SitesRounded';
+import PeopleRounded from '@material-ui/icons/PeopleRounded';
+import SupervisedUserCircleRounded from '@material-ui/icons/SupervisedUserCircleRounded';
+import StorageRounded from '@material-ui/icons/StorageRounded';
+import SubjectRounded from '@material-ui/icons/SubjectRounded';
+import SettingsApplicationsRounded from '@material-ui/icons/SettingsApplicationsRounded';
+import FormatAlignCenterRounded from '@material-ui/icons/FormatAlignCenterRounded';
+import LockRounded from '@material-ui/icons/LockRounded';
+import PublicRounded from '@material-ui/icons/PublicRounded';
+import VpnKeyRounded from '@material-ui/icons/VpnKeyRounded';
 
 export interface LauncherProps {
   open: boolean;
@@ -351,7 +361,7 @@ export default function Launcher(props: LauncherStateProps) {
             systemLinkId: 'preview',
             previewChoice,
             authoringBase,
-            site: siteId
+            site
           });
         });
       }
@@ -445,10 +455,20 @@ Object.entries({
   'craftercms.icons.Preview': PreviewIcon,
   'craftercms.icons.CrafterIcon': About,
   'craftercms.icons.Docs': Docs,
+  'craftercms.icons.Sites': SitesRounded,
   '@material-ui/icons/DashboardRounded': DashboardIcon,
   '@material-ui/icons/SearchRounded': SearchIcon,
   '@material-ui/icons/BuildRounded': BuildIcon,
-  '@material-ui/icons/SettingsRounded': SettingsRoundedIcon
+  '@material-ui/icons/AccountCircleRounded': AccountCircleRounded,
+  '@material-ui/icons/PeopleRounded': PeopleRounded,
+  '@material-ui/icons/SupervisedUserCircleRounded': SupervisedUserCircleRounded,
+  '@material-ui/icons/StorageRounded': StorageRounded,
+  '@material-ui/icons/SubjectRounded': SubjectRounded,
+  '@material-ui/icons/SettingsApplicationsRounded': SettingsApplicationsRounded,
+  '@material-ui/icons/FormatAlignCenterRounded': FormatAlignCenterRounded,
+  '@material-ui/icons/LockRounded': LockRounded,
+  '@material-ui/icons/VpnKeyRounded': VpnKeyRounded,
+  '@material-ui/icons/PublicRounded': PublicRounded
 }).forEach(([id, component]) => {
   components.set(id, component);
 });

--- a/ui/app/src/components/Launcher/Launcher.tsx
+++ b/ui/app/src/components/Launcher/Launcher.tsx
@@ -20,7 +20,7 @@ import { createStyles, makeStyles } from '@material-ui/core/styles';
 import Popover from '@material-ui/core/Popover';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import LauncherSiteCard from '../LauncherSiteCard/LauncherSiteCard';
+import LauncherSiteCard, { LauncherSiteCardOption } from '../LauncherSiteCard/LauncherSiteCard';
 import CloseIcon from '@material-ui/icons/Close';
 import About from '../Icons/About';
 import Docs from '../Icons/Docs';
@@ -66,6 +66,7 @@ import clsx from 'clsx';
 import LauncherLinkTile from '../LauncherLinkTile';
 import LauncherSection, { getSystemLink } from '../LauncherSection';
 import LauncherGlobalNav from '../LauncherGlobalNav';
+import GlobalState from '../../models/GlobalState';
 
 export interface LauncherProps {
   open: boolean;
@@ -79,6 +80,8 @@ export interface LauncherStateProps {
   anchor: string;
   sitesRailPosition?: 'left' | 'right' | 'hidden';
   closeButtonPosition?: 'left' | 'right';
+  // Keeping prop @ GlobalState['uiConfig']['launcher']['globalNavigationPosition']
+  // globalNavigationPosition?: 'before' | 'after';
 }
 
 const messages = defineMessages({
@@ -188,6 +191,7 @@ interface AppsRailProps {
   user: EnhancedUser;
   onLogout(): void;
   closeButtonPosition: LauncherStateProps['closeButtonPosition'];
+  globalNavigationPosition: GlobalState['uiConfig']['launcher']['globalNavigationPosition'];
   userRoles: string[];
 }
 
@@ -198,11 +202,15 @@ const AppsRail = ({
   user,
   onLogout,
   closeButtonPosition,
-  userRoles
+  userRoles,
+  globalNavigationPosition
 }: AppsRailProps) => (
   <Grid item xs={12} md={8} className={classes.appsRail}>
     <div className={clsx(classes.railTop, closeButtonPosition === 'left' && classes.railTopExtraPadded)}>
+      {globalNavigationPosition === 'before' && <LauncherGlobalNav />}
       {renderWidgets(widgets, userRoles)}
+      {/* Using != 'before' (instead of == 'after') to avoid config hiding away the global nav */}
+      {globalNavigationPosition !== 'before' && <LauncherGlobalNav />}
     </div>
     <div className={classes.railBottom}>
       <Card className={classes.userCardRoot}>
@@ -246,15 +254,11 @@ interface SitesRailProps {
   sites: Site[];
   site: string;
   version: string;
-  cardActions: Array<{
-    name: string;
-    href: string | ((id: string) => string);
-    onClick(site): void;
-  }>;
+  options: Array<LauncherSiteCardOption>;
   onSiteCardClick(id: string): void;
 }
 
-const SitesRail = ({ classes, formatMessage, sites, site, onSiteCardClick, cardActions, version }: SitesRailProps) => (
+const SitesRail = ({ classes, formatMessage, sites, site, onSiteCardClick, options, version }: SitesRailProps) => (
   <Hidden only={['xs', 'sm']}>
     <Grid item md={4} className={classes.sitesRail}>
       <div className={classes.railTop}>
@@ -266,13 +270,12 @@ const SitesRail = ({ classes, formatMessage, sites, site, onSiteCardClick, cardA
             {sites.map((item, i) => (
               <LauncherSiteCard
                 key={i}
-                options
                 selected={item.id === site}
                 title={item.name}
                 value={item.id}
                 classes={{ root: classes.titleCard }}
                 onCardClick={() => onSiteCardClick(item.id)}
-                cardActions={cardActions}
+                options={options}
               />
             ))}
           </List>
@@ -308,9 +311,10 @@ export default function Launcher(props: LauncherStateProps) {
   const { launcher } = useSiteUIConfig();
   const siteCardMenuLinks = launcher?.siteCardMenuLinks;
   const widgets = launcher?.widgets;
+  const globalNavigationPosition = launcher?.globalNavigationPosition ?? 'after';
   const userRoles = user.rolesBySite[siteId];
   const anchor = useMemo(() => (anchorSelector ? document.querySelector(anchorSelector) : null), [anchorSelector]);
-  const cardActions = useMemo(
+  const cardActions = useMemo<LauncherSiteCardOption[]>(
     () =>
       siteCardMenuLinks
         ? siteCardMenuLinks
@@ -320,18 +324,19 @@ export default function Launcher(props: LauncherStateProps) {
             )
             .map((descriptor) => ({
               name: typeof descriptor.title === 'string' ? descriptor.title : formatMessage(descriptor.title),
-              href: getSystemLink({
-                systemLinkId: descriptor.systemLinkId,
-                authoringBase,
-                previewChoice,
-                site: siteId
-              }),
+              href: (site) =>
+                getSystemLink({
+                  systemLinkId: descriptor.systemLinkId,
+                  authoringBase,
+                  previewChoice,
+                  site
+                }),
               onClick(site) {
                 setSiteCookie(site);
               }
             }))
-        : [],
-    [siteCardMenuLinks, userRoles, formatMessage, authoringBase, previewChoice, siteId]
+        : null,
+    [siteCardMenuLinks, userRoles, formatMessage, authoringBase, previewChoice]
   );
 
   const onSiteCardClick = (site: string) => {
@@ -369,7 +374,7 @@ export default function Launcher(props: LauncherStateProps) {
       sites={sites}
       site={siteId}
       version={version}
-      cardActions={cardActions}
+      options={cardActions}
       onSiteCardClick={onSiteCardClick}
     />
   );
@@ -383,6 +388,7 @@ export default function Launcher(props: LauncherStateProps) {
       onLogout={onLogout}
       closeButtonPosition={closeButtonPosition}
       userRoles={userRoles}
+      globalNavigationPosition={globalNavigationPosition}
     />
   );
 

--- a/ui/app/src/components/LauncherGlobalNav/LauncherGlobalNav.tsx
+++ b/ui/app/src/components/LauncherGlobalNav/LauncherGlobalNav.tsx
@@ -14,13 +14,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import LauncherTile from '../LauncherTile';
+import LauncherTile, { LauncherTileProps } from '../LauncherTile';
 import { getSimplifiedVersion } from '../../utils/string';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useEnv, useGlobalNavigation, useSystemVersion } from '../../utils/hooks';
 import TranslationOrText from '../../models/TranslationOrText';
 import { useIntl } from 'react-intl';
-import { getLauncherSectionLink, LauncherSectionUI } from '../LauncherSection';
+import { getLauncherSectionLink, LauncherSectionUI, urlMapping } from '../LauncherSection';
 import { messages } from '../LauncherSection/utils';
 import { closeLauncher } from '../../state/actions/dialogs';
 import { useDispatch } from 'react-redux';
@@ -30,6 +30,8 @@ import Skeleton from '@material-ui/lab/Skeleton';
 
 export interface LauncherGlobalNavProps {
   title?: TranslationOrText;
+  onTileClicked?(): void;
+  tileStyles?: LauncherTileProps['styles'];
 }
 
 function LauncherGlobalNav(props: LauncherGlobalNavProps) {
@@ -37,8 +39,19 @@ function LauncherGlobalNav(props: LauncherGlobalNavProps) {
   const { formatMessage } = useIntl();
   const { authoringBase } = useEnv();
   const version = useSystemVersion();
-  const onMenuClose = () => dispatch(closeLauncher());
+  const onTileClicked = props.onTileClicked ?? (() => dispatch(closeLauncher()));
   const { items, error } = useGlobalNavigation();
+  const [activeItemId, setActiveItemId] = useState('');
+  useEffect(() => {
+    const idLookup = {};
+    Object.entries(urlMapping).forEach(([id, hash]) => (idLookup[hash] = id));
+    function hashchange() {
+      const hash = window.location.hash;
+      setActiveItemId(idLookup[hash]);
+    }
+    hashchange();
+    window.addEventListener('hashchange', hashchange, false);
+  }, []);
   if (!error && !items) {
     const style = { margin: 5, width: 120, height: 100, display: 'inline-flex' };
     return (
@@ -57,10 +70,12 @@ function LauncherGlobalNav(props: LauncherGlobalNavProps) {
       {items.map((item) => (
         <LauncherTile
           key={item.id}
+          active={activeItemId === item.id}
           title={formatMessage(globalMenuMessages[item.id])}
-          icon={{ baseClass: `fa ${item.icon}` }}
+          icon={item.icon}
           link={getLauncherSectionLink(item.id, authoringBase)}
-          onClick={onMenuClose}
+          onClick={onTileClicked}
+          styles={props.tileStyles}
         />
       ))}
       <LauncherTile
@@ -68,19 +83,8 @@ function LauncherGlobalNav(props: LauncherGlobalNavProps) {
         icon={{ id: 'craftercms.icons.Docs' }}
         link={`https://docs.craftercms.org/en/${getSimplifiedVersion(version)}/index.html`}
         target="_blank"
-        onClick={onMenuClose}
-      />
-      <LauncherTile
-        title={formatMessage(globalMenuMessages['home.settings'])}
-        icon={{ id: '@material-ui/icons/SettingsRounded' }}
-        link={getLauncherSectionLink('settings', authoringBase)}
-        onClick={onMenuClose}
-      />
-      <LauncherTile
-        icon={{ id: 'craftercms.icons.CrafterIcon' }}
-        link={getLauncherSectionLink('about', authoringBase)}
-        title={formatMessage(globalMenuMessages['home.about-us'])}
-        onClick={onMenuClose}
+        onClick={onTileClicked}
+        styles={props.tileStyles}
       />
     </LauncherSectionUI>
   );

--- a/ui/app/src/components/LauncherGlobalNav/LauncherGlobalNav.tsx
+++ b/ui/app/src/components/LauncherGlobalNav/LauncherGlobalNav.tsx
@@ -29,7 +29,7 @@ import { globalMenuMessages } from '../../utils/i18n-legacy';
 import Skeleton from '@material-ui/lab/Skeleton';
 
 export interface LauncherGlobalNavProps {
-  title: TranslationOrText;
+  title?: TranslationOrText;
 }
 
 function LauncherGlobalNav(props: LauncherGlobalNavProps) {
@@ -53,7 +53,7 @@ function LauncherGlobalNav(props: LauncherGlobalNavProps) {
     return <ApiResponseErrorState error={error.response ?? error} />;
   }
   return (
-    <LauncherSectionUI title={props.title}>
+    <LauncherSectionUI title={props.title ?? formatMessage(messages.global)}>
       {items.map((item) => (
         <LauncherTile
           key={item.id}

--- a/ui/app/src/components/LauncherSection/LauncherSection.tsx
+++ b/ui/app/src/components/LauncherSection/LauncherSection.tsx
@@ -35,7 +35,7 @@ function LauncherSection(props: LauncherSectionProps) {
       site={site}
       user={user}
       translationValues={{
-        siteName: sites[site].name,
+        siteName: sites[site]?.name ?? '',
         muted: (value) => (
           <span className="muted" key={value}>
             {value}

--- a/ui/app/src/components/LauncherSection/LauncherSectionUI.tsx
+++ b/ui/app/src/components/LauncherSection/LauncherSectionUI.tsx
@@ -22,6 +22,12 @@ import TranslationOrText from '../../models/TranslationOrText';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { EnhancedUser } from '../../models/User';
 import { FormatXMLElementFn, PrimitiveType } from 'intl-messageformat';
+import { CSSProperties } from '@material-ui/styles';
+import clsx from 'clsx';
+
+export type LauncherSectionUIClassKey = 'title' | 'nav';
+
+type LauncherSectionUIStyles = Partial<Record<LauncherSectionUIClassKey, CSSProperties>>;
 
 export type LauncherSectionUIProps = PropsWithChildren<{
   title: TranslationOrText;
@@ -29,11 +35,13 @@ export type LauncherSectionUIProps = PropsWithChildren<{
   site?: string;
   widgets?: WidgetDescriptor[];
   translationValues?: Record<string, PrimitiveType | ReactElement | FormatXMLElementFn>;
+  styles?: LauncherSectionUIStyles;
+  classes?: Partial<Record<LauncherSectionUIClassKey, string>>;
 }>;
 
 const useStyles = makeStyles((theme) =>
-  createStyles({
-    title: {
+  createStyles<LauncherSectionUIClassKey, LauncherSectionUIStyles>({
+    title: (styles) => ({
       textTransform: 'uppercase',
       fontWeight: 600,
       margin: '0 0 10px 0',
@@ -41,27 +49,29 @@ const useStyles = makeStyles((theme) =>
         textTransform: 'none',
         marginLeft: '0.315em',
         color: theme.palette.text.secondary
-      }
-    },
-    nav: {
+      },
+      ...styles.title
+    }),
+    nav: (styles) => ({
       display: 'flex',
-      flexWrap: 'wrap'
-    }
+      flexWrap: 'wrap',
+      ...styles.nav
+    })
   })
 );
 
 function LauncherSectionUI(props: LauncherSectionUIProps) {
-  const classes = useStyles();
+  const classes = useStyles(props.styles);
   const title = usePossibleTranslation(props.title, props.translationValues);
   const { children } = props;
   return (
     <>
       {title && (
-        <Typography variant="subtitle1" component="h2" className={classes.title}>
+        <Typography variant="subtitle1" component="h2" className={clsx(classes.title, props.classes?.title)}>
           {title}
         </Typography>
       )}
-      <nav className={classes.nav}>
+      <nav className={clsx(classes.nav, props.classes?.nav)}>
         {children ? children : renderWidgets(props.widgets, props.user.rolesBySite[props.site])}
       </nav>
     </>

--- a/ui/app/src/components/LauncherSection/utils.ts
+++ b/ui/app/src/components/LauncherSection/utils.ts
@@ -30,13 +30,15 @@ export const urlMapping = {
   'home.globalMenu.cluster': '#/globalMenu/cluster',
   'home.globalMenu.encryptionTool': '#/globalMenu/encryption-tool',
   'home.globalMenu.tokenManagement': '#/globalMenu/token-management',
+  'home.globalMenu.about-us': '#/globalMenu/about-us',
+  'home.globalMenu.settings': '#/globalMenu/settings',
+  about: '#/about-us',
+  settings: '#/settings',
   'legacy.preview': '/preview/',
   preview: '/next/preview',
-  about: '#/about-us',
   siteConfig: '/site-config',
   search: '/search',
-  siteDashboard: '/site-dashboard',
-  settings: '#/settings'
+  siteDashboard: '/site-dashboard'
 };
 
 export const messages = defineMessages({

--- a/ui/app/src/components/LauncherSiteCard/LauncherSiteCard.tsx
+++ b/ui/app/src/components/LauncherSiteCard/LauncherSiteCard.tsx
@@ -101,6 +101,8 @@ function LauncherSiteCard(props: LauncherSiteCardProps) {
             <MenuItem
               key={i}
               component={Link}
+              color="inherit"
+              underline="none"
               href={typeof action.href === 'function' ? action.href(value) : action.href}
               onClick={(e) => handleClose(e, action)}
             >

--- a/ui/app/src/components/LauncherSiteCard/LauncherSiteCard.tsx
+++ b/ui/app/src/components/LauncherSiteCard/LauncherSiteCard.tsx
@@ -27,12 +27,17 @@ import ListItemText from '@material-ui/core/ListItemText';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import Box from '@material-ui/core/Box';
 
-interface LauncherSiteCardProps {
+export interface LauncherSiteCardOption {
+  name: string;
+  href: string | ((site: string) => string);
+  onClick?(site: string): void;
+}
+
+export interface LauncherSiteCardProps {
   title: string;
   value?: string;
-  options?: boolean;
   classes?: any;
-  cardActions?: any;
+  options?: Array<LauncherSiteCardOption>;
   disabled?: boolean;
   selected?: boolean;
   onCardClick(id: string): any;
@@ -53,9 +58,10 @@ const useStyles = makeStyles((theme) =>
 );
 
 function LauncherSiteCard(props: LauncherSiteCardProps) {
-  const { title, value, options, onCardClick, cardActions = [], selected = false } = props;
+  const { title, value, onCardClick, options, selected = false } = props;
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const classes = useStyles();
+  const hasOptions = Boolean(options && options.length);
 
   const handleClose = (event, action?) => {
     event.stopPropagation();
@@ -81,25 +87,26 @@ function LauncherSiteCard(props: LauncherSiteCardProps) {
         title={title}
       >
         <ListItemText primary={title} primaryTypographyProps={{ className: classes.siteName, noWrap: true }} />
-        {options && (
+        {hasOptions && (
           <ListItemSecondaryAction>
-            <IconButton aria-label="settings" onClick={(e) => handleOptions(e)}>
+            <IconButton aria-label="settings" onClick={handleOptions}>
               <MoreVertIcon />
             </IconButton>
           </ListItemSecondaryAction>
         )}
       </Box>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-        {cardActions.map((action, i) => (
-          <MenuItem
-            key={i}
-            component={Link}
-            href={typeof action.href === 'function' ? action.href(value) : action.href}
-            onClick={(e) => handleClose(e, action)}
-          >
-            {action.name}
-          </MenuItem>
-        ))}
+        {hasOptions &&
+          options.map((action, i) => (
+            <MenuItem
+              key={i}
+              component={Link}
+              href={typeof action.href === 'function' ? action.href(value) : action.href}
+              onClick={(e) => handleClose(e, action)}
+            >
+              {action.name}
+            </MenuItem>
+          ))}
       </Menu>
     </>
   );

--- a/ui/app/src/components/LauncherTile/LauncherTile.tsx
+++ b/ui/app/src/components/LauncherTile/LauncherTile.tsx
@@ -21,6 +21,11 @@ import SystemIcon, { SystemIconDescriptor } from '../SystemIcon';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { CSSProperties } from '@material-ui/styles';
+
+export type LauncherTileClassKey = 'tile' | 'tileActive' | 'title' | 'iconAvatar';
+
+type LauncherTileStyles = Partial<Record<LauncherTileClassKey, CSSProperties>>;
 
 export interface LauncherTileProps {
   icon: SystemIconDescriptor;
@@ -28,12 +33,15 @@ export interface LauncherTileProps {
   link?: string;
   target?: string;
   disabled?: any;
+  active?: boolean;
+  classes?: Partial<Record<LauncherTileClassKey, string>>;
+  styles?: LauncherTileStyles;
   onClick?(id?: string, type?: string): any;
 }
 
 const useStyles = makeStyles((theme) =>
-  createStyles({
-    tile: {
+  createStyles<LauncherTileClassKey, LauncherTileStyles>({
+    tile: (styles) => ({
       width: '120px',
       height: '100px',
       display: 'flex',
@@ -55,33 +63,44 @@ const useStyles = makeStyles((theme) =>
         opacity: theme.palette.action.disabledOpacity,
         background: theme.palette.action.disabled,
         pointerEvents: 'none'
-      }
-    },
-    title: {
-      lineHeight: 1
-    },
-    iconAvatar: {
+      },
+      ...styles.tile
+    }),
+    title: (styles) => ({
+      lineHeight: 1,
+      ...styles.title
+    }),
+    iconAvatar: (styles) => ({
       backgroundColor: 'transparent',
       color: theme.palette.text.secondary,
-      margin: 5
-    }
+      margin: 5,
+      ...styles.iconAvatar
+    }),
+    tileActive: (styles) => ({
+      '&, &:hover, &:focus': {
+        boxShadow: 'none',
+        cursor: 'default',
+        background: theme.palette.action.selected
+      },
+      ...styles.tileActive
+    })
   })
 );
 
 function LauncherTile(props: LauncherTileProps) {
-  const { title, icon, link, target, onClick, disabled = false } = props;
-  const classes = useStyles();
+  const { title, icon, link, target, onClick, disabled = false, active } = props;
+  const classes = useStyles(props.styles);
   return (
     <Link
-      className={clsx(classes.tile, disabled && 'disabled')}
+      className={clsx(classes.tile, props.classes?.tile, disabled && 'disabled', active && classes.tileActive)}
       href={disabled ? null : link}
       onClick={() => (!disabled && onClick ? onClick() : null)}
       target={target ? target : '_self'}
     >
-      <Avatar variant="rounded" className={classes.iconAvatar} color="inherit">
+      <Avatar variant="rounded" className={clsx(classes.iconAvatar, props.classes?.iconAvatar)}>
         <SystemIcon icon={icon} />
       </Avatar>
-      <Typography color="textPrimary" className={classes.title}>
+      <Typography color="textPrimary" className={clsx(classes.title, props.classes?.title)}>
         {title}
       </Typography>
     </Link>

--- a/ui/app/src/components/SystemStatus/LoginForm.tsx
+++ b/ui/app/src/components/SystemStatus/LoginForm.tsx
@@ -42,6 +42,9 @@ const useStyles = makeStyles((theme) =>
   createStyles({
     spacing: {
       marginBottom: theme.spacing(1)
+    },
+    doubleSpacing: {
+      marginBottom: theme.spacing(2)
     }
   })
 );
@@ -86,7 +89,7 @@ export default function LogInForm(props: LogInFormProps) {
         autoFocus={!enableUsernameInput || Boolean(username)}
         value={password}
         onChange={(e: any) => onSetPassword?.(e.target.value)}
-        className={clsx(cls.spacing, classes?.password)}
+        className={clsx(cls.spacing, classes?.password, 'last-before-button')}
         label={<FormattedMessage id="authMonitor.passwordTextFieldLabel" defaultMessage="Password" />}
       />
       {xsrfParamName && <input type="hidden" name={xsrfParamName} value={xsrfToken} />}

--- a/ui/app/src/components/SystemStatus/LoginView.tsx
+++ b/ui/app/src/components/SystemStatus/LoginView.tsx
@@ -14,12 +14,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import DialogContent from '@material-ui/core/DialogContent';
-import InputLabel from '@material-ui/core/InputLabel';
 import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
@@ -31,7 +30,6 @@ import {
 import { isBlank } from '../../utils/string';
 import Typography from '@material-ui/core/Typography';
 import LogInForm from './LoginForm';
-import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import { fetchProductLanguages } from '../../services/configuration';
 import WarningRounded from '@material-ui/icons/WarningRounded';
@@ -48,7 +46,9 @@ import { useDebouncedInput, useMount } from '../../utils/hooks';
 import palette from '../../styles/palette';
 import { buildStoredLanguageKey, dispatchLanguageChange, getCurrentLocale, setStoredLanguage } from '../../utils/i18n';
 import CrafterCMSLogo from '../Icons/CrafterCMSLogo';
-import FormControl from '@material-ui/core/FormControl';
+import IconButton from '@material-ui/core/IconButton';
+import LanguageRounded from '@material-ui/icons/LanguageRounded';
+import Menu from '@material-ui/core/Menu';
 
 interface SystemLang {
   id: string;
@@ -59,10 +59,6 @@ interface LanguageDropDownProps {
   language: string;
   onChange: Function;
   languages: SystemLang[];
-  classes?: {
-    label?: string;
-    dropDown?: string;
-  };
 }
 
 export interface LoginViewProps {
@@ -146,13 +142,17 @@ const useStyles = makeStyles((theme) =>
     dialogRoot: {
       transition: 'all 600ms ease',
       '& .MuiInput-input': { backgroundColor: theme.palette.background.paper },
-      '& .MuiFormControl-root, & .MuiButton-root': { marginBottom: theme.spacing(1) }
+      '& .MuiFormControl-root, & .MuiButton-root': {
+        marginBottom: theme.spacing(1),
+        '&.last-before-button': { marginBottom: theme.spacing(2) }
+      }
     },
     dialogRootFetching: {
       opacity: 0.2
     },
     dialogPaper: {
       minWidth: 300,
+      overflow: 'visible',
       backgroundColor: theme.palette.type === 'dark' ? 'rgba(0, 0, 0, .8)' : 'rgba(255, 255, 255, .8)'
     },
     logo: {
@@ -160,10 +160,6 @@ const useStyles = makeStyles((theme) =>
       display: 'block',
       margin: `${theme.spacing(2)}px auto ${theme.spacing(1)}px`
     },
-    languageSelect: {
-      margin: 0
-    },
-    languageSelectLabel: {},
     recoverInfoMessage: {
       maxWidth: 300,
       textAlign: 'center',
@@ -335,19 +331,18 @@ function RecoverView(props: SubViewProps) {
           className={classes?.username}
           label={<FormattedMessage id="loginView.usernameTextFieldLabel" defaultMessage="Username" />}
         />
-      </DialogContent>
-      <DialogActions>
         <Button
           type="submit"
           color="primary"
           onClick={onSubmitRecover}
           disabled={isFetching}
           variant="contained"
+          style={{ marginTop: 15 }}
           fullWidth
         >
           <FormattedMessage id="words.submit" defaultMessage="Submit" />
         </Button>
-      </DialogActions>
+      </DialogContent>
       <DialogActions>
         <Button
           fullWidth
@@ -496,27 +491,39 @@ function UnrecognizedView({ classes }: any) {
 
 function LanguageDropDown(props: LanguageDropDownProps) {
   const { formatMessage } = useIntl();
-  const { classes, language, languages, onChange } = props;
+  const buttonRef = useRef();
+  const [openMenu, setOpenMenu] = useState(false);
+  const { language, languages, onChange } = props;
   return (
-    <FormControl fullWidth>
-      <InputLabel id="languageSelectDropDown-label" className={classes?.label}>
+    <>
+      <Button
+        ref={buttonRef}
+        onClick={() => setOpenMenu(true)}
+        style={{ position: 'absolute', bottom: -50, width: '100%', color: 'white' }}
+        startIcon={<LanguageRounded />}
+      >
         {formatMessage(translations.languageDropDownLabel)}
-      </InputLabel>
-      <Select
-        fullWidth
-        value={language}
-        id="languageSelectDropDown"
-        labelId="languageSelectDropDown-label"
-        onChange={(e: any) => onChange(e.target.value)}
-        className={classes?.dropDown}
+      </Button>
+      <Menu
+        anchorEl={buttonRef.current}
+        anchorOrigin={{ horizontal: 'center', vertical: 'center' }}
+        open={openMenu}
+        onClose={() => setOpenMenu(false)}
       >
         {languages?.map(({ id, label }) => (
-          <MenuItem value={id} key={id}>
+          <MenuItem
+            selected={id === language}
+            key={id}
+            onClick={() => {
+              setOpenMenu(false);
+              onChange(id);
+            }}
+          >
             {label}
           </MenuItem>
         ))}
-      </Select>
-    </FormControl>
+      </Menu>
+    </>
   );
 }
 
@@ -683,17 +690,7 @@ export default function LoginViewContainer(props: LoginViewProps) {
     onRecover: () => setMode('recover'),
     xsrfToken,
     xsrfParamName,
-    children: (
-      <LanguageDropDown
-        language={language}
-        languages={languages}
-        onChange={setLanguage}
-        classes={{
-          label: classes.languageSelectLabel,
-          dropDown: classes.languageSelect
-        }}
-      />
-    )
+    children: null
   };
 
   // Retrieve Platform Languages.
@@ -751,6 +748,7 @@ export default function LoginViewContainer(props: LoginViewProps) {
           <CrafterCMSLogo className={classes.logo} width="auto" />
         </DialogTitle>
         <CurrentView {...currentViewProps} />
+        <LanguageDropDown language={language} languages={languages} onChange={setLanguage} />
       </Dialog>
       <Snackbar
         open={snack.open}

--- a/ui/app/src/components/SystemStatus/LoginView.tsx
+++ b/ui/app/src/components/SystemStatus/LoginView.tsx
@@ -46,7 +46,6 @@ import { useDebouncedInput, useMount } from '../../utils/hooks';
 import palette from '../../styles/palette';
 import { buildStoredLanguageKey, dispatchLanguageChange, getCurrentLocale, setStoredLanguage } from '../../utils/i18n';
 import CrafterCMSLogo from '../Icons/CrafterCMSLogo';
-import IconButton from '@material-ui/core/IconButton';
 import LanguageRounded from '@material-ui/icons/LanguageRounded';
 import Menu from '@material-ui/core/Menu';
 

--- a/ui/app/src/models/GlobalState.ts
+++ b/ui/app/src/models/GlobalState.ts
@@ -219,7 +219,7 @@ export interface GlobalState {
     };
     globalNavigation: {
       error: AjaxError;
-      items: Array<{ icon: string; id: string; label: string }>;
+      items: Array<{ icon: SystemIconDescriptor; id: string; label: string }>;
       isFetching: boolean;
     };
   };

--- a/ui/app/src/models/GlobalState.ts
+++ b/ui/app/src/models/GlobalState.ts
@@ -205,6 +205,11 @@ export interface GlobalState {
     };
     launcher: {
       widgets: WidgetDescriptor[];
+      /**
+       * Whether to render the global nav before or after
+       * the additional widgets coming from configuration
+       **/
+      globalNavigationPosition?: 'before' | 'after';
       siteCardMenuLinks: Array<{
         title: TranslationOrText;
         systemLinkId: SystemLinkId;
@@ -215,6 +220,7 @@ export interface GlobalState {
     globalNavigation: {
       error: AjaxError;
       items: Array<{ icon: string; id: string; label: string }>;
+      isFetching: boolean;
     };
   };
   pathNavigator: {

--- a/ui/app/src/modules/Preview/ToolBar.tsx
+++ b/ui/app/src/modules/Preview/ToolBar.tsx
@@ -59,6 +59,7 @@ import Skeleton from '@material-ui/lab/Skeleton';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { setSiteCookie } from '../../utils/auth';
 import LogoAndMenuBundleButton from '../../components/LogoAndMenuBundleButton';
+import { getSystemLink } from '../../components/LauncherSection';
 
 const translations = defineMessages({
   openToolsPanel: {
@@ -312,7 +313,15 @@ export default function ToolBar() {
               dispatch(changeSite(site));
             } else {
               setSiteCookie(site);
-              setTimeout(() => (window.location.href = `${authoringBase}/preview`));
+              setTimeout(
+                () =>
+                  (window.location.href = getSystemLink({
+                    site,
+                    systemLinkId: 'preview',
+                    previewChoice,
+                    authoringBase
+                  }))
+              );
             }
           }}
           onUrlChange={(url) => dispatch(changeCurrentUrl(url))}

--- a/ui/app/src/services/configuration.ts
+++ b/ui/app/src/services/configuration.ts
@@ -156,8 +156,33 @@ export function fetchSiteUiConfig(site: string): Observable<Pick<GlobalState['ui
   );
 }
 
-export function fetchGlobalMenuItems(): Observable<GlobalState['uiConfig']['globalNavigation']> {
-  return get('/studio/api/2/ui/views/global_menu.json').pipe(pluck('response', 'menuItems'));
+const legacyToNextMenuIconMap = {
+  'fa-sitemap': 'craftercms.icons.Sites',
+  'fa-user': '@material-ui/icons/PeopleRounded',
+  'fa-users': '@material-ui/icons/SupervisedUserCircleRounded',
+  'fa-database': '@material-ui/icons/StorageRounded',
+  'fa-bars': '@material-ui/icons/SubjectRounded',
+  'fa-level-down': '@material-ui/icons/SettingsApplicationsRounded',
+  'fa-align-left': '@material-ui/icons/FormatAlignCenterRounded',
+  'fa-globe': '@material-ui/icons/PublicRounded',
+  'fa-lock': '@material-ui/icons/LockRounded',
+  'fa-key': '@material-ui/icons/VpnKeyRounded'
+};
+
+export function fetchGlobalMenuItems(): Observable<GlobalState['uiConfig']['globalNavigation']['items']> {
+  return get('/studio/api/2/ui/views/global_menu.json').pipe(
+    pluck('response', 'menuItems'),
+    map((items) => [
+      ...items.map((item) => ({
+        ...item,
+        icon: legacyToNextMenuIconMap[item.icon]
+          ? { id: legacyToNextMenuIconMap[item.icon] }
+          : { baseClass: item.icon.includes('fa') ? `fa ${item.icon}` : item.icon }
+      })),
+      { id: 'home.globalMenu.about-us', icon: { id: 'craftercms.icons.CrafterIcon' }, label: 'About' },
+      { id: 'home.globalMenu.settings', icon: { id: '@material-ui/icons/AccountCircleRounded' }, label: 'Account' }
+    ])
+  );
 }
 
 export function fetchProductLanguages(): Observable<{ id: string; label: string }[]> {

--- a/ui/app/src/services/users.ts
+++ b/ui/app/src/services/users.ts
@@ -16,7 +16,7 @@
 
 import { forkJoin, Observable, of } from 'rxjs';
 import { User } from '../models/User';
-import { del, get, patchJSON, post, postJSON } from '../utils/ajax';
+import { del, get, patchJSON, postJSON } from '../utils/ajax';
 import { map, mapTo, pluck, switchMap } from 'rxjs/operators';
 import { fetchAll as fetchAllSites } from './sites';
 import LookupTable from '../models/LookupTable';

--- a/ui/app/src/services/users.ts
+++ b/ui/app/src/services/users.ts
@@ -206,7 +206,7 @@ export function getMyPermissions(site: string): Observable<string[]> {
 }
 
 export function hasPermissions(site: string, ...permissions: string[]): Observable<LookupTable<boolean>> {
-  return post(`/studio/api/2/users/me/sites/${site}/has_permissions`, { permissions }).pipe(
+  return postJSON(`/studio/api/2/users/me/sites/${site}/has_permissions`, { permissions }).pipe(
     pluck('response', 'permissions')
   );
 }

--- a/ui/app/src/state/actions/system.ts
+++ b/ui/app/src/state/actions/system.ts
@@ -95,7 +95,7 @@ export const messageSharedWorker = /*#__PURE__*/ createAction<StandardAction>('M
 
 export const fetchGlobalMenu = /*#__PURE__*/ createAction('FETCH_GLOBAL_MENU');
 
-export const fetchGlobalMenuComplete = /*#__PURE__*/ createAction<GlobalState['uiConfig']['globalNavigation']>(
+export const fetchGlobalMenuComplete = /*#__PURE__*/ createAction<GlobalState['uiConfig']['globalNavigation']['items']>(
   'FETCH_GLOBAL_MENU_COMPLETE'
 );
 

--- a/ui/app/src/state/epics/system.ts
+++ b/ui/app/src/state/epics/system.ts
@@ -67,7 +67,11 @@ import { fetchGlobalMenuItems } from '../../services/configuration';
 
 const systemEpics: CrafterCMSEpic[] = [
   // region storeInitialized & changeSite
-  (action$) => action$.pipe(ofType(storeInitialized.type, changeSite.type), mapTo(startPublishingStatusFetcher())),
+  (action$) =>
+    action$.pipe(
+      ofType(storeInitialized.type, changeSite.type),
+      switchMap(() => [startPublishingStatusFetcher(), fetchGlobalMenu()])
+    ),
   // endregion
   // region emitSystemEvent
   (action$) =>

--- a/ui/app/src/state/reducers/uiConfig.ts
+++ b/ui/app/src/state/reducers/uiConfig.ts
@@ -32,7 +32,8 @@ const initialState: GlobalState['uiConfig'] = {
   launcher: null,
   globalNavigation: {
     error: null,
-    items: null
+    items: null,
+    isFetching: false
   }
 };
 
@@ -57,15 +58,24 @@ const reducer = createReducer<GlobalState['uiConfig']>(initialState, {
   [fetchGlobalMenuComplete.type]: (state, { payload }) => ({
     ...state,
     globalNavigation: {
+      ...state.globalNavigation,
+      isFetching: true
+    }
+  }),
+  [fetchGlobalMenuComplete.type]: (state, { payload }) => ({
+    ...state,
+    globalNavigation: {
       error: null,
-      items: payload
+      items: payload,
+      isFetching: false
     }
   }),
   [fetchGlobalMenuFailed.type]: (state, { payload }) => ({
     ...state,
     globalNavigation: {
       error: payload,
-      items: state.globalNavigation.items
+      items: state.globalNavigation.items,
+      isFetching: false
     }
   })
 });

--- a/ui/app/src/translations/locales/en.json
+++ b/ui/app/src/translations/locales/en.json
@@ -9,7 +9,7 @@
   "GlobalMenu.LoggingLevelsEntryLabel": "Logging Levels",
   "GlobalMenu.Login": "Login",
   "GlobalMenu.Recover": "Password Recovery",
-  "GlobalMenu.Settings": "Account Management",
+  "GlobalMenu.Settings": "Account",
   "GlobalMenu.SitesEntryLabel": "Sites",
   "GlobalMenu.UsersEntryLabel": "Users",
   "aboutView.attribution": "Crafter CMS is made possible by these other <a>open source software projects</a>.",

--- a/ui/app/src/utils/codebase-bridge.tsx
+++ b/ui/app/src/utils/codebase-bridge.tsx
@@ -186,7 +186,8 @@ export function createCodebaseBridge() {
       PluginManagement: lazy(() => import('../components/PluginManagement')),
       PublishingStatusDialogBody: lazy(() => import('../components/PublishingStatusDialog/PublishingStatusDialogBody')),
       LogoAndMenuBundleButton: lazy(() => import('../components/LogoAndMenuBundleButton')),
-      CrafterIcon: lazy(() => import('../components/Icons/CrafterIcon'))
+      CrafterIcon: lazy(() => import('../components/Icons/CrafterIcon')),
+      LauncherGlobalNav: lazy(() => import('../components/LauncherGlobalNav/LauncherGlobalNav'))
     },
 
     system: {

--- a/ui/app/src/utils/hooks.ts
+++ b/ui/app/src/utils/hooks.ts
@@ -165,10 +165,10 @@ export function useGlobalNavigation(): GlobalState['uiConfig']['globalNavigation
   const dispatch = useDispatch();
   const data = useSelection((state) => state.uiConfig.globalNavigation);
   useEffect(() => {
-    if (nou(data.items) && nou(data.error)) {
+    if (nou(data.items) && nou(data.error) && !data.isFetching) {
       dispatch(fetchGlobalMenu());
     }
-  }, [data.error, data.items, dispatch]);
+  }, [data.error, data.isFetching, data.items, dispatch]);
   return data;
 }
 

--- a/ui/app/src/utils/i18n-legacy.ts
+++ b/ui/app/src/utils/i18n-legacy.ts
@@ -871,7 +871,7 @@ export const globalMenuMessages = defineMessages({
   },
   'home.settings': {
     id: 'GlobalMenu.Settings',
-    defaultMessage: 'Account Management'
+    defaultMessage: 'Account'
   },
   login: {
     id: 'words.login',
@@ -882,6 +882,9 @@ export const globalMenuMessages = defineMessages({
     defaultMessage: 'Password Recovery'
   }
 });
+
+globalMenuMessages['home.globalMenu.about-us'] = globalMenuMessages['home.about-us'];
+globalMenuMessages['home.globalMenu.settings'] = globalMenuMessages['home.settings'];
 
 export const adminConfigurationMessages = defineMessages({
   encryptMarked: {

--- a/ui/guest/src/react/Guest.tsx
+++ b/ui/guest/src/react/Guest.tsx
@@ -97,7 +97,7 @@ function Guest(props: GuestProps) {
   const status = state.status;
   const hasHost = state.hostCheckedIn;
   const draggable = state.draggable;
-  const refs = useRef({ contentReady: false });
+  const refs = useRef({ contentReady: false, firstRender: true });
   // TODO: Avoid double re-render when draggable changes without coupling to redux on useICE
   const context = useMemo(
     () => ({
@@ -147,10 +147,17 @@ function Guest(props: GuestProps) {
   useEffect(() => {
     if (editMode === false) {
       $('html').removeClass(editModeClass);
-      document.dispatchEvent(new CustomEvent(editModeClass, { detail: false }));
+      document.dispatchEvent(new CustomEvent('craftercms.editMode', { detail: false }));
+      // Refreshing the page for now. Will revisit on a later release.
+      if (!refs.current.firstRender) {
+        window.location.reload();
+      }
     } else {
       $('html').addClass(editModeClass);
-      document.dispatchEvent(new CustomEvent(editModeClass, { detail: true }));
+      document.dispatchEvent(new CustomEvent('craftercms.editMode', { detail: true }));
+    }
+    if (refs.current.firstRender) {
+      refs.current.firstRender = false;
     }
   }, [editMode]);
 


### PR DESCRIPTION
Add site id table header, replace global menu sidebar with LauncherGlobalNavSection, replace legacy icons, proxy global menu api response to add about, settings and map old=>new icons, bugfixes
Add site id table header
Fix launcher site card options menu styles, cleanup, refresh guest when edit mode is switched off, updating login views to downgrade the prominence of the language selector
Update site card option dashboard label
Pre-fetch global menu items, make global menu not-removable by config, site listing UI changes (remove preview & dashboard links), fix hasPermissions post call (wasn't posting json), fix address bar site switcher