### PR TITLE
Add locale configuration to blueprints, remove 'default-timezone' from xml and code #4971

### DIFF
--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -6123,7 +6123,7 @@ var nodeOpen = false,
         if (!studioTimeZone) {
           CStudioAuthoring.Service.getConfiguration(CStudioAuthoringContext.site, '/site-config.xml', {
             success: function(config) {
-              studioTimeZone = config['default-timezone'];
+              studioTimeZone = config.locale.dateTimeFormatOptions.timeZone;
             }
           });
         }

--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -6118,12 +6118,12 @@ var nodeOpen = false,
         return scheduledDate;
       },
 
-      // TODO: use locale > dateTimeFormatOptions > timeZone
       getTimeZoneConfig: function() {
         if (!studioTimeZone) {
           CStudioAuthoring.Service.getConfiguration(CStudioAuthoringContext.site, '/site-config.xml', {
             success: function(config) {
-              studioTimeZone = config.locale.dateTimeFormatOptions.timeZone;
+              studioTimeZone =
+                config.locale?.dateTimeFormatOptions?.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
             }
           });
         }
@@ -8056,8 +8056,10 @@ CStudioAuthoring.FilesDiff = {
       CStudioAuthoring.Utils.getTimeZoneConfig();
     };
 
-    CrafterCMSNext.system.getStore().subscribe(() => {
+    CrafterCMSNext.system.getStore().subscribe((store) => {
       getInitialConfiguration();
+
+      console.log('store', store.getState());
     });
   }, w);
 })(window);

--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -8056,7 +8056,7 @@ CStudioAuthoring.FilesDiff = {
       CStudioAuthoring.Utils.getTimeZoneConfig();
     };
 
-    CrafterCMSNext.system.getStore().subscribe((store) => {
+    CrafterCMSNext.system.getStore().subscribe(() => {
       getInitialConfiguration();
     });
   }, w);

--- a/static-assets/components/cstudio-common/common-api.js
+++ b/static-assets/components/cstudio-common/common-api.js
@@ -8058,8 +8058,6 @@ CStudioAuthoring.FilesDiff = {
 
     CrafterCMSNext.system.getStore().subscribe((store) => {
       getInitialConfiguration();
-
-      console.log('store', store.getState());
     });
   }, w);
 })(window);

