### PR TITLE
[4981] Disabled pages have no indications it is disabled when previewing or in the dashboard

### DIFF
--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -42,7 +42,7 @@ export function getStateMapFromLegacyItem(item: LegacyItem): ItemStateMap {
     submittedToLive: item.submittedToEnvironment === 'live',
     staged: item.isStaged,
     live: item.isLive,
-    disabled: item.isDisabled,
+    disabled: item.disabled,
     translationInProgress: false,
     translationPending: false,
     translationUpToDate: false


### PR DESCRIPTION
-Update parseLegacyItem to read `disabled` property instead of `isDisabled` (that last one doesn't get the correct value)

https://github.com/craftercms/craftercms/issues/4981