### PR TITLE
[4806] Utilise "ICE Groups" to open specific pieces of a content form

### DIFF
--- a/ui/app/src/modules/Preview/Tools/EditFormPanel.tsx
+++ b/ui/app/src/modules/Preview/Tools/EditFormPanel.tsx
@@ -194,7 +194,7 @@ function EditFormPanelBody(props: EditFormPanelBodyProps) {
   function openDialog(type: string) {
     onDismiss();
     if (type === 'form') {
-      const selectedFields = field ? [field.id] : null;
+      const selectedFields = selected[0] && selected[0].fieldId.length > 0 ? selected[0].fieldId : null;
       dispatch(
         showEditDialog(
           getEditDialogProps({ authoringBase, childrenMap, model, models, path, selectedFields, selectedId, site })

--- a/ui/app/src/modules/Preview/Tools/EditFormPanel.tsx
+++ b/ui/app/src/modules/Preview/Tools/EditFormPanel.tsx
@@ -194,7 +194,7 @@ function EditFormPanelBody(props: EditFormPanelBodyProps) {
   function openDialog(type: string) {
     onDismiss();
     if (type === 'form') {
-      const selectedFields = selected[0] && selected[0].fieldId.length > 0 ? selected[0].fieldId : null;
+      const selectedFields = selected[0]?.fieldId.length ? selected[0].fieldId : null;
       dispatch(
         showEditDialog(
           getEditDialogProps({ authoringBase, childrenMap, model, models, path, selectedFields, selectedId, site })


### PR DESCRIPTION
Update to open all selected fields (when multiple in one zone)

https://github.com/craftercms/craftercms/issues/4806