### PR TITLE
[4649][3.1.x] Add note in Remote Repositories not to use Studio as a git merge and conflict resolution platform

### DIFF
--- a/static-assets/ng-views/admin-repository.html
+++ b/static-assets/ng-views/admin-repository.html
@@ -111,7 +111,10 @@
         </table>
       </div>
     </div>
-    <div class="col-md-12" ng-show="repositories.status.conflicting.length < 1">
+    <div
+      class="col-md-12"
+      ng-show="repositories.status.conflicting.length < 1 && repositories.status.uncommittedChanges.length < 1"
+    >
       <p class="note mb0 tac">
         {{ repositories.repoMessages.repositoriesNote }}
       </p>


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4649
- Do not show repositories note twice when there are uncommitted changes.