### PR TITLE
4.0.0/stability

### DIFF
--- a/ui/app/src/components/GlobalAppToolbar/GlobalAppToolbar.tsx
+++ b/ui/app/src/components/GlobalAppToolbar/GlobalAppToolbar.tsx
@@ -113,6 +113,7 @@ const GlobalAppToolbar = React.memo<GlobalAppToolbarProps>(function(props) {
     <ViewToolbar elevation={props.elevation} styles={styles} classes={props.classes}>
       {showHamburgerMenuButton && (
         <LogoAndMenuBundleButton
+          showCrafterIcon={showAppsButton}
           aria-label={formatMessage(translations.toggleSidebar)}
           onClick={() => setState({ openSidebar: !openSidebar })}
         />

--- a/ui/app/src/components/LogoAndMenuBundleButton/LogoAndMenuBundleButton.tsx
+++ b/ui/app/src/components/LogoAndMenuBundleButton/LogoAndMenuBundleButton.tsx
@@ -35,13 +35,19 @@ const useStyles = makeStyles(() =>
 
 export type LogoAndMenuBundleButtonProps = ButtonProps & {
   classes?: ButtonProps['classes'] & Partial<Record<'crafterIcon' | 'menuIcon', string>>;
+  showCrafterIcon?: boolean;
 };
 
 const LogoAndMenuBundleButton = React.forwardRef<HTMLButtonElement, LogoAndMenuBundleButtonProps>(function(props, ref) {
   const classes = useStyles();
+  const { showCrafterIcon = true, ...buttonProps } = props;
   return (
-    <Button ref={ref} {...props}>
-      <CrafterIcon className={clsx(classes.crafterIcon, props.classes?.crafterIcon)} />{' '}
+    <Button ref={ref} {...buttonProps}>
+      {showCrafterIcon && (
+        <>
+          <CrafterIcon className={clsx(classes.crafterIcon, props.classes?.crafterIcon)} />{' '}
+        </>
+      )}
       <MenuRounded className={props.classes?.menuIcon} />
     </Button>
   );

--- a/ui/app/src/components/SiteToolsApp/EmbeddedSiteTools.tsx
+++ b/ui/app/src/components/SiteToolsApp/EmbeddedSiteTools.tsx
@@ -48,7 +48,7 @@ export const EmbeddedSiteToolsContainer = () => {
       imageUrl={`${baseUrl}/static-assets/images/choose_option.svg`}
       hideSidebarSiteSwitcher={true}
       activeToolId={activeToolId}
-      openSidebar={openSidebar}
+      openSidebar={openSidebar || !activeToolId}
       tools={tools}
       classes={{
         root: classes.root

--- a/ui/app/src/state/reducers/uiConfig.ts
+++ b/ui/app/src/state/reducers/uiConfig.ts
@@ -57,7 +57,7 @@ const initialState: GlobalState['uiConfig'] = {
 };
 
 const reducer = createReducer<GlobalState['uiConfig']>(initialState, {
-  [changeSite.type]: (state) => ({ ...initialState }),
+  [changeSite.type]: (state) => ({ ...initialState, useLegacyPreviewLookup: state.useLegacyPreviewLookup }),
   [fetchSiteUiConfig.type]: (state, { payload: { site } }) => ({
     ...state,
     isFetching: true,
@@ -130,7 +130,6 @@ const reducer = createReducer<GlobalState['uiConfig']>(initialState, {
       error: payload
     }
   }),
-  [changeSite.type]: () => initialState,
   [fetchSiteLocale.type]: (state) => ({
     ...state,
     locale: {

--- a/ui/app/src/utils/content.ts
+++ b/ui/app/src/utils/content.ts
@@ -293,7 +293,7 @@ export function parseSandBoxItemToDetailedItem(
 ): DetailedItem | DetailedItem[] {
   if (Array.isArray(item)) {
     // including level descriptors to avoid issues on pathNavigator;
-    return item.map((i) => parseSandBoxItemToDetailedItem(i, detailedItemComplement[i.path]));
+    return item.map((i) => parseSandBoxItemToDetailedItem(i, detailedItemComplement?.[i.path]));
   }
   return {
     sandbox: {


### PR DESCRIPTION
- Fix unable to select site tool on site tools dialog when sidebar collapsed preference is stored to collapsed
- Fix missing handling of null for optional argument on parse sandbox to detailed util
- GlobalAppToolbar to only display crafter icon when the apps (laucher) button is too displayed to be able to address crafter logo shown on the site tools dialog.
- Fix `useLegacyPreviewLookup` getting wiped out on every site change