### PR TITLE
[4974] The Save & Close button in Code Editor is displaying an incorrect warning. 

### DIFF
--- a/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
+++ b/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
@@ -93,9 +93,20 @@ export default function CodeEditorDialog(props: CodeEditorDialogProps) {
     }
   };
 
+  const onSaveClose = () => {
+    dispatch(conditionallyUnlockItem({ path: props.path }));
+    onClose();
+  };
+
   return (
     <Dialog fullWidth maxWidth="xl" {...rest} open={open && !minimized} keepMounted={minimized} onClose={onDialogClose}>
-      <CodeEditorDialogContainer {...props} onClose={onDialogClose} title={title} onMinimized={onMinimized} />
+      <CodeEditorDialogContainer
+        {...props}
+        onClose={onDialogClose}
+        onSaveClose={onSaveClose}
+        title={title}
+        onMinimized={onMinimized}
+      />
     </Dialog>
   );
 }

--- a/ui/app/src/components/CodeEditorDialog/CodeEditorDialogContainer.tsx
+++ b/ui/app/src/components/CodeEditorDialog/CodeEditorDialogContainer.tsx
@@ -151,8 +151,8 @@ export function CodeEditorDialogContainer(props: CodeEditorDialogContainerProps)
   };
 
   const save = useCallback(
-    (unlock: boolean = true, callback?: Function) => {
-      writeContent(site, path, editorRef.current.getValue(), { unlock }).subscribe(
+    (callback?: Function) => {
+      writeContent(site, path, editorRef.current.getValue(), { unlock: false }).subscribe(
         () => {
           setTimeout(callback);
           dispatch(
@@ -182,20 +182,20 @@ export function CodeEditorDialogContainer(props: CodeEditorDialogContainerProps)
   };
 
   const onSave = useCallback(() => {
-    save(true, () => {
+    save(() => {
       setContent(editorRef.current.getValue());
     });
   }, [save]);
 
   const onSaveAndMinimize = () => {
-    save(false, () => {
+    save(() => {
       setContent(editorRef.current.getValue());
       onMinimized?.();
     });
   };
 
   const saveAndClose = () => {
-    save(false, onSaveClose);
+    save(onSaveClose);
   };
 
   const onAddSnippet = (event) => {


### PR DESCRIPTION
creating onSaveClose prop to close the dialog without pending changes confirmation;

https://github.com/craftercms/craftercms/issues/4974
