### PR TITLE
4.0.0/stability

### DIFF
--- a/static-assets/scripts/communicator.js
+++ b/static-assets/scripts/communicator.js
@@ -247,7 +247,7 @@
           if ('topic' in data) {
             doLocalPublish(data.topic, data.scope, data.message);
           } else if (
-            // This is the signature of PageBuilder messages
+            // This is the signature of ui4 messages
             'type' in data &&
             'meta' in data
           ) {
@@ -257,12 +257,12 @@
       }
     }
 
-    /*private*/
+    /* private */
     function getScopeSpecificTopic(topic, scope) {
       return topic + (scope ? ':' + scope : '');
     }
 
-    /*private*/
+    /* private */
     function doLocalPublish(topic, scope, message) {
       amplify.publish(ALL_TOPICS, topic, message, scope);
       amplify.publish(topic, message, scope);

--- a/static-assets/scripts/crafter.js
+++ b/static-assets/scripts/crafter.js
@@ -73,7 +73,7 @@
       Topics: {
         ALL: '*',
 
-        // PageBuilder
+        // UI4
         GUEST_CHECK_IN: 'GUEST_CHECK_IN',
         LEGACY_CHECK_IN: 'LEGACY_CHECK_IN',
 

--- a/static-assets/scripts/guest.js
+++ b/static-assets/scripts/guest.js
@@ -251,7 +251,7 @@ crafterDefine('guest', ['crafter', 'jquery', 'communicator', 'ice-overlay'], fun
       communicator.publish(Topics.ICE_ZONE_ON, props);
     });
 
-    // Toggle PageBuilder edit mode
+    // Toggle edit mode on UI4
     $document.on('keypress', function(e) {
       if (e.key.toLowerCase() === 'e') {
         communicator.publish('EDIT_MODE_TOGGLE_HOTKEY');

--- a/static-assets/scripts/guest.js
+++ b/static-assets/scripts/guest.js
@@ -132,7 +132,11 @@ crafterDefine('guest', ['crafter', 'jquery', 'communicator', 'ice-overlay'], fun
       });
     });
 
-    communicator.on(Topics.REFRESH_PREVIEW, function(message) {
+    communicator.on(Topics.REFRESH_PREVIEW, function() {
+      window.location.reload();
+    });
+
+    communicator.on('RELOAD_REQUEST', function() {
       window.location.reload();
     });
 

--- a/ui/app/src/assets/uiConfigMessages.ts
+++ b/ui/app/src/assets/uiConfigMessages.ts
@@ -17,10 +17,6 @@
 import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
-  pageBuilder: {
-    id: 'pageBuilder.title',
-    defaultMessage: 'Page Building'
-  },
   siteTools: {
     id: 'siteTools.title',
     defaultMessage: 'Site Tools'

--- a/ui/app/src/components/ICEToolsPanel/ICEToolsPanel.tsx
+++ b/ui/app/src/components/ICEToolsPanel/ICEToolsPanel.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { Suspense, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { initPageBuilderPanelConfig, updatePageBuilderPanelWidth } from '../../state/actions/preview';
+import { initIcePanelConfig, updateIcePanelWidth } from '../../state/actions/preview';
 import LoadingState, { ConditionalLoadingState } from '../SystemStatus/LoadingState';
 import { useSelection } from '../../utils/hooks/useSelection';
 import { useActiveSiteId } from '../../utils/hooks/useActiveSiteId';
@@ -32,42 +32,35 @@ import { nnou } from '../../utils/object';
 import { getComputedEditMode } from '../../utils/content';
 import { useCurrentPreviewItem } from '../../utils/hooks/useCurrentPreviewItem';
 
-export function PageBuilderPanel() {
+export function ICEToolsPanel() {
   const dispatch = useDispatch();
   const uiConfig = useSiteUIConfig();
-  const { pageBuilderPanel } = usePreviewState();
+  const { icePanel } = usePreviewState();
   const site = useActiveSiteId();
   const { rolesBySite, username } = useActiveUser();
-  const { pageBuilderPanelWidth: width, editMode, pageBuilderPanelStack } = useSelection((state) => state.preview);
-  const onWidthChange = (width) => dispatch(updatePageBuilderPanelWidth({ width }));
+  const { icePanelWidth: width, editMode, icePanelStack } = useSelection((state) => state.preview);
+  const onWidthChange = (width) => dispatch(updateIcePanelWidth({ width }));
   const item = useCurrentPreviewItem();
   const isOpen = getComputedEditMode({ item, editMode, username });
 
   useEffect(() => {
-    if (nnou(uiConfig.xml) && !pageBuilderPanel) {
-      dispatch(initPageBuilderPanelConfig({ configXml: uiConfig.xml }));
+    if (nnou(uiConfig.xml) && !icePanel) {
+      dispatch(initIcePanelConfig({ configXml: uiConfig.xml }));
     }
-  }, [uiConfig.xml, dispatch, pageBuilderPanel]);
+  }, [uiConfig.xml, dispatch, icePanel]);
 
   return (
     <ResizeableDrawer open={isOpen} belowToolbar anchor="right" width={width} onWidthChange={onWidthChange}>
       <Suspense fallback={<LoadingState />}>
-        <ConditionalLoadingState isLoading={!Boolean(pageBuilderPanel)}>
-          {pageBuilderPanel?.widgets && pageBuilderPanel.widgets.length > 0 ? (
+        <ConditionalLoadingState isLoading={!Boolean(icePanel)}>
+          {icePanel?.widgets && icePanel.widgets.length > 0 ? (
             renderWidgets(
-              pageBuilderPanelStack.length
-                ? pageBuilderPanelStack.slice(pageBuilderPanelStack.length - 1)
-                : pageBuilderPanel.widgets,
+              icePanelStack.length ? icePanelStack.slice(icePanelStack.length - 1) : icePanel.widgets,
               rolesBySite[site]
             )
           ) : (
             <EmptyState
-              title={
-                <FormattedMessage
-                  id="pageBuilderPanel.noWidgetsMessage"
-                  defaultMessage="No tools have been configured"
-                />
-              }
+              title={<FormattedMessage id="icePanel.noWidgetsMessage" defaultMessage="No tools have been configured" />}
             />
           )}
         </ConditionalLoadingState>
@@ -76,4 +69,4 @@ export function PageBuilderPanel() {
   );
 }
 
-export default PageBuilderPanel;
+export default ICEToolsPanel;

--- a/ui/app/src/components/ICEToolsPanel/index.ts
+++ b/ui/app/src/components/ICEToolsPanel/index.ts
@@ -14,6 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { default } from './PageBuilderPanel';
+export { default } from './ICEToolsPanel';
 
-export * from './PageBuilderPanel';
+export * from './ICEToolsPanel';

--- a/ui/app/src/components/PathNavigator/PathNavigatorHeader.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigatorHeader.tsx
@@ -26,7 +26,8 @@ import SystemIcon, { SystemIconDescriptor } from '../SystemIcon';
 interface HeaderProps {
   locale: string;
   title: string;
-  icon?: SystemIconDescriptor;
+  icon?: SystemIconDescriptor & Partial<{ expandedStyle: {}; collapsedStyle: {} }>;
+  collapsed: boolean;
   onLanguageMenu?(anchor: Element): void;
   onContextMenu?(anchor: Element): void;
 }
@@ -34,12 +35,18 @@ interface HeaderProps {
 // PathNavigatorHeader
 export function PathNavigatorHeader(props: HeaderProps) {
   const classes = useStyles();
-  const { title, icon, locale, onLanguageMenu, onContextMenu } = props;
+  const { title, icon, locale, onLanguageMenu, onContextMenu, collapsed = false } = props;
   const currentFlag = (locale: string) => <LanguageRounded />;
   return (
     <AccordionSummary classes={{ root: classes.accordionSummary, content: classes.accordionSummaryContent }}>
       <div className={classes.accordionSummaryTitle}>
-        {icon && <SystemIcon icon={icon} className={classes.headerIcon} />}
+        {icon && (
+          <SystemIcon
+            icon={icon}
+            className={classes.headerIcon}
+            style={icon[collapsed ? 'collapsedStyle' : 'expandedStyle']}
+          />
+        )}
         <Typography variant="body1" component="h6" className={classes.headerTitle} children={title} />
       </div>
       <div className={classes.accordionSummaryActions}>

--- a/ui/app/src/components/PathNavigator/PathNavigatorUI.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigatorUI.tsx
@@ -234,6 +234,7 @@ export function PathNavigatorUI(props: PathNavigatorUIProps) {
             ? (anchor) => onHeaderButtonClick(anchor, 'language')
             : null
         }
+        collapsed={state.collapsed}
       />
       <AccordionDetails className={clsx(classes.accordionDetails, props.classes?.body)}>
         <Breadcrumbs

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeUI.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeUI.tsx
@@ -123,6 +123,7 @@ export default function PathNavigatorTreeUI(props: PathNavigatorTreeUIProps) {
         icon={icon}
         title={title}
         locale={null}
+        collapsed={isCollapsed}
         onContextMenu={(element) => {
           onHeaderButtonClick(element);
         }}

--- a/ui/app/src/components/ToolsPanelPage/ToolsPanelPage.tsx
+++ b/ui/app/src/components/ToolsPanelPage/ToolsPanelPage.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import ToolPanel from '../../modules/Preview/Tools/ToolPanel';
 import { renderWidgets, WidgetDescriptor } from '../Widget';
 import { useDispatch } from 'react-redux';
-import { popPageBuilderPanelPage, popToolsPanelPage } from '../../state/actions/preview';
+import { popIcePanelPage, popToolsPanelPage } from '../../state/actions/preview';
 import { useActiveSiteId } from '../../utils/hooks/useActiveSiteId';
 import { useActiveUser } from '../../utils/hooks/useActiveUser';
 import { usePossibleTranslation } from '../../utils/hooks/usePossibleTranslation';
@@ -26,7 +26,7 @@ import { usePossibleTranslation } from '../../utils/hooks/usePossibleTranslation
 export interface ToolsPanelPageDescriptor {
   title: string;
   widgets: WidgetDescriptor[];
-  target?: 'pageBuilderPanel' | 'toolsPanel';
+  target?: 'icePanel' | 'toolsPanel';
 }
 
 export interface ToolsPanelPageProps extends ToolsPanelPageDescriptor {}
@@ -36,7 +36,7 @@ export default function ToolsPanelPage(props: ToolsPanelPageProps) {
   const dispatch = useDispatch();
   const site = useActiveSiteId();
   const { rolesBySite } = useActiveUser();
-  const popPage = target === 'toolsPanel' ? popToolsPanelPage : popPageBuilderPanelPage;
+  const popPage = target === 'toolsPanel' ? popToolsPanelPage : popIcePanelPage;
   const pop = () => dispatch(popPage());
   return (
     <ToolPanel title={usePossibleTranslation(props.title)} onBack={pop}>

--- a/ui/app/src/components/ToolsPanelPageButton/ToolsPanelPageButton.tsx
+++ b/ui/app/src/components/ToolsPanelPageButton/ToolsPanelPageButton.tsx
@@ -17,21 +17,21 @@
 import React from 'react';
 import ToolsPanelListItemButton from '../ToolsPanelListItemButton';
 import { useDispatch } from 'react-redux';
-import { pushPageBuilderPanelPage, pushToolsPanelPage } from '../../state/actions/preview';
+import { pushIcePanelPage, pushToolsPanelPage } from '../../state/actions/preview';
 import { createWidgetDescriptor } from '../../utils/state';
 import { SystemIconDescriptor } from '../SystemIcon';
 
 export interface ToolsPanelPageButtonProps {
   title: string;
   subtitle: string;
-  target?: 'pageBuilderPanel' | 'toolsPanel';
+  target?: 'icePanel' | 'toolsPanel';
   icon: SystemIconDescriptor;
 }
 
 export default function ToolsPanelPageButton(props: ToolsPanelPageButtonProps) {
   const { target = 'toolsPanel' } = props;
   const dispatch = useDispatch();
-  const pushPage = target === 'toolsPanel' ? pushToolsPanelPage : pushPageBuilderPanelPage;
+  const pushPage = target === 'toolsPanel' ? pushToolsPanelPage : pushIcePanelPage;
   const turnPage = () => {
     dispatch(
       pushPage(

--- a/ui/app/src/models/GlobalState.ts
+++ b/ui/app/src/models/GlobalState.ts
@@ -147,8 +147,8 @@ export interface GlobalState {
     showToolsPanel: boolean;
     toolsPanelPageStack: WidgetDescriptor[];
     toolsPanelWidth: number;
-    pageBuilderPanelWidth: number;
-    pageBuilderPanelStack: WidgetDescriptor[];
+    icePanelWidth: number;
+    icePanelStack: WidgetDescriptor[];
     hostSize: WidthAndHeight;
     guest: GuestData;
     assets: PagedEntityState<MediaItem>;
@@ -178,7 +178,7 @@ export interface GlobalState {
         widgets: WidgetDescriptor[];
       };
     };
-    pageBuilderPanel: {
+    icePanel: {
       widgets: WidgetDescriptor[];
     };
   };

--- a/ui/app/src/modules/Preview/Host.tsx
+++ b/ui/app/src/modules/Preview/Host.tsx
@@ -179,7 +179,7 @@ export default function Host() {
   const classes = useStyles({});
   const site = useActiveSiteId();
   const { guestBase, previewLandingBase } = useEnv();
-  const { hostSize, showToolsPanel, toolsPanelWidth, pageBuilderPanelWidth, editMode } = usePreviewState();
+  const { hostSize, showToolsPanel, toolsPanelWidth, icePanelWidth, editMode } = usePreviewState();
   const { currentUrlPath } = usePreviewNavigation();
   const { username } = useActiveUser();
   const item = useCurrentPreviewItem();
@@ -194,7 +194,7 @@ export default function Host() {
   return (
     <div
       style={{
-        width: `calc(100% - ${showToolsPanel ? toolsPanelWidth : 0}px - ${isEditMode ? pageBuilderPanelWidth : 0}px)`,
+        width: `calc(100% - ${showToolsPanel ? toolsPanelWidth : 0}px - ${isEditMode ? icePanelWidth : 0}px)`,
         marginLeft: showToolsPanel ? toolsPanelWidth : 0
       }}
       className={clsx(classes.hostContainer, { [classes.shift]: showToolsPanel })}

--- a/ui/app/src/modules/Preview/Preview.tsx
+++ b/ui/app/src/modules/Preview/Preview.tsx
@@ -21,7 +21,7 @@ import Host from './Host';
 import ToolBar from './ToolBar';
 import { PreviewConcierge } from './PreviewConcierge';
 import usePreviewUrlControl from './usePreviewUrlControl';
-import PageBuilderPanel from '../../components/PageBuilderPanel';
+import ICEToolsPanel from '../../components/ICEToolsPanel';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -41,7 +41,7 @@ function Preview(props) {
           <ToolBar />
           <Host />
           <ToolsPanel />
-          <PageBuilderPanel />
+          <ICEToolsPanel />
         </section>
       </PreviewConcierge>
     </>

--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -206,7 +206,7 @@ export function PreviewConcierge(props: any) {
     guest,
     editMode,
     highlightMode,
-    pageBuilderPanelWidth,
+    icePanelWidth,
     toolsPanelWidth,
     hostSize,
     showToolsPanel
@@ -245,7 +245,7 @@ export function PreviewConcierge(props: any) {
         clearTimeout(timeout);
       };
     }
-  }, [pageBuilderPanelWidth, toolsPanelWidth, hostSize, editMode, showToolsPanel]);
+  }, [icePanelWidth, toolsPanelWidth, hostSize, editMode, showToolsPanel]);
   // endregion
 
   // region Permissions and fetch of DetailedItem

--- a/ui/app/src/state/actions/preview.ts
+++ b/ui/app/src/state/actions/preview.ts
@@ -281,9 +281,7 @@ export const setPreviewEditMode = /*#__PURE__*/ createAction<{ editMode: boolean
 
 export const previewItem = /*#__PURE__*/ createAction<{ item: DetailedItem; newTab?: boolean }>('PREVIEW_ITEM');
 
-export const updatePageBuilderPanelWidth = /*#__PURE__#*/ createAction<{ width: number }>(
-  'UPDATE_PAGE_BUILDER_PANEL_WIDTH'
-);
+export const updateIcePanelWidth = /*#__PURE__#*/ createAction<{ width: number }>('UPDATE_ICE_PANEL_WIDTH');
 
 export const initToolsPanelConfig = /*#__PURE__*/ createAction<{
   configXml: string;
@@ -292,9 +290,9 @@ export const initToolsPanelConfig = /*#__PURE__*/ createAction<{
 
 export const initToolbarConfig = /*#__PURE__*/ createAction<{ configXml: string }>('INIT_TOOLBAR_CONFIG');
 
-export const initPageBuilderPanelConfig = /*#__PURE__*/ createAction<{
+export const initIcePanelConfig = /*#__PURE__*/ createAction<{
   configXml: string;
-}>('INIT_PAGE_BUILDER_PANEL_CONFIG');
+}>('INIT_ICE_PANEL_CONFIG');
 
 // endregion
 
@@ -306,11 +304,11 @@ export const popToolsPanelPage = /*#__PURE__*/ createAction('POP_TOOLS_PANEL_PAG
 
 // endregion
 
-// region Page builder panel stack
+// region ICE panel stack
 
-export const pushPageBuilderPanelPage = /*#__PURE__*/ createAction<WidgetDescriptor>('PUSH_PAGE_BUILDER_PANEL_PAGE');
+export const pushIcePanelPage = /*#__PURE__*/ createAction<WidgetDescriptor>('PUSH_ICE_PANEL_PAGE');
 
-export const popPageBuilderPanelPage = /*#__PURE__*/ createAction('POP_PAGE_BUILDER_PANEL_PAGE');
+export const popIcePanelPage = /*#__PURE__*/ createAction('POP_ICE_PANEL_PAGE');
 
 // endregion
 

--- a/ui/app/src/state/reducers/preview.ts
+++ b/ui/app/src/state/reducers/preview.ts
@@ -38,13 +38,13 @@ import {
   GUEST_CHECK_OUT,
   guestModelUpdated,
   guestPathUpdated,
-  initPageBuilderPanelConfig,
+  initIcePanelConfig,
   initToolbarConfig,
   initToolsPanelConfig,
   OPEN_TOOLS,
-  popPageBuilderPanelPage,
+  popIcePanelPage,
   popToolsPanelPage,
-  pushPageBuilderPanelPage,
+  pushIcePanelPage,
   pushToolsPanelPage,
   SELECT_FOR_EDIT,
   SET_ACTIVE_TARGETING_MODEL,
@@ -57,7 +57,7 @@ import {
   SET_ITEM_BEING_DRAGGED,
   setHighlightMode,
   UPDATE_AUDIENCES_PANEL_MODEL,
-  updatePageBuilderPanelWidth,
+  updateIcePanelWidth,
   updateToolsPanelWidth
 } from '../actions/preview';
 import {
@@ -139,8 +139,8 @@ const initialState: GlobalState['preview'] = {
   toolsPanelPageStack: [],
   showToolsPanel: process.env.REACT_APP_SHOW_TOOLS_PANEL ? process.env.REACT_APP_SHOW_TOOLS_PANEL === 'true' : true,
   toolsPanelWidth: 240,
-  pageBuilderPanelWidth: 240,
-  pageBuilderPanelStack: [],
+  icePanelWidth: 240,
+  icePanelStack: [],
   guest: null,
   assets: assetsPanelInitialState,
   audiencesPanel: audiencesPanelInitialState,
@@ -155,7 +155,7 @@ const initialState: GlobalState['preview'] = {
     middleSection: null,
     rightSection: null
   },
-  pageBuilderPanel: null
+  icePanel: null
 };
 
 const fetchGuestModelsCompleteHandler = (state, { type, payload }) => {
@@ -501,7 +501,7 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
       toolsPanelWidth: payload.width
     };
   },
-  [updatePageBuilderPanelWidth.type]: (state, { payload }) => {
+  [updateIcePanelWidth.type]: (state, { payload }) => {
     const minDrawerWidth = 240;
     const maxDrawerWidth = 500;
     if (payload.width < minDrawerWidth || payload.width > maxDrawerWidth) {
@@ -509,7 +509,7 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
     }
     return {
       ...state,
-      pageBuilderPanelWidth: payload.width
+      icePanelWidth: payload.width
     };
   },
   [pushToolsPanelPage.type]: (state, { payload }) => {
@@ -526,18 +526,18 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
       toolsPanelPageStack: stack
     };
   },
-  [pushPageBuilderPanelPage.type]: (state, { payload }) => {
+  [pushIcePanelPage.type]: (state, { payload }) => {
     return {
       ...state,
-      pageBuilderPanelStack: [...state.pageBuilderPanelStack, payload]
+      icePanelStack: [...state.icePanelStack, payload]
     };
   },
-  [popPageBuilderPanelPage.type]: (state) => {
-    let stack = [...state.pageBuilderPanelStack];
+  [popIcePanelPage.type]: (state) => {
+    let stack = [...state.icePanelStack];
     stack.pop();
     return {
       ...state,
-      pageBuilderPanelStack: stack
+      icePanelStack: stack
     };
   },
   [guestPathUpdated.type]: (state, { payload }) => ({
@@ -561,7 +561,7 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
         'previewChoice',
         'showToolsPanel',
         'toolsPanelWidth',
-        'pageBuilderPanelWidth'
+        'icePanelWidth'
       )
     };
   },
@@ -603,7 +603,7 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
     ...state,
     toolsPanel: initialState.toolsPanel,
     toolbar: initialState.toolbar,
-    pageBuilderPanel: initialState.pageBuilderPanel
+    icePanel: initialState.icePanel
   }),
   [initToolbarConfig.type]: (state, { payload }) => {
     let toolbarConfig = {
@@ -641,8 +641,8 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
       toolbar: toolbarConfig
     };
   },
-  [initPageBuilderPanelConfig.type]: (state, { payload }) => {
-    let pageBuilderPanelConfig = {
+  [initIcePanelConfig.type]: (state, { payload }) => {
+    let icePanelConfig = {
       widgets: [
         {
           id: 'craftercms.component.EmptyState',
@@ -656,25 +656,22 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
     };
     const arrays = ['widgets', 'devices', 'values'];
     const configDOM = fromString(payload.configXml);
-    const pageBuilderPanel = configDOM.querySelector(
-      '[id="craftercms.components.PageBuilderPanel"] > configuration > widgets'
-    );
-    if (pageBuilderPanel) {
+    const icePanel = configDOM.querySelector('[id="craftercms.components.PageBuilderPanel"] > configuration > widgets');
+    if (icePanel) {
       const lookupTables = ['fields'];
-      pageBuilderPanel.querySelectorAll('widget').forEach((e, index) => {
+      icePanel.querySelectorAll('widget').forEach((e) => {
         if (e.getAttribute('id') === 'craftercms.components.ToolsPanelPageButton') {
-          e.querySelector(':scope > configuration')?.setAttribute('target', 'pageBuilderPanel');
+          e.querySelector(':scope > configuration')?.setAttribute('target', 'icePanel');
         }
       });
-      pageBuilderPanelConfig = applyDeserializedXMLTransforms(deserialize(pageBuilderPanel), {
+      icePanelConfig = applyDeserializedXMLTransforms(deserialize(icePanel), {
         arrays,
         lookupTables
       });
     }
-
     return {
       ...state,
-      pageBuilderPanel: pageBuilderPanelConfig
+      icePanel: icePanelConfig
     };
   }
 });

--- a/ui/guest/src/index.tsx
+++ b/ui/guest/src/index.tsx
@@ -73,7 +73,7 @@ export function fetchIsAuthoring(config?: BaseCrafterConfig): Promise<boolean> {
     .then((response) => response.preview);
 }
 
-export function initPageBuilder(props: GuestProps) {
+export function initInContextEditing(props: GuestProps) {
   const guestProxyElement = document.createElement('craftercms-guest-proxy');
   ReactDOM.render(
     <Guest isAuthoring {...props}>


### PR DESCRIPTION
Restore expandedStyle/collapsedStyle props for navigators, rename page builder (panel) to ice (panel).
Reload 3.1.x sites on successful form editing