### PR TITLE
[5061][5062] - Shared content DS issues

### DIFF
--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -271,7 +271,7 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
     }
 
     if (this.enableSearchExisting || this.defaultEnableSearchExisting) {
-      if (this.countOptions > 1) {
+      if (this.countOptions > 1 || onlyAppend) {
         addContainerEl.search = document.createElement('div');
         addContainerEl.appendChild(addContainerEl.search);
         YAHOO.util.Dom.addClass(addContainerEl.search, 'cstudio-form-controls-search-element');

--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -174,7 +174,8 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
     }
 
     if (this.browsePath) {
-      searchContext.path = this.browsePath.endsWith('/') ? `${this.browsePath}.+` : `${this.browsePath}/.+`;
+      const path = _self.processPathsForMacros(this.browsePath)
+      searchContext.path = path.endsWith('/') ? `${path}.+` : `${path}/.+`;
       searchContext.externalPath = true;
     }
 


### PR DESCRIPTION
When search is enabled for a DS and on the browse path the parentPath macro is used, an exception is thrown #5061 - https://github.com/craftercms/craftercms/issues/5061
Studio opens both DS when they're setup for search #5062 - https://github.com/craftercms/craftercms/issues/5062
