### PR TITLE
[5081] When an item is selected in move mode and the user switches to edit mode, the item still behaves as movable

### DIFF
--- a/ui/guest/src/react/Guest.tsx
+++ b/ui/guest/src/react/Guest.tsx
@@ -219,6 +219,9 @@ function Guest(props: GuestProps) {
       switch (type) {
         case highlightModeChanged.type:
         case setPreviewEditMode.type:
+          if (status === EditingStatus.FIELD_SELECTED && action.payload.highlightMode !== 'move') {
+            clearAndListen$.next();
+          }
           dispatch(action);
           break;
         case assetDragStarted.type:

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -409,7 +409,6 @@ const reducer = createReducer(initialState, {
     state.highlightMode !== payload.highlightMode
       ? {
           ...resetState(state),
-          highlighted: {},
           highlightMode: payload.highlightMode
         }
       : state,

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -408,7 +408,7 @@ const reducer = createReducer(initialState, {
   [highlightModeChanged.type]: (state, { payload }) =>
     state.highlightMode !== payload.highlightMode
       ? {
-          ...state,
+          ...resetState(state),
           highlighted: {},
           highlightMode: payload.highlightMode
         }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5081