--- a/static-assets/components/cstudio-forms/controls/date-time.js
+++ b/static-assets/components/cstudio-forms/controls/date-time.js
@@ -1476,12 +1476,7 @@ YAHOO.extend(CStudioForms.Controls.DateTime, CStudioForms.CStudioFormField, {
           context: this,
 
           success: function(config) {
-            // config['default-timezone'] = null;
-            if (config['default-timezone']) {
-              this.context.timezone = config['default-timezone'];
-            } else {
-              this.context.timezone = this.context.defaultTimezone;
-            }
+            this.context.timezone = config.locale?.dateTimeFormatOptions?.timeZone ?? this.context.defaultTimezone;
             this.context.setStaticTimezone(value, this.context.timezone);
           },
 

--- a/static-assets/components/cstudio-forms/controls/date-time.js
+++ b/static-assets/components/cstudio-forms/controls/date-time.js
@@ -1472,7 +1472,7 @@ YAHOO.extend(CStudioForms.Controls.DateTime, CStudioForms.CStudioFormField, {
       this._setValue(value, this.timezone);
     } else {
       if (!this.timezone) {
-        var timezoneCb = {
+        CStudioAuthoring.Service.lookupConfigurtion(CStudioAuthoringContext.site, '/site-config.xml', {
           context: this,
 
           success: function(config) {
@@ -1483,9 +1483,7 @@ YAHOO.extend(CStudioForms.Controls.DateTime, CStudioForms.CStudioFormField, {
           failure: function() {
             this.context.timezone = this.context.defaultTimezone;
           }
-        };
-
-        CStudioAuthoring.Service.lookupConfigurtion(CStudioAuthoringContext.site, '/site-config.xml', timezoneCb);
+        });
       } else {
         this.setStaticTimezone(value, this.timezone);
       }

--- a/static-assets/components/cstudio-forms/controls/time.js
+++ b/static-assets/components/cstudio-forms/controls/time.js
@@ -1194,7 +1194,7 @@ YAHOO.extend(CStudioForms.Controls.Time, CStudioForms.CStudioFormField, {
       this._setValue(value, this.timezone);
     } else {
       if (!this.timezone) {
-        var timezoneCb = {
+        CStudioAuthoring.Service.lookupConfigurtion(CStudioAuthoringContext.site, '/site-config.xml', {
           context: this,
 
           success: function(config) {
@@ -1205,9 +1205,7 @@ YAHOO.extend(CStudioForms.Controls.Time, CStudioForms.CStudioFormField, {
           failure: function() {
             this.context.timezone = this.context.defaultTimezone;
           }
-        };
-
-        CStudioAuthoring.Service.lookupConfigurtion(CStudioAuthoringContext.site, '/site-config.xml', timezoneCb);
+        });
       } else {
         this.setStaticTimezone(value, this.timezone);
       }

--- a/static-assets/components/cstudio-forms/controls/time.js
+++ b/static-assets/components/cstudio-forms/controls/time.js
@@ -1198,11 +1198,7 @@ YAHOO.extend(CStudioForms.Controls.Time, CStudioForms.CStudioFormField, {
           context: this,
 
           success: function(config) {
-            if (config['default-timezone']) {
-              this.context.timezone = config['default-timezone'];
-            } else {
-              this.context.timezone = this.context.defaultTimezone;
-            }
+            this.context.timezone = config.locale?.dateTimeFormatOptions?.timeZone ?? this.context.defaultTimezone;
             this.context.setStaticTimezone(value, this.context.timezone);
           },
 

--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1172,7 +1172,7 @@ var CStudioForms =
         CStudioAuthoring.Service.lookupConfigurtion(CStudioAuthoringContext.site, '/site-config.xml', {
           failure: crafter.noop,
           success: function(config) {
-            timezone = config.locale.dateTimeFormatOptions.timeZone;
+            timezone = config.locale.dateTimeFormatOptions.timeZone ?? 'EST5EDT';
           }
         });
 

--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1172,7 +1172,7 @@ var CStudioForms =
         CStudioAuthoring.Service.lookupConfigurtion(CStudioAuthoringContext.site, '/site-config.xml', {
           failure: crafter.noop,
           success: function(config) {
-            timezone = config['default-timezone'];
+            timezone = config.locale.dateTimeFormatOptions.timeZone;
           }
         });
 

--- a/ui/app/src/state/reducers/uiConfig.ts
+++ b/ui/app/src/state/reducers/uiConfig.ts
@@ -152,7 +152,7 @@ const reducer = createReducer<GlobalState['uiConfig']>(initialState, {
       cdataEscapedFieldPatterns,
       locale: {
         ...state.locale,
-        localeCode: locale.localeCode ?? state.locale.localeCode,
+        localeCode: locale.localeCode ? locale.localeCode : locale.localeCode !== '' ? state.locale.localeCode : [],
         dateTimeFormatOptions: locale.dateTimeFormatOptions ?? state.locale.dateTimeFormatOptions
       },
       publishing: {

--- a/ui/app/src/state/reducers/uiConfig.ts
+++ b/ui/app/src/state/reducers/uiConfig.ts
@@ -155,7 +155,7 @@ const reducer = createReducer<GlobalState['uiConfig']>(initialState, {
         // If locale has localeCode different than empty string -> set it as the localeCode.
         // If locale.localeCode is empty string -> set empty array to use browsers localeCode.
         // If locale.localCode doesn't exist -> use default localeCode from state.
-        localeCode: locale.localeCode ? locale.localeCode : locale.localeCode !== '' ? state.locale.localeCode : [],
+        localeCode: locale?.localeCode ? locale.localeCode : locale?.localeCode === '' ? [] : state.locale.localeCode,
         dateTimeFormatOptions: locale.dateTimeFormatOptions ?? state.locale.dateTimeFormatOptions
       },
       publishing: {

--- a/ui/app/src/state/reducers/uiConfig.ts
+++ b/ui/app/src/state/reducers/uiConfig.ts
@@ -152,6 +152,9 @@ const reducer = createReducer<GlobalState['uiConfig']>(initialState, {
       cdataEscapedFieldPatterns,
       locale: {
         ...state.locale,
+        // If locale has localeCode different than empty string -> set it as the localeCode.
+        // If locale.localeCode is empty string -> set empty array to use browsers localeCode.
+        // If locale.localCode doesn't exist -> use default localeCode from state.
         localeCode: locale.localeCode ? locale.localeCode : locale.localeCode !== '' ? state.locale.localeCode : [],
         dateTimeFormatOptions: locale.dateTimeFormatOptions ?? state.locale.dateTimeFormatOptions
       },


### PR DESCRIPTION
- Set default localeCode in reducer if empty string from config
- Load timezone from locale.dateTimeFormatOptions.timeZone

https://github.com/craftercms/craftercms/issues/4971