### PR TITLE
[4829][3.1.x] Browse interface does not display folders in tree nav with no child items

### DIFF
--- a/static-assets/components/cstudio-browse/browse.js
+++ b/static-assets/components/cstudio-browse/browse.js
@@ -191,7 +191,7 @@
     var parsed = JSON.parse(JSON.stringify(obj), function (key, value) {
       if (key === 'children') {
         $.each(value, function (index, elem) {
-          if (elem.numOfChildren === 0) {
+          if (!elem.folder && elem.numOfChildren === 0) {
             value[index].li_attr = {
               'data-display': 'hidden-node'
             };


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/4829