### PR TITLE
[3.1] Remove accent/diacritics in file-name control

### DIFF
--- a/static-assets/components/cstudio-forms/controls/file-name.js
+++ b/static-assets/components/cstudio-forms/controls/file-name.js
@@ -164,6 +164,9 @@ YAHOO.extend(CStudioForms.Controls.FileName, CStudioForms.CStudioFormField, {
         el.selectionEnd = cursorPosition;
       }
     }
+    // Remove accents/diacritics
+    el.value = el.value.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+
     var data = el.value;
 
     if (invalid.exec(data) != null) {


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Replace accent/diacritics character to English character in file-name control.

Ex: Copy/Paste text `Crème Brûlée` to the form URL will result with text `creme-brulee`

![2021-12-02_13-59](https://user-images.githubusercontent.com/2996543/144373559-f53573e4-5ba2-4de1-aba9-094523885454.png)

