### PR TITLE
[4322][3.1.x] Bugfix/bulk upload nested failed

### DIFF
--- a/ui/app/src/components/BulkUpload.tsx
+++ b/ui/app/src/components/BulkUpload.tsx
@@ -352,8 +352,8 @@ const DropZone = React.forwardRef((props: DropZoneProps, ref: any) => {
       });
   }
 
-  function checkFileExist(newFile: File) {
-    return !uppy.getFiles().some((file) => file.name === newFile.name && file.type === newFile.type);
+  function checkFileExist(newFile: File & { relativePath?: string }) {
+    return !uppy.getFiles().some((file) => file.meta.relativePath === newFile.relativePath && file.type === newFile.type);
   }
 
   function removeDragData(event: React.DragEvent<HTMLElement>) {


### PR DESCRIPTION
A suggestion fix for issue https://github.com/craftercms/craftercms/issues/4322

While checking file existing, we are checking filename which is not correct for nested structure. Better to use relativePath to identify file with same name but different path.
