### PR TITLE
[5061][5062][next] - Shared content DS issues

### DIFF
--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -245,7 +245,7 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
     }
 
     if (this.enableSearchExisting || this.defaultEnableSearchExisting) {
-      if (this.countOptions > 1) {
+      if (this.countOptions > 1 || onlyAppend) {
         const search = $(
           `<li class="cstudio-form-controls-search-element"><a class="cstudio-form-control-node-selector-add-container-item">${CMgs.format(
             langBundle,

--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -160,7 +160,8 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
     }
 
     if (this.browsePath) {
-      searchContext.path = this.browsePath.endsWith('/') ? `${this.browsePath}.+` : `${this.browsePath}/.+`;
+      const path = _self.processPathsForMacros(this.browsePath);
+      searchContext.path = path.endsWith('/') ? `${path}.+` : `${path}/.+`;
     }
 
     CStudioAuthoring.Operations.openSearch(

--- a/ui/legacy/src/components/cstudio-forms/data-sources/dropTargets.js
+++ b/ui/legacy/src/components/cstudio-forms/data-sources/dropTargets.js
@@ -150,8 +150,14 @@
       return [];
     },
 
+    _processPathsForMacros: function (path) {
+      const model = this.form.model;
+      return CStudioAuthoring.Operations.processPathsForMacros(path, model);
+    },
+
     _openBrowse: function (contentType, control) {
-      const path = `${this.baseBrowsePath}/${contentType.replace(/\//g, '_').substr(1)}`;
+      let path = this._processPathsForMacros(this.baseBrowsePath);
+      path = `${path}/${contentType.replace(/\//g, '_').substr(1)}`;
       CStudioAuthoring.Operations.openBrowse('', path, -1, 'select', true, {
         success: function (searchId, selectedTOs) {
           for (let i = 0; i < selectedTOs.length; i++) {


### PR DESCRIPTION
When search is enabled for a DS and on the browse path the parentPath macro is used, an exception is thrown #5061 - craftercms/craftercms#5061
Studio opens both DS when they're setup for search #5062 - craftercms/craftercms#5062