### PR TITLE
[4966] Components options panel of page builder should open on the right side

### DIFF
--- a/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
+++ b/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
@@ -38,6 +38,7 @@ import { batchActions } from '../../state/actions/misc';
 import { createToolsPanelPage, createWidgetDescriptor } from '../../utils/state';
 import { useSelection } from '../../utils/hooks/useSelection';
 import { useSelectorResource } from '../../utils/hooks/useSelectorResource';
+import EmptyState from '../SystemStatus/EmptyState';
 
 const translations = defineMessages({
   previewComponentsPanelTitle: {
@@ -68,7 +69,6 @@ export default function PreviewComponentsPanel() {
     errorSelector: (source) => source.error,
     resultSelector: (source) => Object.values(reversePluckProps(source.byId, '/component/level-descriptor'))
   });
-
   return (
     <>
       <SuspenseWithEmptyState
@@ -78,13 +78,7 @@ export default function PreviewComponentsPanel() {
         }}
         withEmptyStateProps={{
           emptyStateProps: {
-            title: <FormattedMessage id="componentsPanel.emptyStateMessage" defaultMessage="No components found" />,
-            subtitle: (
-              <FormattedMessage
-                id="componentsPanel.emptyStateMessageSubtitle"
-                defaultMessage="Communicate with your developers to create the required components in the system."
-              />
-            )
+            title: <FormattedMessage id="componentsPanel.emptyStateMessage" defaultMessage="No contentTypes found" />
           }
         }}
       >
@@ -168,16 +162,28 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
   return (
     <>
       <List>
-        {componentTypes.map((contentType) => (
-          <DraggablePanelListItem
-            key={contentType.id}
-            primaryText={contentType.name}
-            secondaryText={contentType.id}
-            onDragStart={() => onDragStart(contentType)}
-            onDragEnd={onDragEnd}
-            onMenu={(anchor) => setMenuContext({ anchor, contentType })}
+        {componentTypes.length ? (
+          componentTypes.map((contentType) => (
+            <DraggablePanelListItem
+              key={contentType.id}
+              primaryText={contentType.name}
+              secondaryText={contentType.id}
+              onDragStart={() => onDragStart(contentType)}
+              onDragEnd={onDragEnd}
+              onMenu={(anchor) => setMenuContext({ anchor, contentType })}
+            />
+          ))
+        ) : (
+          <EmptyState
+            title={<FormattedMessage id="componentsPanel.emptyComponents" defaultMessage="No components found" />}
+            subtitle={
+              <FormattedMessage
+                id="componentsPanel.emptyComponentsSubtitle"
+                defaultMessage="Communicate with your developers to create the required components in the system."
+              />
+            }
           />
-        ))}
+        )}
       </List>
 
       <Menu open={!!menuContext} anchorEl={menuContext?.anchor} onClose={onMenuClose}>

--- a/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
+++ b/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
@@ -25,7 +25,7 @@ import {
   COMPONENT_DRAG_ENDED,
   COMPONENT_DRAG_STARTED,
   CONTENT_TYPE_DROP_TARGETS_REQUEST,
-  pushToolsPanelPage,
+  pushPageBuilderPanelPage,
   setContentTypeFilter,
   setPreviewEditMode
 } from '../../state/actions/preview';
@@ -123,10 +123,12 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
     dispatch(
       batchActions([
         setContentTypeFilter(menuContext.contentType.id),
-        pushToolsPanelPage(
-          createToolsPanelPage({ id: 'previewBrowseComponentsPanel.title' }, [
-            createWidgetDescriptor({ id: 'craftercms.components.PreviewBrowseComponentsPanel' })
-          ])
+        pushPageBuilderPanelPage(
+          createToolsPanelPage(
+            { id: 'previewBrowseComponentsPanel.title' },
+            [createWidgetDescriptor({ id: 'craftercms.components.PreviewBrowseComponentsPanel' })],
+            'pageBuilderPanel'
+          )
         )
       ])
     );
@@ -136,10 +138,12 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
     dispatch(
       batchActions([
         setContentTypeFilter(menuContext.contentType.id),
-        pushToolsPanelPage(
-          createToolsPanelPage({ id: 'previewInPageInstancesPanel.title' }, [
-            createWidgetDescriptor({ id: 'craftercms.components.PreviewInPageInstancesPanel' })
-          ])
+        pushPageBuilderPanelPage(
+          createToolsPanelPage(
+            { id: 'previewInPageInstancesPanel.title' },
+            [createWidgetDescriptor({ id: 'craftercms.components.PreviewInPageInstancesPanel' })],
+            'pageBuilderPanel'
+          )
         )
       ])
     );
@@ -147,10 +151,12 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
 
   const onListDropTargetsClick = () => {
     dispatch(
-      pushToolsPanelPage(
-        createToolsPanelPage({ id: 'previewDropTargetsPanel.title', defaultMessage: 'Component Drop Targets' }, [
-          createWidgetDescriptor({ id: 'craftercms.components.PreviewDropTargetsPanel' })
-        ])
+      pushPageBuilderPanelPage(
+        createToolsPanelPage(
+          { id: 'previewDropTargetsPanel.title', defaultMessage: 'Component Drop Targets' },
+          [createWidgetDescriptor({ id: 'craftercms.components.PreviewDropTargetsPanel' })],
+          'pageBuilderPanel'
+        )
       )
     );
     hostToGuest$.next({

--- a/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
+++ b/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
@@ -25,6 +25,7 @@ import {
   COMPONENT_DRAG_ENDED,
   COMPONENT_DRAG_STARTED,
   CONTENT_TYPE_DROP_TARGETS_REQUEST,
+  pushIcePanelPage,
   setContentTypeFilter,
   setPreviewEditMode
 } from '../../state/actions/preview';
@@ -122,7 +123,7 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
     dispatch(
       batchActions([
         setContentTypeFilter(menuContext.contentType.id),
-        pushPageBuilderPanelPage(
+        pushIcePanelPage(
           createToolsPanelPage(
             { id: 'previewBrowseComponentsPanel.title' },
             [createWidgetDescriptor({ id: 'craftercms.components.PreviewBrowseComponentsPanel' })],
@@ -137,7 +138,7 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
     dispatch(
       batchActions([
         setContentTypeFilter(menuContext.contentType.id),
-        pushPageBuilderPanelPage(
+        pushIcePanelPage(
           createToolsPanelPage(
             { id: 'previewInPageInstancesPanel.title' },
             [createWidgetDescriptor({ id: 'craftercms.components.PreviewInPageInstancesPanel' })],
@@ -150,7 +151,7 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
 
   const onListDropTargetsClick = () => {
     dispatch(
-      pushPageBuilderPanelPage(
+      pushIcePanelPage(
         createToolsPanelPage(
           { id: 'previewDropTargetsPanel.title', defaultMessage: 'Component Drop Targets' },
           [createWidgetDescriptor({ id: 'craftercms.components.PreviewDropTargetsPanel' })],

--- a/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
+++ b/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
@@ -78,7 +78,13 @@ export default function PreviewComponentsPanel() {
         }}
         withEmptyStateProps={{
           emptyStateProps: {
-            title: <FormattedMessage id="componentsPanel.emptyStateMessage" defaultMessage="No contentTypes found" />
+            title: <FormattedMessage id="componentsPanel.emptyStateMessage" defaultMessage="No content types found" />,
+            subtitle: (
+              <FormattedMessage
+                id="componentsPanel.emptyComponentsSubtitle"
+                defaultMessage="Communicate with your developers to create the required components in the system."
+              />
+            )
           }
         }}
       >
@@ -121,7 +127,7 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
           createToolsPanelPage(
             { id: 'previewBrowseComponentsPanel.title' },
             [createWidgetDescriptor({ id: 'craftercms.components.PreviewBrowseComponentsPanel' })],
-            'pageBuilderPanel'
+            'icePanel'
           )
         )
       ])
@@ -136,7 +142,7 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
           createToolsPanelPage(
             { id: 'previewInPageInstancesPanel.title' },
             [createWidgetDescriptor({ id: 'craftercms.components.PreviewInPageInstancesPanel' })],
-            'pageBuilderPanel'
+            'icePanel'
           )
         )
       ])
@@ -149,7 +155,7 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
         createToolsPanelPage(
           { id: 'previewDropTargetsPanel.title', defaultMessage: 'Component Drop Targets' },
           [createWidgetDescriptor({ id: 'craftercms.components.PreviewDropTargetsPanel' })],
-          'pageBuilderPanel'
+          'icePanel'
         )
       )
     );
@@ -175,7 +181,7 @@ export const ComponentsPanelUI: React.FC<ComponentsPanelUIProps> = (props) => {
           ))
         ) : (
           <EmptyState
-            title={<FormattedMessage id="componentsPanel.emptyComponents" defaultMessage="No components found" />}
+            title={<FormattedMessage id="componentsPanel.emptyStateMessage" defaultMessage="No content types found" />}
             subtitle={
               <FormattedMessage
                 id="componentsPanel.emptyComponentsSubtitle"

--- a/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
+++ b/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
@@ -25,7 +25,6 @@ import {
   COMPONENT_DRAG_ENDED,
   COMPONENT_DRAG_STARTED,
   CONTENT_TYPE_DROP_TARGETS_REQUEST,
-  pushPageBuilderPanelPage,
   setContentTypeFilter,
   setPreviewEditMode
 } from '../../state/actions/preview';

--- a/ui/app/src/components/ToolsPanelPage/ToolsPanelPage.tsx
+++ b/ui/app/src/components/ToolsPanelPage/ToolsPanelPage.tsx
@@ -22,11 +22,12 @@ import { popIcePanelPage, popToolsPanelPage } from '../../state/actions/preview'
 import { useActiveSiteId } from '../../utils/hooks/useActiveSiteId';
 import { useActiveUser } from '../../utils/hooks/useActiveUser';
 import { usePossibleTranslation } from '../../utils/hooks/usePossibleTranslation';
+import ToolsPanelTarget from '../../models/ToolsPanelTarget';
 
 export interface ToolsPanelPageDescriptor {
   title: string;
   widgets: WidgetDescriptor[];
-  target?: 'icePanel' | 'toolsPanel';
+  target?: ToolsPanelTarget;
 }
 
 export interface ToolsPanelPageProps extends ToolsPanelPageDescriptor {}

--- a/ui/app/src/components/ToolsPanelPageButton/ToolsPanelPageButton.tsx
+++ b/ui/app/src/components/ToolsPanelPageButton/ToolsPanelPageButton.tsx
@@ -20,11 +20,12 @@ import { useDispatch } from 'react-redux';
 import { pushIcePanelPage, pushToolsPanelPage } from '../../state/actions/preview';
 import { createWidgetDescriptor } from '../../utils/state';
 import { SystemIconDescriptor } from '../SystemIcon';
+import ToolsPanelTarget from '../../models/ToolsPanelTarget';
 
 export interface ToolsPanelPageButtonProps {
   title: string;
   subtitle: string;
-  target?: 'icePanel' | 'toolsPanel';
+  target?: ToolsPanelTarget;
   icon: SystemIconDescriptor;
 }
 

--- a/ui/app/src/models/ToolsPanelTarget.ts
+++ b/ui/app/src/models/ToolsPanelTarget.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type ToolsPanelTarget = 'icePanel' | 'toolsPanel';
+
+export default ToolsPanelTarget;

--- a/ui/app/src/state/reducers/preview.ts
+++ b/ui/app/src/state/reducers/preview.ts
@@ -80,6 +80,7 @@ import { changeSite } from './sites';
 import { deserialize, fromString } from '../../utils/xml';
 import { defineMessages } from 'react-intl';
 import { fetchSiteUiConfigComplete } from '../actions/configuration';
+import ToolsPanelTarget from '../../models/ToolsPanelTarget';
 
 const messages = defineMessages({
   emptyUiConfigMessageTitle: {
@@ -661,7 +662,8 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
       const lookupTables = ['fields'];
       icePanel.querySelectorAll('widget').forEach((e) => {
         if (e.getAttribute('id') === 'craftercms.components.ToolsPanelPageButton') {
-          e.querySelector(':scope > configuration')?.setAttribute('target', 'icePanel');
+          let target: ToolsPanelTarget = 'icePanel';
+          e.querySelector(':scope > configuration')?.setAttribute('target', target);
         }
       });
       icePanelConfig = applyDeserializedXMLTransforms(deserialize(icePanel), {

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -19,6 +19,7 @@ import { WidgetDescriptor } from '../components/Widget';
 import { nanoid as uuid } from 'nanoid';
 import TranslationOrText from '../models/TranslationOrText';
 import { DashboardPreferences } from '../models/Dashboard';
+import ToolsPanelTarget from '../models/ToolsPanelTarget';
 
 export function setStoredGlobalMenuSiteViewPreference(value: 'grid' | 'list', user: string) {
   return window.localStorage.setItem(`craftercms.${user}.globalMenuSiteViewPreference`, value);
@@ -125,7 +126,7 @@ export function getStoredGlobalAppOpenSidebar(user: string): string {
 export function createToolsPanelPage(
   title: TranslationOrText,
   widgets: WidgetDescriptor[],
-  target?: 'pageBuilderPanel' | 'toolsPanel'
+  target?: ToolsPanelTarget
 ): WidgetDescriptor {
   return createWidgetDescriptor({
     id: 'craftercms.components.ToolsPanelPage',

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -122,11 +122,16 @@ export function getStoredGlobalAppOpenSidebar(user: string): string {
   return window.localStorage.getItem(`craftercms.${user}.globalAppOpenSidebar`);
 }
 
-export function createToolsPanelPage(title: TranslationOrText, widgets: WidgetDescriptor[]): WidgetDescriptor {
+export function createToolsPanelPage(
+  title: TranslationOrText,
+  widgets: WidgetDescriptor[],
+  target?: 'pageBuilderPanel' | 'toolsPanel'
+): WidgetDescriptor {
   return createWidgetDescriptor({
     id: 'craftercms.components.ToolsPanelPage',
     configuration: {
       title,
+      target,
       widgets
     }
   });


### PR DESCRIPTION
 PreviewComponentsPanel.tsx: using pushPageBuilderPanelPage instead of pushToolsPanelPage, to open components tool pages;

adding target prop to createToolsPanelPage;

https://github.com/craftercms/craftercms/issues/4966
