### PR TITLE
4.0.0/stability

### DIFF
--- a/ui/app/src/components/EditGroupDialog/EditGroupDialog.tsx
+++ b/ui/app/src/components/EditGroupDialog/EditGroupDialog.tsx
@@ -23,7 +23,7 @@ export interface EditGroupDialogProps {
   open: boolean;
   group?: Group;
   onClose(): void;
-  onClosed(): void;
+  onClosed?(): void;
   onGroupSaved(group: Group): void;
   onGroupDeleted(group: Group): void;
 }

--- a/ui/app/src/components/EditGroupDialog/EditGroupDialogUI.tsx
+++ b/ui/app/src/components/EditGroupDialog/EditGroupDialogUI.tsx
@@ -55,7 +55,7 @@ interface GroupEditDialogUIProps {
 
 const translations = defineMessages({
   confirmHelperText: {
-    id: 'groupEditDialog.helperText',
+    id: 'editGroupDialog.helperText',
     defaultMessage: 'Delete "{name}" group?'
   },
   confirmOk: {
@@ -104,7 +104,7 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
               confirmHelperText={formatMessage(translations.confirmHelperText, {
                 name: group.name
               })}
-              iconTooltip={<FormattedMessage id="groupEditDialog.deleteGroup" defaultMessage="Delete group" />}
+              iconTooltip={<FormattedMessage id="editGroupDialog.deleteGroup" defaultMessage="Delete group" />}
               icon={DeleteRoundedIcon}
               iconColor="action"
               onConfirm={() => {
@@ -112,7 +112,7 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
               }}
             />
           )}
-          <Tooltip title={<FormattedMessage id="groupEditDialog.close" defaultMessage="Close" />}>
+          <Tooltip title={<FormattedMessage id="editGroupDialog.close" defaultMessage="Close" />}>
             <IconButton edge="end" onClick={onClose}>
               <CloseRoundedIcon />
             </IconButton>
@@ -123,9 +123,14 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
       <DialogBody className={classes.body}>
         <section className={clsx(classes.section, 'noPaddingBottom')}>
           <Typography variant="subtitle1" className={classes.sectionTitle}>
-            <FormattedMessage id="groupEditDialog.groupDetails" defaultMessage="Group Details" />
+            <FormattedMessage id="editGroupDialog.groupDetails" defaultMessage="Group Details" />
           </Typography>
-          <form>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSave?.();
+            }}
+          >
             <Box display="flex" alignItems="center" p="15px  0">
               <InputLabel htmlFor="groupName" className={classes.label}>
                 <Typography variant="subtitle2">
@@ -142,6 +147,7 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
                   onChange={(e) => onChangeValue({ key: 'name', value: e.currentTarget.value })}
                   value={group.name}
                   fullWidth
+                  autoFocus
                 />
               )}
             </Box>
@@ -156,6 +162,7 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
                 onChange={(e) => onChangeValue({ key: 'desc', value: e.currentTarget.value })}
                 value={group.desc}
                 fullWidth
+                autoFocus={isEdit}
               />
             </Box>
             <div className={classes.formActions}>
@@ -164,7 +171,7 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
                   <FormattedMessage id="words.cancel" defaultMessage="Cancel" />
                 </SecondaryButton>
               )}
-              <PrimaryButton disabled={!isDirty} onClick={onSave} loading={false}>
+              <PrimaryButton disabled={!isDirty} type="submit">
                 <FormattedMessage id="words.save" defaultMessage="Save" />
               </PrimaryButton>
             </div>
@@ -172,10 +179,10 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
         </section>
         <Divider />
         <section className={classes.section}>
