### PR TITLE
[3959] Create folder in Scripts blocks the use of {} in the name which are used to indicate parametrized portions of the url

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -3989,7 +3989,7 @@ var nodeOpen = false,
        */
       lookupSiteContent: function(site, path, depth, order, callback) {
         CrafterCMSNext.services.content
-          .fetchLegacyItemsTree(site, encodeURI(path), {
+          .fetchLegacyItemsTree(site, path, {
             depth,
             order
           })

--- a/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-assets-folder.js
+++ b/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-assets-folder.js
@@ -715,7 +715,7 @@ var storage = CStudioAuthoring.Storage;
      * method fired when tree node is expanded for first time
      */
     onLoadNodeDataOnClick: function(node, fnLoadComplete) {
-      var path = encodeURI(node.treeNodeTO.path);
+      var path = node.treeNodeTO.path;
       var site = node.treeNodeTO.site;
       var pathToOpenTo = node.openToPath;
 

--- a/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-root-folder.js
+++ b/static-assets/components/cstudio-contextual-nav/wcm-site-dropdown-mods/wcm-root-folder.js
@@ -1453,7 +1453,7 @@
         }
 
         var plainpath = node.treeNodeTO.path,
-          path = encodeURI(plainpath),
+          path = plainpath,
           site = node.treeNodeTO.site,
           pathToOpenTo = node.openToPath;
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3959
Removing Double path Encoding

