### PR TITLE
Content form engine opened thorough new content option can't be close. #4758

### DIFF
--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1710,6 +1710,8 @@ var CStudioForms =
                         }
                       }
                     });
+                } else {
+                  CStudioAuthoring.InContextEdit.unstackDialog(editorId);
                 }
               }
             }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4758