### PR TITLE
Update legacy item parse functions

### DIFF
--- a/ui/app/src/components/ItemPublishingTargetIcon/ItemPublishingTargetIcon.tsx
+++ b/ui/app/src/components/ItemPublishingTargetIcon/ItemPublishingTargetIcon.tsx
@@ -44,13 +44,13 @@ const useStyles = makeStyles(() =>
       color: palette.gray.medium2,
       ...styles.root
     }),
-    publishingTargetLive: (styles) => ({
-      color: palette.green.main,
-      ...styles.publishingTargetLive
-    }),
     publishingTargetStaged: (styles) => ({
       color: palette.blue.main,
       ...styles.publishingTargetStaged
+    }),
+    publishingTargetLive: (styles) => ({
+      color: palette.green.main,
+      ...styles.publishingTargetLive
     }),
     publishingIcon: (styles) => ({
       ...styles.publishingIcon

--- a/ui/app/src/components/ItemPublishingTargetIcon/ItemPublishingTargetIcon.tsx
+++ b/ui/app/src/components/ItemPublishingTargetIcon/ItemPublishingTargetIcon.tsx
@@ -44,13 +44,13 @@ const useStyles = makeStyles(() =>
       color: palette.gray.medium2,
       ...styles.root
     }),
-    publishingTargetStaged: (styles) => ({
-      color: palette.blue.main,
-      ...styles.publishingTargetStaged
-    }),
     publishingTargetLive: (styles) => ({
       color: palette.green.main,
       ...styles.publishingTargetLive
+    }),
+    publishingTargetStaged: (styles) => ({
+      color: palette.blue.main,
+      ...styles.publishingTargetStaged
     }),
     publishingIcon: (styles) => ({
       ...styles.publishingIcon
@@ -70,8 +70,11 @@ export default function ItemPublishingTargetIcon(props: ItemPublishingTargetIcon
           classes.publishingIcon,
           propClasses?.root,
           className,
-          item.stateMap.live && classes.publishingTargetLive,
-          item.stateMap.staged && classes.publishingTargetStaged
+          item.stateMap.live
+            ? classes.publishingTargetLive
+            : item.stateMap.staged
+            ? classes.publishingTargetStaged
+            : false
         )}
       />
     </Tooltip>

--- a/ui/app/src/components/ItemStatesManagement/ItemStatesManagement.tsx
+++ b/ui/app/src/components/ItemStatesManagement/ItemStatesManagement.tsx
@@ -28,7 +28,7 @@ import FilterListRoundedIcon from '@material-ui/icons/FilterListRounded';
 import { useStyles } from './styles';
 import LookupTable from '../../models/LookupTable';
 import { createPresenceTable } from '../../utils/array';
-import { getStateMask } from './utils';
+import { getStateBitmap } from './utils';
 import { ItemStateMap, SandboxItem } from '../../models/Item';
 import { PagedArray } from '../../models/PagedArray';
 import Box from '@material-ui/core/Box';
@@ -86,10 +86,10 @@ export default function ItemStatesManagement(props: ItemStatesManagementProps) {
   const rootRef = useRef<HTMLDivElement>();
 
   const fetchStates = useCallback(() => {
-    let stateMask = getStateMask(filtersLookup as ItemStateMap);
+    let stateBitmap = getStateBitmap(filtersLookup as ItemStateMap);
 
     setFetching(true);
-    fetchItemStates(siteId, debouncePathRegex, stateMask ? stateMask : null, { limit, offset }).subscribe(
+    fetchItemStates(siteId, debouncePathRegex, stateBitmap ? stateBitmap : null, { limit, offset }).subscribe(
       (states) => {
         setItems(states);
         setFetching(false);
@@ -221,8 +221,8 @@ export default function ItemStatesManagement(props: ItemStatesManagementProps) {
         fetchStates();
       });
     } else if (isSelectedItemsOnAllPages) {
-      let stateMask = getStateMask(filtersLookup as ItemStateMap);
-      setItemStatesByQuery(siteId, stateMask ? stateMask : null, update, debouncePathRegex).subscribe(() => {
+      let stateBitmap = getStateBitmap(filtersLookup as ItemStateMap);
+      setItemStatesByQuery(siteId, stateBitmap ? stateBitmap : null, update, debouncePathRegex).subscribe(() => {
         fetchStates();
       });
     } else {

--- a/ui/app/src/components/ItemStatesManagement/utils.tsx
+++ b/ui/app/src/components/ItemStatesManagement/utils.tsx
@@ -27,7 +27,7 @@ import {
   STATE_SYSTEM_PROCESSING_MASK
 } from '../../utils/constants';
 
-export function getStateMask(stateMap: ItemStateMap): number {
+export function getStateBitmap(stateMap: ItemStateMap): number {
   let mask = 0;
   if (stateMap.new) {
     mask += STATE_NEW_MASK;

--- a/ui/app/src/utils/content.ts
+++ b/ui/app/src/utils/content.ts
@@ -64,6 +64,7 @@ import {
   STATE_TRANSLATION_UP_TO_DATE_MASK
 } from './constants';
 import { SystemType } from '../models/SystemType';
+import { getStateBitmap } from '../components/ItemStatesManagement/utils';
 
 export function isEditableAsset(path: string) {
   return (
@@ -195,6 +196,8 @@ function getLegacyItemSystemType(item: LegacyItem): SystemType {
 }
 
 export function parseLegacyItemToBaseItem(item: LegacyItem): BaseItem {
+  const stateMap = getStateMapFromLegacyItem(item);
+  const state = getStateBitmap(stateMap);
   return {
     id: item.uri ?? item.path,
     label: item.internalName ?? item.name,
@@ -205,14 +208,14 @@ export function parseLegacyItemToBaseItem(item: LegacyItem): BaseItem {
     previewUrl: item.uri?.includes('index.xml') ? item.browserUri || '/' : null,
     systemType: getLegacyItemSystemType(item),
     mimeType: item.mimeType,
-    state: null,
-    stateMap: getStateMapFromLegacyItem(item),
+    state,
+    stateMap,
     lockOwner: null,
     disabled: null,
     localeCode: 'en',
     translationSourceId: null,
-    availableActions: 0,
-    availableActionsMap: {} as ItemActionsMap
+    availableActions: null,
+    availableActionsMap: null
   };
 }
 

--- a/ui/app/src/utils/content.ts
+++ b/ui/app/src/utils/content.ts
@@ -229,7 +229,7 @@ export function parseLegacyItemToSandBoxItem(item: LegacyItem | LegacyItem[]): S
     creator: null,
     dateCreated: null,
     modifier: item.user,
-    dateModified: null,
+    dateModified: item.lastEditDate,
     commitId: null,
     sizeInBytes: null
   };
@@ -249,7 +249,7 @@ export function parseLegacyItemToDetailedItem(item: LegacyItem | LegacyItem[]): 
       creator: null,
       dateCreated: null,
       modifier: item.user,
-      dateModified: null,
+      dateModified: item.lastEditDate,
       commitId: null,
       sizeInBytes: null
     },

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -29,11 +29,11 @@ export function getStoredGlobalMenuSiteViewPreference(user: string): 'grid' | 'l
 
 export function getStateMapFromLegacyItem(item: LegacyItem): ItemStateMap {
   return {
-    live: false,
+    live: item.endpoint === 'live',
     locked: false,
     modified: false,
-    new: false,
-    staged: false,
+    new: item.isNew,
+    staged: item.endpoint === 'live' || item.endpoint === 'staged',
     systemProcessing: false,
     translationInProgress: false,
     translationPending: false,

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -30,8 +30,8 @@ export function getStoredGlobalMenuSiteViewPreference(user: string): 'grid' | 'l
 export function getStateMapFromLegacyItem(item: LegacyItem): ItemStateMap {
   return {
     live: item.endpoint === 'live',
-    locked: false,
-    modified: false,
+    locked: Boolean(item.lockOwner),
+    modified: item.isInProgress,
     new: item.isNew,
     staged: item.endpoint === 'live' || item.endpoint === 'staged',
     systemProcessing: false,


### PR DESCRIPTION
- Update legacy item parse functions
 - Move staged style in ItemPublishingTargetIcon before the live style for live to have higher precedence (when both live and staged are true)
