### PR TITLE
[4649][next] Add note in Remote Repositories not to use Studio as a git merge and conflict resolution platform

### DIFF
--- a/static-assets/ng-views/admin-repository.html
+++ b/static-assets/ng-views/admin-repository.html
@@ -109,7 +109,10 @@
           </tbody>
         </table>
       </div>
-      <div class="col-md-12" ng-show="repositories.status.conflicting.length < 1">
+      <div
+        class="col-md-12"
+        ng-show="repositories.status.conflicting.length < 1 && repositories.status.uncommittedChanges.length < 1"
+      >
         <p class="note mb0 tac">
           {{ repositories.repoMessages.repositoriesNote }}
         </p>
@@ -156,10 +159,7 @@
           </a>
         </div>
         <div class="mb30">
-          <h3
-            class="header header--inline mb10"
-          >{{ 'admin.repositories.REPOSITORY_STATUS' | translate }}
-          </h3>
+          <h3 class="header header--inline mb10">{{ 'admin.repositories.REPOSITORY_STATUS' | translate }}</h3>
           <p class="note mb0">
             {{ repositories.repoMessages.repositoriesNote }}
           </p>

--- a/static-assets/scripts/admin.js
+++ b/static-assets/scripts/admin.js
@@ -1936,8 +1936,9 @@
           .cancelFailedPull({
             siteId: repositories.site
           })
-          .then(function(data) {
-            repositories.status = data.repositoryStatus;
+          .then(function(repositoryStatus) {
+            repositories.status = repositoryStatus;
+            $scope.$apply();
           });
       };
     }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4649
- Do not show repositories note twice when there are uncommitted changes
- Fix status update after cancelFailedPull call