### PR TITLE
Stop over-sizing node selector box when max is 1.

### DIFF
--- a/static-assets/components/cstudio-forms/controls/node-selector.js
+++ b/static-assets/components/cstudio-forms/controls/node-selector.js
@@ -191,6 +191,9 @@ YAHOO.extend(CStudioForms.Controls.NodeSelector, CStudioForms.CStudioFormField, 
     var nodeItemsContainerEl = document.createElement('div');
     nodeItemsContainerEl.id = this.id + '-target';
     YAHOO.util.Dom.addClass(nodeItemsContainerEl, 'cstudio-form-control-node-selector-items-container');
+    if (this.maxSize === 1) {
+      nodeItemsContainerEl.style.minHeight = "27px";
+    }
     nodeControlboxEl.appendChild(nodeItemsContainerEl);
     this.itemsContainerEl = nodeItemsContainerEl;
 


### PR DESCRIPTION
Highly visible usability improvement in node selectors when only one item is allowed to be selected.