### PR TITLE
[5039] Don't attempt to renew token if it's already expired

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -134,7 +134,6 @@
     "@babel/cli": "^7.8.3",
     "@babel/core": "^7.8.3",
     "@babel/runtime": "^7.8.3",
-    "@types/react": "^17.0.21",
     "babel-plugin-react-intl": "^5.1.16",
     "ncp": "^2.0.0",
     "prop-types": "^15.7.2",

--- a/ui/app/src/shared-worker.ts
+++ b/ui/app/src/shared-worker.ts
@@ -74,46 +74,59 @@ function onmessage(event) {
   }
 }
 
+function isExpired(time = Date.now()) {
+  return current.expiresAt !== null && time >= current.expiresAt;
+}
+
+function unauthenticated() {
+  log(`Auth has expired`);
+  status = 'expired';
+  broadcast(sharedWorkerUnauthenticated());
+}
+
 function retrieve() {
   clearTimeout(timeout);
-  return obtainAuthToken().subscribe({
-    next(response) {
-      if (response) {
-        log('New token received');
-        status = 'active';
-        current = response;
-        broadcast(sharedWorkerToken(current));
-        refreshInterval = Math.floor((current.expiresAt - Date.now()) * refreshAtFactor);
-        if (clients.length) {
-          // If there are clients connected, keep the token refresh going
-          timeout = self.setTimeout(retrieve, refreshInterval);
+  if (isExpired()) {
+    log(`Skipping token retrieval: local expiration check determined auth is expired.`);
+    unauthenticated();
+    return null;
+  } else {
+    return obtainAuthToken().subscribe({
+      next(response) {
+        if (response) {
+          log('New token received');
+          status = 'active';
+          current = response;
+          broadcast(sharedWorkerToken(current));
+          refreshInterval = Math.floor((current.expiresAt - Date.now()) * refreshAtFactor);
+          if (clients.length) {
+            // If there are clients connected, keep the token refresh going
+            timeout = self.setTimeout(retrieve, refreshInterval);
+          } else {
+            // Do SharedWorkers stop as soon as all their tabs are terminated?
+            clearTimeout(timeout);
+          }
         } else {
-          // Do SharedWorkers stop as soon as all their tabs are terminated?
-          clearTimeout(timeout);
+          unauthenticated();
         }
-      } else {
-        log(`Auth has expired`);
-        status = 'expired';
-        broadcast(sharedWorkerUnauthenticated());
-      }
-      return current;
-    },
-    error(e: AjaxError) {
-      clearTimeout(timeout);
-      log('Error retrieving token', e);
-      if (e.status === 401) {
-        status = 'expired';
-        broadcast(sharedWorkerUnauthenticated());
-      } else {
-        status = 'error';
-        broadcast(sharedWorkerError({ status: e.status, message: e.message }));
-        // If there are clients connected try again.
-        if (clients.length) {
-          timeout = self.setTimeout(retrieve, Math.floor(refreshInterval * 0.9));
+        return current;
+      },
+      error(e: AjaxError) {
+        clearTimeout(timeout);
+        log('Error retrieving token', e);
+        if (e.status === 401) {
+          unauthenticated();
+        } else {
+          status = 'error';
+          broadcast(sharedWorkerError({ status: e.status, message: e.message }));
+          // If there are clients connected try again.
+          if (clients.length) {
+            timeout = self.setTimeout(retrieve, Math.floor(refreshInterval * 0.9));
+          }
         }
       }
-    }
-  });
+    });
+  }
 }
 
 function broadcast(message: StandardAction, excludedClient?: MessagePort) {

--- a/ui/app/src/shared-worker.ts
+++ b/ui/app/src/shared-worker.ts
@@ -76,8 +76,8 @@ function onmessage(event) {
 
 function retrieve() {
   clearTimeout(timeout);
-  return obtainAuthToken().subscribe(
-    (response) => {
+  return obtainAuthToken().subscribe({
+    next(response) {
       if (response) {
         log('New token received');
         status = 'active';
@@ -98,7 +98,7 @@ function retrieve() {
       }
       return current;
     },
-    (e: AjaxError) => {
+    error(e: AjaxError) {
       clearTimeout(timeout);
       log('Error retrieving token', e);
       if (e.status === 401) {
@@ -113,7 +113,7 @@ function retrieve() {
         }
       }
     }
-  );
+  });
 }
 
 function broadcast(message: StandardAction, excludedClient?: MessagePort) {

--- a/ui/app/src/state/store.ts
+++ b/ui/app/src/state/store.ts
@@ -93,7 +93,6 @@ function registerSharedWorker(): Observable<ObtainAuthTokenResponse & { worker: 
     return fromEvent<MessageEvent>(worker.port, 'message').pipe(
       tap((e) => {
         if (e.data?.type === sharedWorkerUnauthenticated.type) {
-          window.location.reload();
           throw new Error('User not authenticated.');
         }
       }),


### PR DESCRIPTION
- craftercms/craftercms#5039
- Change deprecated subscribe method call signature in worker
- remove @types/react from the app package in favour of using the one at the shared root (workspace)
