### PR TITLE
[4663] Preview stops working after a 403

### DIFF
--- a/ui/app/src/components/PreviewAddressBar/PreviewAddressBar.tsx
+++ b/ui/app/src/components/PreviewAddressBar/PreviewAddressBar.tsx
@@ -160,7 +160,7 @@ export function PreviewAddressBar(props: AddressBarProps) {
       <PreviewBackButton />
       <PreviewForwardButton />
       <Tooltip title={<FormattedMessage id="previewAddressBar.reloadButtonLabel" defaultMessage="Reload this page" />}>
-        <IconButton onClick={onRefresh} size="large">
+        <IconButton onClick={onRefresh} size="large" disabled={disabled}>
           <RefreshRounded />
         </IconButton>
       </Tooltip>
@@ -186,7 +186,6 @@ export function PreviewAddressBar(props: AddressBarProps) {
           />
         )}
         <SingleItemSelector
-          disabled={disabled}
           rootPath="/site/website/index.xml"
           selectedItem={item as DetailedItem}
           open={openSelector}

--- a/ui/app/src/components/SingleItemSelector/SingleItemSelector.tsx
+++ b/ui/app/src/components/SingleItemSelector/SingleItemSelector.tsx
@@ -346,7 +346,11 @@ export default function SingleItemSelector(props: SingleItemSelectorProps) {
 
   const handleDropdownClick = (item: DetailedItem) => {
     onDropdownClick();
-    let nextPath = withoutIndex(item.path) === withoutIndex(rootPath) ? item.path : getParentPath(item.path);
+    let nextPath = item
+      ? withoutIndex(item.path) === withoutIndex(rootPath)
+        ? item.path
+        : getParentPath(item.path)
+      : rootPath;
     exec(fetchParentsItems(nextPath));
   };
 

--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -850,14 +850,9 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
           horizontal: 'center'
         }}
         action={
-          <>
-            <Button key="learnMore" color="secondary" size="small">
-              Learn More
-            </Button>
-            <IconButton color="secondary" size="small" onClick={() => setGuestDetectionSnackbarOpen(false)}>
-              <CloseRounded />
-            </IconButton>
-          </>
+          <IconButton color="secondary" size="small" onClick={() => setGuestDetectionSnackbarOpen(false)}>
+            <CloseRounded />
+          </IconButton>
         }
       />
       <KeyboardShortcutsDialog


### PR DESCRIPTION
- Remove Learn more link from no guest detected snackbar
- Disable refresh when no guest is detected
- Enable SingleItemSelector when no guest is detected

https://github.com/craftercms/craftercms/issues/4663