-          {users && members ? (
+          {isEdit && users && members ? (
             <>
               <Typography variant="subtitle1" className={classes.sectionTitleEdit}>
-                <FormattedMessage id="groupEditDialog.editGroupMembers" defaultMessage="Edit Group Members" />
+                <FormattedMessage id="editGroupDialog.editGroupMembers" defaultMessage="Edit Group Members" />
               </Typography>
               <TransferList
                 onTargetListItemsAdded={(items) => onAddMembers(items.map((item) => item.id))}
@@ -183,11 +190,23 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
                 inProgressIds={inProgressIds}
                 source={{
                   title: <FormattedMessage id="words.users" defaultMessage="Users" />,
-                  items: users.map((user) => ({ id: user.username, title: user.username, subtitle: user.email }))
+                  items: users.map((user) => ({ id: user.username, title: user.username, subtitle: user.email })),
+                  emptyMessage: (
+                    <FormattedMessage
+                      id="transferList.emptyListMessage"
+                      defaultMessage="All users are members of this group"
+                    />
+                  )
                 }}
                 target={{
                   title: <FormattedMessage id="words.members" defaultMessage="Members" />,
-                  items: members.map((user) => ({ id: user.username, title: user.username, subtitle: user.email }))
+                  items: members.map((user) => ({ id: user.username, title: user.username, subtitle: user.email })),
+                  emptyMessage: (
+                    <FormattedMessage
+                      id="transferList.targetEmptyStateMessage"
+                      defaultMessage="No members on this group"
+                    />
+                  )
                 }}
               />
             </>
@@ -195,7 +214,7 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
             <Box display="flex" justifyContent="center">
               <Typography variant="subtitle2" color="textSecondary">
                 <FormattedMessage
-                  id="groupEditDialog.groupMemberHelperText"
+                  id="editGroupDialog.groupMemberHelperText"
                   defaultMessage="Group members are editable after creation"
                 />
               </Typography>

--- a/ui/app/src/components/EditGroupDialog/EditGroupDialogUI.tsx
+++ b/ui/app/src/components/EditGroupDialog/EditGroupDialogUI.tsx
@@ -196,7 +196,7 @@ export default function EditGroupDialogUI(props: GroupEditDialogUIProps) {
               <Typography variant="subtitle2" color="textSecondary">
                 <FormattedMessage
                   id="groupEditDialog.groupMemberHelperText"
-                  defaultMessage="To edit group members the group needs to be created"
+                  defaultMessage="Group members are editable after creation"
                 />
               </Typography>
             </Box>

--- a/ui/app/src/components/LoggingLevelsManagement/LoggingLevelsManagement.tsx
+++ b/ui/app/src/components/LoggingLevelsManagement/LoggingLevelsManagement.tsx
@@ -19,17 +19,26 @@ import { Logger, LoggerLevel } from '../../models/Logger';
 import ApiResponse from '../../models/ApiResponse';
 import { fetchLoggers as fetchLoggersService, setLogger } from '../../services/logs';
 import GlobalAppToolbar from '../GlobalAppToolbar';
-import { FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useLogicResource } from '../../utils/hooks';
 import { SuspenseWithEmptyState } from '../SystemStatus/Suspencified';
 import LoggingLevelsGridUI, { LoggingLevelsGridSkeletonTable } from '../LoggingLevelsGrid';
 import { useDispatch } from 'react-redux';
 import { showErrorDialog } from '../../state/reducers/dialogs/error';
+import { showSystemNotification } from '../../state/actions/system';
+
+const messages = defineMessages({
+  levelChangedSuccess: {
+    id: 'loggingLevelsManagement.levelChangedSuccessMessage',
+    defaultMessage: 'Logging level changed successfully'
+  }
+});
 
 export default function LoggingLevelsManagement() {
   const [fetching, setFetching] = useState(false);
   const [loggers, setLoggers] = useState<Array<Logger>>(null);
   const [error, setError] = useState<ApiResponse>();
+  const { formatMessage } = useIntl();
   const dispatch = useDispatch();
 
   const fetchLoggers = useCallback(() => {
@@ -51,10 +60,15 @@ export default function LoggingLevelsManagement() {
   }, [fetchLoggers]);
 
   const changeLevel = (logger: Logger, level: LoggerLevel) => {
-    logger.level = level;
     setLogger(logger.name, level).subscribe(
       () => {
         fetchLoggers();
+        dispatch(
+          showSystemNotification({
+            message: formatMessage(messages.levelChangedSuccess),
+            options: { variant: 'success' }
+          })
+        );
       },
       (response) => {
         dispatch(showErrorDialog({ error: response }));
@@ -75,7 +89,9 @@ export default function LoggingLevelsManagement() {
 
   return (
     <section>
-      <GlobalAppToolbar title={<FormattedMessage id="GlobalMenu.Users" defaultMessage="Logging Levels" />} />
+      <GlobalAppToolbar
+        title={<FormattedMessage id="GlobalMenu.LoggingLevelsEntryLabel" defaultMessage="Logging Levels" />}
+      />
       <SuspenseWithEmptyState
         resource={resource}
         suspenseProps={{

--- a/ui/app/src/components/PreviewAddressBar/PreviewAddressBar.tsx
+++ b/ui/app/src/components/PreviewAddressBar/PreviewAddressBar.tsx
@@ -33,6 +33,14 @@ import { DetailedItem } from '../../models/Item';
 import ActionsGroup from '../ActionsGroup';
 import Skeleton from '@material-ui/lab/Skeleton';
 
+export interface AddressBarProps {
+  site: string;
+  url: string;
+  item?: DetailedItem;
+  onUrlChange: (value: string) => any;
+  onRefresh: (e) => any;
+}
+
 const useAddressBarStyles = makeStyles((theme: Theme) =>
   createStyles({
     toolbar: {
@@ -101,14 +109,6 @@ const translations = defineMessages({
   }
 });
 
-export interface AddressBarProps {
-  site: string;
-  url: string;
-  item?: DetailedItem;
-  onUrlChange: (value: string) => any;
-  onRefresh: (e) => any;
-}
-
 export function AddressBar(props: AddressBarProps) {
   const classes = useAddressBarStyles();
   const { formatMessage } = useIntl();
@@ -146,7 +146,19 @@ export function AddressBar(props: AddressBarProps) {
       clipboard,
       event
     });
-  const actions = generateSingleItemOptions(item, formatMessage)?.flatMap((options) => options);
+  const actions = generateSingleItemOptions(item, formatMessage, {
+    includeOnly: [
+      'edit',
+      'delete',
+      'dependencies',
+      'history',
+      'publish',
+      'approvePublish',
+      'schedulePublish',
+      'rejectPublish',
+      'duplicate'
+    ]
+  })?.flatMap((options) => options);
 
   return (
     <>

--- a/ui/app/src/components/TransferList/TransferList.tsx
+++ b/ui/app/src/components/TransferList/TransferList.tsx
@@ -23,6 +23,7 @@ import useStyles from './styles';
 import { createLookupTable } from '../../utils/object';
 import TransferListColumn, { TransferListItem } from '../TransferListColumn';
 import { FormattedMessage } from 'react-intl';
+import Tooltip from '@material-ui/core/Tooltip';
 
 export interface TransferListProps {
   source: TransferListObject;
@@ -34,6 +35,7 @@ export interface TransferListProps {
 
 export interface TransferListObject {
   title?: ReactNode;
+  emptyMessage?: ReactNode;
   items: TransferListItem[];
 }
 
@@ -83,33 +85,32 @@ export default function TransferList(props: TransferListProps) {
     );
   };
 
-  const moveLeftToRight = () => {
+  const addToTarget = () => {
     const nextCheckedList = {};
     const leftCheckedItems = getChecked(sourceItems);
-
-    leftCheckedItems.forEach((item) => {
-      nextCheckedList[item.id] = false;
-    });
-
-    setCheckedList({ ...checkedList, ...nextCheckedList });
-    setSourceItems(not(sourceItems, leftCheckedItems));
-    setTargetItems([...targetItems, ...leftCheckedItems]);
-    onTargetListItemsAdded(leftCheckedItems);
+    if (leftCheckedItems.length) {
+      leftCheckedItems.forEach((item) => (nextCheckedList[item.id] = false));
+      setCheckedList({ ...checkedList, ...nextCheckedList });
+      setSourceItems(not(sourceItems, leftCheckedItems));
+      setTargetItems([...targetItems, ...leftCheckedItems]);
+      onTargetListItemsAdded(leftCheckedItems);
+    }
   };
 
-  const moveRightToLeft = () => {
+  const removeFromTarget = () => {
     const nextCheckedList = {};
     const rightCheckedItems = getChecked(targetItems);
-
-    rightCheckedItems.forEach((item) => {
-      nextCheckedList[item.id] = false;
-    });
-
-    setCheckedList({ ...checkedList, ...nextCheckedList });
-    setTargetItems(not(targetItems, rightCheckedItems));
-    setSourceItems([...sourceItems, ...rightCheckedItems]);
-    onTargetListItemsRemoved(rightCheckedItems);
+    if (rightCheckedItems.length) {
+      rightCheckedItems.forEach((item) => (nextCheckedList[item.id] = false));
+      setCheckedList({ ...checkedList, ...nextCheckedList });
+      setTargetItems(not(targetItems, rightCheckedItems));
+      setSourceItems([...sourceItems, ...rightCheckedItems]);
+      onTargetListItemsRemoved(rightCheckedItems);
+    }
   };
+
+  const disableAdd = getChecked(sourceItems).length === 0;
+  const disableRemove = getChecked(targetItems).length === 0;
 
   const isAllChecked = useCallback(
     (items: TransferListItem[]) => {
@@ -143,20 +144,45 @@ export default function TransferList(props: TransferListProps) {
         onItemClick={onItemClicked}
         isAllChecked={sourceItemsAllChecked}
         inProgressIds={inProgressIds}
-        emptyStateMessage={
-          <FormattedMessage
-            id="transferList.sourceEmptyStateMessage"
-            defaultMessage="All users are members of this group"
-          />
-        }
+        emptyStateMessage={source.emptyMessage}
       />
       <section className={classes.buttonsWrapper}>
-        <IconButton onClick={moveLeftToRight}>
-          <NavigateNextIcon />
-        </IconButton>
-        <IconButton onClick={moveRightToLeft}>
-          <NavigateBeforeIcon />
-        </IconButton>
+        <Tooltip
+          title={
+            disableAdd ? (
+              <FormattedMessage
+                id="transferList.addDisabledTooltip"
+                defaultMessage="Select items to add from the left"
+              />
+            ) : (
+              <FormattedMessage id="transferList.addToTarget" defaultMessage="Add selected" />
+            )
+          }
+        >
+          <span>
+            <IconButton onClick={addToTarget} disabled={disableAdd}>
+              <NavigateNextIcon />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip
+          title={
+            disableRemove ? (
+              <FormattedMessage
+                id="transferList.removeDisabledTooltip"
+                defaultMessage="Select items to remove from the right"
+              />
+            ) : (
+              <FormattedMessage id="transferList.removeFromTarget" defaultMessage="Remove selected" />
+            )
+          }
+        >
+          <span>
+            <IconButton onClick={removeFromTarget} disabled={disableRemove}>
+              <NavigateBeforeIcon />
+            </IconButton>
+          </span>
+        </Tooltip>
       </section>
       <TransferListColumn
         title={props.target.title}
@@ -166,9 +192,7 @@ export default function TransferList(props: TransferListProps) {
         onItemClick={onItemClicked}
         isAllChecked={targetItemsAllChecked}
         inProgressIds={inProgressIds}
-        emptyStateMessage={
-          <FormattedMessage id="transferList.targetEmptyStateMessage" defaultMessage="No members of this group" />
-        }
+        emptyStateMessage={target.emptyMessage}
       />
     </Box>
   );

--- a/ui/app/src/utils/itemActions.ts
+++ b/ui/app/src/utils/itemActions.ts
@@ -105,6 +105,7 @@ import {
 import { isNavigable } from '../components/PathNavigator/utils';
 import React from 'react';
 import { previewItem } from '../state/actions/preview';
+import { createPresenceTable } from './array';
 
 export type ContextMenuOptionDescriptor = { id: string; label: MessageDescriptor; values?: any };
 
@@ -283,6 +284,10 @@ const unparsedMenuOptions: Record<AllItemActions, ContextMenuOptionDescriptor> =
   // endregion
 };
 
+// `unparsedMenuOptions` is just used as a convenient way of dynamically getting all the actions,
+// not using it for any other reason other than getting the full list of item actions.
+export const allItemActions = Object.keys(unparsedMenuOptions);
+
 export function toContextMenuOptionsLookup<Keys extends string = AllItemActions>(
   menuOptionDescriptors: Record<Keys, ContextMenuOptionDescriptor>,
   formatMessage: IntlFormatters['formatMessage']
@@ -298,10 +303,16 @@ export function toContextMenuOptionsLookup<Keys extends string = AllItemActions>
 export function generateSingleItemOptions(
   item: DetailedItem,
   formatMessage: IntlFormatters['formatMessage'],
-  options?: {
+  options?: Partial<{
     hasClipboard: boolean;
-  }
+    includeOnly: AllItemActions[];
+  }>
 ): ContextMenuOption[][] {
+  const actionsToInclude = createPresenceTable(options?.includeOnly ?? allItemActions) as Record<
+    AllItemActions,
+    boolean
+  >;
+
   let sections: ContextMenuOption[][] = [];
   let sectionA: ContextMenuOption[] = [];
   let sectionB: ContextMenuOption[] = [];
@@ -322,41 +333,41 @@ export function generateSingleItemOptions(
   );
 
   // region Section A
-  if (hasEditAction(item.availableActions)) {
+  if (hasEditAction(item.availableActions) && actionsToInclude.edit) {
     if (['page', 'component', 'taxonomy', 'levelDescriptor'].includes(type)) {
       sectionA.push(menuOptions.edit);
     } else {
       sectionA.push(menuOptions.editCode);
     }
   }
-  if (hasCreateAction(item.availableActions)) {
+  if (hasCreateAction(item.availableActions) && actionsToInclude.createContent) {
     sectionA.push(menuOptions.createContent);
   }
-  if (hasUploadAction(item.availableActions)) {
+  if (hasUploadAction(item.availableActions) && actionsToInclude.upload) {
     sectionB.push(menuOptions.upload);
   }
-  if (hasCreateFolderAction(item.availableActions)) {
+  if (hasCreateFolderAction(item.availableActions) && actionsToInclude.createFolder) {
     sectionA.push(menuOptions.createFolder);
   }
-  if (hasContentDeleteAction(item.availableActions)) {
+  if (hasContentDeleteAction(item.availableActions) && actionsToInclude.delete) {
     sectionA.push(menuOptions.delete);
   }
-  if (hasGetDependenciesAction(item.availableActions)) {
+  if (hasGetDependenciesAction(item.availableActions) && actionsToInclude.dependencies) {
     sectionA.push(menuOptions.dependencies);
   }
-  if (hasRenameAction(item.availableActions)) {
+  if (hasRenameAction(item.availableActions) && actionsToInclude.rename) {
     sectionA.push(menuOptions.rename);
   }
-  if (hasReadHistoryAction(item.availableActions)) {
+  if (hasReadHistoryAction(item.availableActions) && actionsToInclude.history) {
     sectionA.push(menuOptions.history);
   }
-  if (hasChangeTypeAction(item.availableActions)) {
+  if (hasChangeTypeAction(item.availableActions) && actionsToInclude.changeContentType) {
     sectionA.push(menuOptions.changeContentType);
   }
-  if (isNavigable(item)) {
+  if (isNavigable(item) && actionsToInclude.preview) {
     sectionA.push(menuOptions.preview);
   }
-  if (hasReadAction(item.availableActions)) {
+  if (hasReadAction(item.availableActions) && actionsToInclude.view) {
     if (['page', 'component', 'taxonomy', 'levelDescriptor'].includes(type)) {
       sectionA.push(menuOptions.view);
     } else if (isImage) {
@@ -368,16 +379,16 @@ export function generateSingleItemOptions(
   // endregion
 
   // region Section B
-  if (hasCutAction(item.availableActions)) {
+  if (hasCutAction(item.availableActions) && actionsToInclude.cut) {
     sectionB.push(menuOptions.cut);
   }
-  if (hasCopyAction(item.availableActions)) {
+  if (hasCopyAction(item.availableActions) && actionsToInclude.copy) {
     sectionB.push(menuOptions.copy);
   }
-  if (hasPasteAction(item.availableActions) && options?.hasClipboard) {
+  if (hasPasteAction(item.availableActions) && options?.hasClipboard && actionsToInclude.paste) {
     sectionB.push(menuOptions.paste);
   }
-  if (hasDuplicateAction(item.availableActions)) {
+  if (hasDuplicateAction(item.availableActions) && actionsToInclude.duplicate) {
     if (['page', 'component', 'taxonomy', 'levelDescriptor'].includes(type)) {
       sectionB.push(menuOptions.duplicate);
     } else {
@@ -387,40 +398,40 @@ export function generateSingleItemOptions(
   // endregion
 
   // region Section C
-  if (hasPublishAction(item.availableActions)) {
+  if (hasPublishAction(item.availableActions) && actionsToInclude.publish) {
     sectionC.push(menuOptions.publish);
   }
-  if (hasPublishRequestAction(item.availableActions)) {
+  if (hasPublishRequestAction(item.availableActions) && actionsToInclude.requestPublish) {
     sectionC.push(menuOptions.requestPublish);
   }
-  if (hasApprovePublishAction(item.availableActions)) {
+  if (hasApprovePublishAction(item.availableActions) && actionsToInclude.approvePublish) {
     sectionC.push(menuOptions.approvePublish);
   }
-  if (hasSchedulePublishAction(item.availableActions)) {
+  if (hasSchedulePublishAction(item.availableActions) && actionsToInclude.schedulePublish) {
     sectionC.push(menuOptions.schedulePublish);
   }
-  if (hasPublishRejectAction(item.availableActions)) {
+  if (hasPublishRejectAction(item.availableActions) && actionsToInclude.rejectPublish) {
     sectionC.push(menuOptions.rejectPublish);
   }
   // endregion
 
   // region Section D
-  if (hasEditControllerAction(item.availableActions)) {
+  if (hasEditControllerAction(item.availableActions) && actionsToInclude.editController) {
     sectionD.push(menuOptions.editController);
   }
-  if (hasDeleteControllerAction(item.availableActions)) {
+  if (hasDeleteControllerAction(item.availableActions) && actionsToInclude.deleteController) {
     sectionD.push(menuOptions.deleteController);
   }
-  if (hasEditTemplateAction(item.availableActions)) {
+  if (hasEditTemplateAction(item.availableActions) && actionsToInclude.editTemplate) {
     sectionD.push(menuOptions.editTemplate);
   }
-  if (hasDeleteTemplateAction(item.availableActions)) {
+  if (hasDeleteTemplateAction(item.availableActions) && actionsToInclude.deleteTemplate) {
     sectionD.push(menuOptions.deleteTemplate);
   }
-  if (hasCreateAction(item.availableActions) && isTemplate) {
+  if (isTemplate && hasCreateAction(item.availableActions) && actionsToInclude.createTemplate) {
     sectionD.push(menuOptions.createTemplate);
   }
-  if (hasCreateAction(item.availableActions) && isController) {
+  if (isController && hasCreateAction(item.availableActions) && actionsToInclude.createController) {
     sectionD.push(menuOptions.createController);
   }
   // endregion


### PR DESCRIPTION
- [4657] Reactify Global App (Logging Levels)
  - Fix translation key, add success notification to level changes
- Implement ability to include/exclude only certain actions in the computed list of available actions of an item
  - Use `includeOnly` argument on the context nav to make it more manageable as well as consistent with the actions that are shown in the 3.x UI
- [4657] Reactify GlobalApp (Groups)
  - EditGroup dialog usability
  - Fix incorrect component defaults and options
  - Language and copy adjustments
  - Bug fixes

craftercms/craftercms#4657