### PR TITLE
[studio-ui] 4.0.0/stability

### DIFF
--- a/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
+++ b/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
@@ -50,8 +50,10 @@ export interface CodeEditorDialogStateProps extends CodeEditorDialogBaseProps {
   onDismiss?: StandardAction;
 }
 
+export const codeEditorId = 'code-editor';
+
 export default function CodeEditorDialog(props: CodeEditorDialogProps) {
-  const id = 'code-editor';
+  const id = codeEditorId;
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
   const { open, mode, pendingChanges, path, readonly, contentType, onClosed, onClose, onSuccess, ...rest } = props;

--- a/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
+++ b/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
@@ -54,7 +54,7 @@ export default function CodeEditorDialog(props: CodeEditorDialogProps) {
   const id = 'code-editor';
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
-  const { open, mode, pendingChanges, path, readonly, contentType, onClosed, onSuccess, ...rest } = props;
+  const { open, mode, pendingChanges, path, readonly, contentType, onClosed, onClose, onSuccess, ...rest } = props;
 
   const title = formatMessage(translations.title);
 
@@ -68,7 +68,7 @@ export default function CodeEditorDialog(props: CodeEditorDialogProps) {
     dispatch(minimizeDialog({ id }));
   };
 
-  const onClose = () => {
+  const onDialogClose = () => {
     if (readonly) {
       props.onClose();
       return;
@@ -92,8 +92,8 @@ export default function CodeEditorDialog(props: CodeEditorDialogProps) {
   };
 
   return (
-    <Dialog open={open && !minimized} keepMounted={minimized} onClose={onClose} fullWidth maxWidth="xl" {...rest}>
-      <CodeEditorDialogContainer {...props} onClose={onClose} title={title} onMinimized={onMinimized} />
+    <Dialog open={open && !minimized} keepMounted={minimized} onClose={onDialogClose} fullWidth maxWidth="xl" {...rest}>
+      <CodeEditorDialogContainer {...props} onClose={onDialogClose} title={title} onMinimized={onMinimized} />
     </Dialog>
   );
 }

--- a/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
+++ b/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
@@ -94,7 +94,7 @@ export default function CodeEditorDialog(props: CodeEditorDialogProps) {
   };
 
   return (
-    <Dialog open={open && !minimized} keepMounted={minimized} onClose={onDialogClose} fullWidth maxWidth="xl" {...rest}>
+    <Dialog fullWidth maxWidth="xl" {...rest} open={open && !minimized} keepMounted={minimized} onClose={onDialogClose}>
       <CodeEditorDialogContainer {...props} onClose={onDialogClose} title={title} onMinimized={onMinimized} />
     </Dialog>
   );

--- a/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
+++ b/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
@@ -87,7 +87,7 @@ export default function CodeEditorDialog(props: CodeEditorDialogProps) {
       );
     } else {
       dispatch(conditionallyUnlockItem({ path: props.path }));
-      props.onClose();
+      onClose();
     }
   };
 

--- a/ui/app/src/components/Controls/SearchBar.tsx
+++ b/ui/app/src/components/Controls/SearchBar.tsx
@@ -74,7 +74,7 @@ const useStyles = makeStyles((theme: Theme) =>
 const messages = defineMessages({
   placeholder: {
     id: 'searchBar.placeholder',
-    defaultMessage: 'Search...'
+    defaultMessage: 'Filter...'
   }
 });
 

--- a/ui/app/src/components/Dialogs/LegacyFormDialog.tsx
+++ b/ui/app/src/components/Dialogs/LegacyFormDialog.tsx
@@ -292,8 +292,10 @@ const EmbeddedLegacyEditor = React.forwardRef(function EmbeddedLegacyEditor(prop
   );
 });
 
+export const legacyEditorId = 'legacy-editor';
+
 export default function LegacyFormDialog(props: LegacyFormDialogProps) {
-  const id = 'legacy-editor';
+  const id = legacyEditorId;
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
   const classes = styles();

--- a/ui/app/src/components/EditGroupDialog/EditGroupDialog.tsx
+++ b/ui/app/src/components/EditGroupDialog/EditGroupDialog.tsx
@@ -17,22 +17,45 @@
 import React, { useState } from 'react';
 import Dialog from '@material-ui/core/Dialog';
 import EditGroupDialogContainer, { EditGroupDialogContainerProps } from './EditGroupDialogContainer';
+import { FormattedMessage } from 'react-intl';
+import ConfirmDialog from '../Dialogs/ConfirmDialog';
 
-export interface EditGroupDialogProps extends Omit<EditGroupDialogContainerProps, 'setDisableBackdropClick'> {}
+export interface EditGroupDialogProps extends Omit<EditGroupDialogContainerProps, 'setPendingChanges'> {
+  open: boolean;
+}
 
 export default function EditGroupDialog(props: EditGroupDialogProps) {
-  const { open, onClose } = props;
-  const [disableBackdropClick, setDisableBackdropClick] = useState(false);
+  const { open, onClose, ...rest } = props;
+  const [pendingChanges, setPendingChanges] = useState(false);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+  const onDialogClose = () => {
+    if (pendingChanges) {
+      setShowConfirmDialog(true);
+    } else {
+      onClose();
+    }
+  };
+
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      fullWidth
-      maxWidth="md"
-      disableBackdropClick={disableBackdropClick}
-      disableEscapeKeyDown={disableBackdropClick}
-    >
-      <EditGroupDialogContainer setDisableBackdropClick={setDisableBackdropClick} {...props} />
-    </Dialog>
+    <>
+      <Dialog open={open} onClose={onDialogClose} fullWidth maxWidth="md">
+        <EditGroupDialogContainer onClose={onDialogClose} setPendingChanges={setPendingChanges} {...rest} />
+      </Dialog>
+      <ConfirmDialog
+        open={showConfirmDialog}
+        title={
+          <FormattedMessage
+            id="editGroupDialog.pendingChangesConfirmation"
+            defaultMessage="Close without saving changes?"
+          />
+        }
+        onOk={() => {
+          setShowConfirmDialog(false);
+          onClose();
+        }}
+        onCancel={() => setShowConfirmDialog(false)}
+      />
+    </>
   );
 }

--- a/ui/app/src/components/EditGroupDialog/EditGroupDialog.tsx
+++ b/ui/app/src/components/EditGroupDialog/EditGroupDialog.tsx
@@ -33,6 +33,7 @@ export default function EditGroupDialog(props: EditGroupDialogProps) {
     if (pendingChanges) {
       setShowConfirmDialog(true);
     } else {
+      setPendingChanges(false);
       onClose();
     }
   };
@@ -52,6 +53,7 @@ export default function EditGroupDialog(props: EditGroupDialogProps) {
         }
         onOk={() => {
           setShowConfirmDialog(false);
+          setPendingChanges(false);
           onClose();
         }}
         onCancel={() => setShowConfirmDialog(false)}

--- a/ui/app/src/components/EditGroupDialog/EditGroupDialogContainer.tsx
+++ b/ui/app/src/components/EditGroupDialog/EditGroupDialogContainer.tsx
@@ -154,6 +154,7 @@ export default function EditGroupDialogContainer(props: EditGroupDialogContainer
   };
 
   const onChangeValue = (property: { key: string; value: string }) => {
+    console.log('asd');
     setIsDirty(true);
     setGroup({ [property.key]: property.value });
     setPendingChanges(Boolean(group[property.key === 'name' ? 'desc' : 'name'] || property.value));

--- a/ui/app/src/components/EditGroupDialog/EditGroupDialogContainer.tsx
+++ b/ui/app/src/components/EditGroupDialog/EditGroupDialogContainer.tsx
@@ -37,13 +37,12 @@ import { useUnmount } from '../../utils/hooks/useUnmount';
 import { useSpreadState } from '../../utils/hooks/useSpreadState';
 
 export interface EditGroupDialogContainerProps {
-  open: boolean;
   group?: Group;
   onClose(): void;
   onClosed?(): void;
   onGroupSaved(group: Group): void;
   onGroupDeleted(group: Group): void;
-  setDisableBackdropClick?(disabled: boolean): void;
+  setPendingChanges?(disabled: boolean): void;
 }
 
 const translations = defineMessages({
@@ -70,7 +69,7 @@ const translations = defineMessages({
 });
 
 export default function EditGroupDialogContainer(props: EditGroupDialogContainerProps) {
-  const { onClose, onGroupSaved, onGroupDeleted, onClosed, setDisableBackdropClick = () => void 0 } = props;
+  const { onClose, onGroupSaved, onGroupDeleted, onClosed, setPendingChanges = () => void 0 } = props;
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
 
@@ -157,7 +156,7 @@ export default function EditGroupDialogContainer(props: EditGroupDialogContainer
   const onChangeValue = (property: { key: string; value: string }) => {
     setIsDirty(true);
     setGroup({ [property.key]: property.value });
-    setDisableBackdropClick(Boolean(group[property.key === 'name' ? 'desc' : 'name'] || property.value));
+    setPendingChanges(Boolean(group[property.key === 'name' ? 'desc' : 'name'] || property.value));
   };
 
   const onSave = () => {

--- a/ui/app/src/components/PreviewSearchPanel/PreviewSearchPanel.tsx
+++ b/ui/app/src/components/PreviewSearchPanel/PreviewSearchPanel.tsx
@@ -52,7 +52,7 @@ import { useSubject } from '../../utils/hooks/useSubject';
 const translations = defineMessages({
   previewSearchPanelTitle: {
     id: 'previewSearchPanel.title',
-    defaultMessage: 'Search...'
+    defaultMessage: 'Search'
   },
   previousPage: {
     id: 'pagination.previousPage',

--- a/ui/app/src/components/PreviewSearchPanel/PreviewSearchPanel.tsx
+++ b/ui/app/src/components/PreviewSearchPanel/PreviewSearchPanel.tsx
@@ -52,7 +52,7 @@ import { useSubject } from '../../utils/hooks/useSubject';
 const translations = defineMessages({
   previewSearchPanelTitle: {
     id: 'previewSearchPanel.title',
-    defaultMessage: 'Search'
+    defaultMessage: 'Search...'
   },
   previousPage: {
     id: 'pagination.previousPage',

--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -326,7 +326,7 @@ export function PreviewConcierge(props: any) {
   }, [items[currentItemPath], editMode, user.username]);
   useEffect(() => {
     if (currentItemPath && site) {
-      dispatch(fetchSandboxItem({ path: currentItemPath }));
+      dispatch(fetchSandboxItem({ path: currentItemPath, force: true }));
     }
   }, [dispatch, currentItemPath, site]);
 


### PR DESCRIPTION
- Renaming default SearchBar placeholder to 'Filter...'
- Force item to re-fetch when the page refresh
- Calling onClose when CodeEditorDialog backdrop click or esc keydown
- Adding confirm dialog to EditGroupDialog.tsx
- Fixing issues related with opening more of one form/code-editor dialogs