### PR TITLE
[ #4840] Login screen select back English does not work

### DIFF
--- a/ui/app/src/components/SystemStatus/LoginView.tsx
+++ b/ui/app/src/components/SystemStatus/LoginView.tsx
@@ -478,6 +478,7 @@ function LanguageDropDown(props: LanguageDropDownProps) {
       <Menu
         anchorEl={buttonRef.current}
         anchorOrigin={{ horizontal: 'center', vertical: 'center' }}
+        getContentAnchorEl={null}
         open={openMenu}
         onClose={() => setOpenMenu(false)}
       >

--- a/ui/app/src/utils/i18n.ts
+++ b/ui/app/src/utils/i18n.ts
@@ -48,6 +48,8 @@ let currentTranslations = bundledTranslations;
 let intl = createIntlInstance(getCurrentLocale());
 
 function createIntlInstance(locale: string): IntlShape {
+  // TODO: Currently old studio UI uses the wrong code for korean
+  locale = locale.replace('kr', 'ko');
   return createIntl(
     {
       locale: locale,


### PR DESCRIPTION
Adding getContentAnchorEl to avoid issues when setting up the anchorOrigin;
Replacing kr to ko, to avoid issues when selecting unknown locale kr

https://github.com/craftercms/craftercms/issues/4840

