### PR TITLE
[4646] Drag & drop usability

### DIFF
--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -250,6 +250,7 @@ export function PreviewConcierge(props: any) {
   // region Permissions and fetch of DetailedItem
 
   useEffect(() => {
+    // FYI. Path navigator refresh triggers this effect too due to item changing.
     if (item) {
       getHostToGuestBus().next({
         type: setPreviewEditMode.type,

--- a/ui/guest/package.json
+++ b/ui/guest/package.json
@@ -22,6 +22,7 @@
     "build": "run-s build:install build:app",
     "build:install": "yarn",
     "build:app": "rollup -c",
+    "start": "rollup -c -w",
     "watch": "rollup -c -w",
     "rollup": "rollup -c",
     "rollup:watch": "rollup -c -w",

--- a/ui/guest/src/classes/ElementRegistry.ts
+++ b/ui/guest/src/classes/ElementRegistry.ts
@@ -44,9 +44,8 @@ import { removeLastPiece } from '../utils/string';
 import $ from 'jquery';
 
 let seq = 0;
-
-const db: LookupTable<ElementRecord> = {};
-const registry = {};
+let db: LookupTable<ElementRecord> = {};
+let registry = {};
 
 export function get(id: number): ElementRecord {
   const record = db[id];
@@ -420,4 +419,10 @@ export function getParentsElementFromICEProps(
   });
 
   return recordId === null ? null : getRecordsFromIceId(recordId).map((registryEntry) => $(registryEntry.element));
+}
+
+export function flush(): void {
+  db = {};
+  registry = {};
+  iceRegistry.flush();
 }

--- a/ui/guest/src/react/DragGhostElement.tsx
+++ b/ui/guest/src/react/DragGhostElement.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Box, Theme } from '@mui/material';
+import { SxProps } from '@mui/system';
+
+export interface DragGhostElementProps {
+  sx?: SxProps<Theme>;
+  label: string;
+}
+
+export function DragGhostElement(props: DragGhostElementProps) {
+  return (
+    <Box
+      className="craftercms-dragged-element"
+      sx={{
+        display: 'block',
+        maxWidth: 200,
+        backgroundColor: 'common.white',
+        color: 'text.secondary',
+        padding: '5px 10px',
+        borderRadius: 1,
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+        position: 'absolute',
+        // top: -1000,
+        left: -1000,
+        ...props.sx
+      }}
+    >
+      {props.label}
+    </Box>
+  );
+}
+
+export default DragGhostElement;

--- a/ui/guest/src/react/DropMarker.tsx
+++ b/ui/guest/src/react/DropMarker.tsx
@@ -59,7 +59,7 @@ function getSx(sx: DropMarkerPartialSx): DropMarkerFullSx {
       position: 'absolute',
       ...sx?.tips
     },
-    horizontal: {
+    vertical: {
       height: 2,
       visibility: 'visible',
       backgroundColor: 'primary.main',
@@ -72,7 +72,7 @@ function getSx(sx: DropMarkerPartialSx): DropMarkerFullSx {
       },
       ...sx?.horizontal
     },
-    vertical: {
+    horizontal: {
       width: 2,
       minHeight: '5px',
       marginLeft: '3px',

--- a/ui/guest/src/react/Guest.tsx
+++ b/ui/guest/src/react/Guest.tsx
@@ -149,8 +149,12 @@ function Guest(props: GuestProps) {
             if (refs.current.keysPressed.z && type === 'click') {
               return false;
             }
-            event.preventDefault();
-            event.stopPropagation();
+            // Click & dblclick require stopping as early as possible to avoid
+            // navigation or other click defaults.
+            if (type === 'click' || 'dblclick' === type) {
+              event.preventDefault();
+              event.stopPropagation();
+            }
             dispatch({ type: type, payload: { event, record } });
             return true;
           }
@@ -454,6 +458,15 @@ function Guest(props: GuestProps) {
 
   const draggableItemElemRecId = Object.entries(state.draggable ?? {}).find(([, ice]) => ice !== false)?.[0];
 
+  const hasZoneMarker =
+    [
+      EditingStatus.SORTING_COMPONENT,
+      EditingStatus.PLACING_NEW_COMPONENT,
+      EditingStatus.PLACING_DETACHED_COMPONENT
+    ].includes(status) &&
+    state.dragContext.inZone &&
+    !state.dragContext.invalidDrop;
+
   return (
     <GuestContextProvider value={context}>
       {children}
@@ -510,22 +523,16 @@ function Guest(props: GuestProps) {
               );
             })}
 
-            {[
-              EditingStatus.SORTING_COMPONENT,
-              EditingStatus.PLACING_NEW_COMPONENT,
-              EditingStatus.PLACING_DETACHED_COMPONENT
-            ].includes(status) &&
-              state.dragContext.inZone &&
-              !state.dragContext.invalidDrop && (
-                <DropMarker
-                  onDropPosition={(payload) => dispatch(setDropPosition(payload))}
-                  dropZone={state.dragContext.dropZone}
-                  over={state.dragContext.over}
-                  prev={state.dragContext.prev}
-                  next={state.dragContext.next}
-                  coordinates={state.dragContext.coordinates}
-                />
-              )}
+            {hasZoneMarker && (
+              <DropMarker
+                onDropPosition={(payload) => dispatch(setDropPosition(payload))}
+                dropZone={state.dragContext.dropZone}
+                over={state.dragContext.over}
+                prev={state.dragContext.prev}
+                next={state.dragContext.next}
+                coordinates={state.dragContext.coordinates}
+              />
+            )}
           </CrafterCMSPortal>
         )}
         {snack && (

--- a/ui/guest/src/react/MoveModeZoneMenu.tsx
+++ b/ui/guest/src/react/MoveModeZoneMenu.tsx
@@ -20,36 +20,75 @@ import ArrowDownwardRoundedIcon from '@mui/icons-material/ArrowDownwardRounded';
 import ArrowUpwardRoundedIcon from '@mui/icons-material/ArrowUpwardRounded';
 import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded';
 import UltraStyledIconButton from './UltraStyledIconButton';
+import HighlightOffRoundedIcon from '@mui/icons-material/HighlightOffRounded';
+import { Tooltip } from '@mui/material';
+import { useDispatch } from './GuestContext';
+import * as elementRegistry from '../classes/ElementRegistry';
+import DragGhostElement from './DragGhostElement';
 
-export interface MoveModeZoneMenuProps {}
+export interface MoveModeZoneMenuProps {
+  [key: string]: any;
+}
 
 export function MoveModeZoneMenu(props: MoveModeZoneMenuProps) {
+  const { record, dispatch } = props;
+  // const dispatch = useDispatch();
   // region callbacks
   const onMoveUp = () => void 0;
   const onMoveDown = () => void 0;
   const onTrash = () => void 0;
+  const onCancel = () => void 0;
   const onDragStart = (e) => {
-    e.preventDefault();
     e.stopPropagation();
-    console.log('Drag start');
+    const image = document.querySelector('.craftercms-dragged-element');
+    e.dataTransfer.setData('text/plain', `${record.id}`);
+    e.dataTransfer.setDragImage(image, 20, 20);
+    setTimeout(() => {
+      dispatch({ type: 'dragstart', payload: { event: e, record } });
+    });
   };
   // endregion
   return (
     <>
-      <UltraStyledIconButton size="small" onClick={onMoveUp}>
-        <ArrowUpwardRoundedIcon />
-      </UltraStyledIconButton>
-      <UltraStyledIconButton size="small" onClick={onMoveDown}>
-        <ArrowDownwardRoundedIcon />
-      </UltraStyledIconButton>
-      <UltraStyledIconButton size="small" onClick={onTrash}>
-        <DeleteOutlineRoundedIcon />
-      </UltraStyledIconButton>
-      <UltraStyledIconButton size="small" draggable sx={{ cursor: 'grab' }} onDragStart={onDragStart}>
-        <DragIndicatorRounded />
-      </UltraStyledIconButton>
+      <DragGhostElement label="Test Test Test" />
+      <Tooltip title="Cancel (Esc)">
+        <UltraStyledIconButton size="small" onClick={onCancel}>
+          <HighlightOffRoundedIcon />
+        </UltraStyledIconButton>
+      </Tooltip>
+      <Tooltip title="Move up/left (← or ↑)">
+        <UltraStyledIconButton size="small" onClick={onMoveUp}>
+          <ArrowUpwardRoundedIcon />
+        </UltraStyledIconButton>
+      </Tooltip>
+      <Tooltip title="Move down/right (→ or ↓)">
+        <UltraStyledIconButton size="small" onClick={onMoveDown}>
+          <ArrowDownwardRoundedIcon />
+        </UltraStyledIconButton>
+      </Tooltip>
+      <Tooltip title="Trash (⌫)">
+        <UltraStyledIconButton size="small" onClick={onTrash}>
+          <DeleteOutlineRoundedIcon />
+        </UltraStyledIconButton>
+      </Tooltip>
+      <Tooltip title="Move">
+        <UltraStyledIconButton size="small" draggable sx={{ cursor: 'grab' }} onDragStart={onDragStart}>
+          <DragIndicatorRounded />
+        </UltraStyledIconButton>
+      </Tooltip>
     </>
   );
 }
+
+// Could use a more generic version...
+// function IconButtonCollection({ actions }) {
+//   return actions.map((action) => (
+//     <Tooltip title={`${action.label} ${action.shortcut ?? ''}`.trim()}>
+//       <UltraStyledIconButton size="small" {...action.props}>
+//         <DragIndicatorRounded />
+//       </UltraStyledIconButton>
+//     </Tooltip>
+//   ));
+// }
 
 export default MoveModeZoneMenu;

--- a/ui/guest/src/react/ZoneMarker.tsx
+++ b/ui/guest/src/react/ZoneMarker.tsx
@@ -98,7 +98,7 @@ export function ZoneMarker(props: ZoneMarkerProps) {
         >
           <Paper className={classes?.paper} sx={sx.paper}>
             {inherited ? <LevelDescriptorIcon sx={sx.icon} /> : <FieldIcon sx={sx.icon} />}
-            <Typography title={label} noWrap>
+            <Typography title={label} noWrap sx={{ pointerEvents: 'all' }}>
               {label}
             </Typography>
             {menuItems && (

--- a/ui/guest/src/store/epics/root.ts
+++ b/ui/guest/src/store/epics/root.ts
@@ -71,6 +71,16 @@ import {
 } from '../actions';
 
 const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
+  // region mouseover, mouseleave
+  (action$, state$) =>
+    action$.pipe(
+      ofType('mouseover', 'mouseleave'),
+      withLatestFrom(state$),
+      filter((args) => args[1].status === EditingStatus.LISTENING),
+      tap(([action]) => action.payload.event.stopPropagation()),
+      ignoreElements()
+    ),
+  // endregion
   // region dragstart
   (action$: MouseEventActionObservable, state$) =>
     action$.pipe(
@@ -276,12 +286,11 @@ const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
     ),
   // endregion
   // region assetDragEnded, componentDragEnded, componentInstanceDragEnded, desktopAssetDragEnded
-  (action$: MouseEventActionObservable) => {
-    return action$.pipe(
+  (action$: MouseEventActionObservable) =>
+    action$.pipe(
       ofType(assetDragEnded.type, componentDragEnded.type, componentInstanceDragEnded.type, desktopAssetDragEnded.type),
       map(() => computedDragEnd())
-    );
-  },
+    ),
   // endregion
   // region click
   (action$: MouseEventActionObservable, state$) =>
@@ -339,6 +348,8 @@ const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
         } else if (state.highlightMode === HighlightMode.MOVE_TARGETS) {
           const movableRecordId = iceRegistry.getMovableParentRecord(record.iceIds[0]);
           if (notNullOrUndefined(movableRecordId)) {
+            // Inform host of the field selection
+            // post();
             // By this point element is already highlighted. We just need to freeze
             // and change mode to reveal the move/sort options.
             return merge(
@@ -480,8 +491,8 @@ const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
   },
   // endregion
   // region componentDragStarted
-  (action$: MouseEventActionObservable, state$) => {
-    return action$.pipe(
+  (action$: MouseEventActionObservable, state$) =>
+    action$.pipe(
       ofType(componentDragStarted.type),
       withLatestFrom(state$),
       switchMap(([, state]) => {
@@ -502,8 +513,7 @@ const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
         }
         return NEVER;
       })
-    );
-  },
+    ),
   // endregion
   // region componentInstanceDragStarted
   (action$: MouseEventActionObservable, state$) => {

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -21,7 +21,8 @@ import {
   getHighlighted,
   getHoverData,
   getRecordsFromIceId,
-  getSiblingRects
+  getSiblingRects,
+  getDraggable
 } from '../../classes/ElementRegistry';
 import { dragOk } from '../util';
 import * as iceRegistry from '../../classes/ICERegistry';
@@ -122,12 +123,17 @@ const reducer = createReducer(initialState, {
         const iceId = record.iceIds[0];
         const movableRecordId = iceRegistry.getMovableParentRecord(iceId);
         if (notNullOrUndefined(movableRecordId)) {
+          const draggable = getDraggable(movableRecordId);
           const highlight = getHoverData(
             // If (iceId == movableRecordId) the current record is already
             // the one to show the highlight on.
             iceId === movableRecordId ? record.id : fromICEId(movableRecordId).id
           );
-          return { ...state, highlighted: { [record.id]: highlight } };
+          return {
+            ...state,
+            highlighted: { [movableRecordId]: highlight },
+            draggable: draggable ? { [movableRecordId]: draggable } : state.draggable
+          };
         }
       }
     }
@@ -149,8 +155,8 @@ const reducer = createReducer(initialState, {
   dragstart: (state, action) => {
     const { record } = action.payload;
     // onMouseOver pre-populates the draggable record
-    // Items that browser make draggable by default (images, etc)
     const iceId = state.draggable?.[record.id];
+    // Items that browser make draggable by default (images, etc) may not have an ice id
     if (notNullOrUndefined(iceId)) {
       const dropTargets = iceRegistry.getRecordDropTargets(iceId);
       const validationsLookup = iceRegistry.runDropTargetsValidations(dropTargets);
@@ -160,7 +166,6 @@ const reducer = createReducer(initialState, {
         record
       );
       const highlighted = getHighlighted(dropZones);
-
       return {
         ...state,
         highlighted,
@@ -385,18 +390,24 @@ const reducer = createReducer(initialState, {
   }),
   // endregion
   // region setPreviewEditMode
-  [setPreviewEditMode.type]: (state, action) => ({
-    ...state,
-    highlighted: {},
-    editMode: action.payload.editMode
-  }),
+  [setPreviewEditMode.type]: (state, action) =>
+    action.payload.editMode !== state.editMode
+      ? {
+          ...state,
+          highlighted: {},
+          editMode: action.payload.editMode
+        }
+      : state,
   // endregion
   // region highlightModeChanged
-  [highlightModeChanged.type]: (state, { payload }) => ({
-    ...state,
-    highlighted: {},
-    highlightMode: payload.highlightMode
-  }),
+  [highlightModeChanged.type]: (state, { payload }) =>
+    state.highlightMode !== payload.highlightMode
+      ? {
+          ...state,
+          highlighted: {},
+          highlightMode: payload.highlightMode
+        }
+      : state,
   // endregion
   // region contentTypeDropTargetsRequest
   // TODO: Not pure

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -41,6 +41,7 @@ import {
   contentTreeFieldSelected,
   contentTreeSwitchFieldInstance,
   contentTypeDropTargetsRequest,
+  desktopAssetUploadComplete,
   desktopAssetUploadProgress,
   desktopAssetUploadStarted,
   highlightModeChanged,
@@ -436,9 +437,12 @@ const reducer = createReducer(initialState, {
     }
   }),
   // endregion
-  // region DESKTOP_ASSET_UPLOAD_COMPLETE
+  // region desktopAssetUploadComplete
   // TODO: Carry or retrieve record for these events
-  DESKTOP_ASSET_UPLOAD_COMPLETE: (state, { payload: { record } }: GuestStandardAction<{ record: ElementRecord }>) => ({
+  [desktopAssetUploadComplete.type]: (
+    state,
+    { payload: { record } }: GuestStandardAction<{ record: ElementRecord }>
+  ) => ({
     ...state,
     uploading: reversePluckProps(state.uploading, record.id)
   }),

--- a/ui/guest/src/utils/contentType.ts
+++ b/ui/guest/src/utils/contentType.ts
@@ -57,18 +57,18 @@ export function getField(
   fieldId: string,
   contentTypes?: LookupTable<ContentType>
 ): ContentTypeField {
-  if (!contentTypes) {
-    throw new Error(
-      `Content types not provided to content type helper \`getField\` method. ` +
-        `Unable to retrieve the field \`${fieldId}\` without full list of content types.`
-    );
-  }
   const fields = fieldId.split('.');
   let accumulator = Array.isArray(type.fields) ? createLookupTable(type.fields) : type.fields;
   let parsedFieldId = [];
   fields.forEach((field) => {
     parsedFieldId.push(field);
     if (accumulator.type === 'node-selector') {
+      if (!contentTypes) {
+        throw new Error(
+          `Content types not provided to content type helper \`getField\` method. ` +
+            `Unable to retrieve the field \`${fieldId}\` without full list of content types.`
+        );
+      }
       const contentTypeWithTargetFieldId = accumulator.validations.allowedContentTypes.value.find((ct) =>
         Boolean(contentTypes[ct].fields[field])
       );


### PR DESCRIPTION
- Restore drag & drop
- Migrate DropMarker component to new styles system
- Add `yarn start` as an alias for rollup watch on guest package
- Add `flush` method to ElementRegistry
- Revert change on contentType.ts that caused a bug

craftercms/craftercms#4646