### PR TITLE
[next] Add option to file-name control to remove accent/diacritics

### DIFF
--- a/static-assets/components/cstudio-common/resources/de/base.js
+++ b/static-assets/components/cstudio-common/resources/de/base.js
@@ -845,7 +845,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'de', {
   enableBrowseExisting: "Zeige 'Auswählen'",
   enableSearchExisting: "Zeige 'Suchen'",
   useSearch: 'Suche verwenden',
-  allowEditWithoutWarning: 'Allow Edit Without Warning',
+  allowEditWithoutWarning: 'Bearbeiten ohne Warnung zulassen',
   replaceAccent: 'Konvertieren Sie Akzente/diakritische Zeichen in lateinische Zeichen',
 
   /*Restrictions*/

--- a/static-assets/components/cstudio-common/resources/de/base.js
+++ b/static-assets/components/cstudio-common/resources/de/base.js
@@ -846,7 +846,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'de', {
   enableSearchExisting: "Zeige 'Suchen'",
   useSearch: 'Suche verwenden',
   allowEditWithoutWarning: 'Allow Edit Without Warning',
-  replaceAccent: 'Convert accent/diacritics to latin characters',
+  replaceAccent: 'Konvertieren Sie Akzente/diakritische Zeichen in lateinische Zeichen',
 
   /*Restrictions*/
   required: 'Erforderlich',

--- a/static-assets/components/cstudio-common/resources/de/base.js
+++ b/static-assets/components/cstudio-common/resources/de/base.js
@@ -846,7 +846,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'de', {
   enableSearchExisting: "Zeige 'Suchen'",
   useSearch: 'Suche verwenden',
   allowEditWithoutWarning: 'Bearbeiten ohne Warnung zulassen',
-  replaceAccent: 'Konvertieren Sie Akzente/diakritische Zeichen in lateinische Zeichen',
+  allowAccent: 'Akzente und diakritische Zeichen zulassen',
 
   /*Restrictions*/
   required: 'Erforderlich',

--- a/static-assets/components/cstudio-common/resources/de/base.js
+++ b/static-assets/components/cstudio-common/resources/de/base.js
@@ -845,6 +845,8 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'de', {
   enableBrowseExisting: "Zeige 'Auswählen'",
   enableSearchExisting: "Zeige 'Suchen'",
   useSearch: 'Suche verwenden',
+  allowEditWithoutWarning: 'Allow Edit Without Warning',
+  replaceAccent: 'Convert accent/diacritics to latin characters',
 
   /*Restrictions*/
   required: 'Erforderlich',

--- a/static-assets/components/cstudio-common/resources/en/base.js
+++ b/static-assets/components/cstudio-common/resources/en/base.js
@@ -842,7 +842,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'en', {
   enableSearchExisting: 'Enable Search Existing',
   useSearch: 'Use Search',
   allowEditWithoutWarning: 'Allow Edit Without Warning',
-  replaceAccent: 'Convert accent/diacritics to latin characters',
+  allowAccent: 'Allow accents and diacritics',
 
   /*Restrictions*/
   required: 'Required',

--- a/static-assets/components/cstudio-common/resources/en/base.js
+++ b/static-assets/components/cstudio-common/resources/en/base.js
@@ -842,6 +842,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'en', {
   enableSearchExisting: 'Enable Search Existing',
   useSearch: 'Use Search',
   allowEditWithoutWarning: 'Allow Edit Without Warning',
+  replaceAccent: 'Convert accent/diacritics to latin characters',
 
   /*Restrictions*/
   required: 'Required',

--- a/static-assets/components/cstudio-common/resources/es/base.js
+++ b/static-assets/components/cstudio-common/resources/es/base.js
@@ -812,7 +812,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'es', {
   enableSearchExisting: "Mostrar 'Buscar Existentes'",
   useSearch: 'Usar Búsqueda',
   allowEditWithoutWarning: 'Permitir edición sin advertencia',
-  replaceAccent: 'Convert accent/diacritics to latin characters',
+  replaceAccent: 'Convertir acentos/diacríticos en caracteres latinos',
 
   /*Restrictions*/
   required: 'Requerido',

--- a/static-assets/components/cstudio-common/resources/es/base.js
+++ b/static-assets/components/cstudio-common/resources/es/base.js
@@ -812,7 +812,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'es', {
   enableSearchExisting: "Mostrar 'Buscar Existentes'",
   useSearch: 'Usar Búsqueda',
   allowEditWithoutWarning: 'Permitir edición sin advertencia',
-  replaceAccent: 'Convertir acentos/diacríticos en caracteres latinos',
+  allowAccent: 'Permitir acentos y diacríticos',
 
   /*Restrictions*/
   required: 'Requerido',

--- a/static-assets/components/cstudio-common/resources/es/base.js
+++ b/static-assets/components/cstudio-common/resources/es/base.js
@@ -811,7 +811,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'es', {
   enableBrowseExisting: "Mostrar 'Seleccionar Existentes'",
   enableSearchExisting: "Mostrar 'Buscar Existentes'",
   useSearch: 'Usar Búsqueda',
-  allowEditWithoutWarning: 'Allow Edit Without Warning',
+  allowEditWithoutWarning: 'Permitir edición sin advertencia',
   replaceAccent: 'Convert accent/diacritics to latin characters',
 
   /*Restrictions*/

--- a/static-assets/components/cstudio-common/resources/es/base.js
+++ b/static-assets/components/cstudio-common/resources/es/base.js
@@ -811,6 +811,8 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'es', {
   enableBrowseExisting: "Mostrar 'Seleccionar Existentes'",
   enableSearchExisting: "Mostrar 'Buscar Existentes'",
   useSearch: 'Usar Búsqueda',
+  allowEditWithoutWarning: 'Allow Edit Without Warning',
+  replaceAccent: 'Convert accent/diacritics to latin characters',
 
   /*Restrictions*/
   required: 'Requerido',

--- a/static-assets/components/cstudio-common/resources/fr/base.js
+++ b/static-assets/components/cstudio-common/resources/fr/base.js
@@ -34,8 +34,3 @@ CStudioAuthoring.Messages.registerBundle('siteDashboard', 'fr', {
   dashletGoLiveEdit: 'FR-Edit'
 });
 
-CStudioAuthoring.Messages.registerBundle('contentTypes', 'fr', {
-  /*Properties*/
-  allowEditWithoutWarning: 'Allow Edit Without Warning',
-  replaceAccent: 'Convert accent/diacritics to latin characters',
-});

--- a/static-assets/components/cstudio-common/resources/fr/base.js
+++ b/static-assets/components/cstudio-common/resources/fr/base.js
@@ -33,3 +33,9 @@ CStudioAuthoring.Messages.registerBundle('siteDashboard', 'fr', {
   dashletGoLiveAssets: 'FR-Assets ({0})',
   dashletGoLiveEdit: 'FR-Edit'
 });
+
+CStudioAuthoring.Messages.registerBundle('contentTypes', 'fr', {
+  /*Properties*/
+  allowEditWithoutWarning: 'Allow Edit Without Warning',
+  replaceAccent: 'Convert accent/diacritics to latin characters',
+});

--- a/static-assets/components/cstudio-common/resources/kr/base.js
+++ b/static-assets/components/cstudio-common/resources/kr/base.js
@@ -778,7 +778,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'kr', {
   enableBrowseExisting: '쇼 기존 항목 찾아보기',
   enableSearchExisting: '쇼 기존 검색',
   useSearch: '검색 사용',
-  allowEditWithoutWarning: 'Allow Edit Without Warning',
+  allowEditWithoutWarning: '경고 없이 편집 허용',
   replaceAccent: 'Convert accent/diacritics to latin characters',
 
   /*Restrictions*/

--- a/static-assets/components/cstudio-common/resources/kr/base.js
+++ b/static-assets/components/cstudio-common/resources/kr/base.js
@@ -778,6 +778,8 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'kr', {
   enableBrowseExisting: '쇼 기존 항목 찾아보기',
   enableSearchExisting: '쇼 기존 검색',
   useSearch: '검색 사용',
+  allowEditWithoutWarning: 'Allow Edit Without Warning',
+  replaceAccent: 'Convert accent/diacritics to latin characters',
 
   /*Restrictions*/
   required: '필요',

--- a/static-assets/components/cstudio-common/resources/kr/base.js
+++ b/static-assets/components/cstudio-common/resources/kr/base.js
@@ -779,7 +779,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'kr', {
   enableSearchExisting: '쇼 기존 검색',
   useSearch: '검색 사용',
   allowEditWithoutWarning: '경고 없이 편집 허용',
-  replaceAccent: 'Convert accent/diacritics to latin characters',
+  replaceAccent: '악센트/분음 부호를 라틴 문자로 변환',
 
   /*Restrictions*/
   required: '필요',

--- a/static-assets/components/cstudio-common/resources/kr/base.js
+++ b/static-assets/components/cstudio-common/resources/kr/base.js
@@ -779,7 +779,7 @@ CStudioAuthoring.Messages.registerBundle('contentTypes', 'kr', {
   enableSearchExisting: '쇼 기존 검색',
   useSearch: '검색 사용',
   allowEditWithoutWarning: '경고 없이 편집 허용',
-  replaceAccent: '악센트/분음 부호를 라틴 문자로 변환',
+  allowAccent: '악센트 및 발음 구별 부호 허용',
 
   /*Restrictions*/
   required: '필요',

--- a/static-assets/components/cstudio-common/resources/sr/base.js
+++ b/static-assets/components/cstudio-common/resources/sr/base.js
@@ -111,3 +111,9 @@ CStudioAuthoring.Messages.registerBundle('contextnav', 'en', {
 
   logout: 'Log Out'
 });
+
+CStudioAuthoring.Messages.registerBundle('contentTypes', 'sr', {
+  /*Properties*/
+  allowEditWithoutWarning: 'Allow Edit Without Warning',
+  replaceAccent: 'Convert accent/diacritics to latin characters',
+});

--- a/static-assets/components/cstudio-common/resources/sr/base.js
+++ b/static-assets/components/cstudio-common/resources/sr/base.js
@@ -111,9 +111,3 @@ CStudioAuthoring.Messages.registerBundle('contextnav', 'en', {
 
   logout: 'Log Out'
 });
-
-CStudioAuthoring.Messages.registerBundle('contentTypes', 'sr', {
-  /*Properties*/
-  allowEditWithoutWarning: 'Allow Edit Without Warning',
-  replaceAccent: 'Convert accent/diacritics to latin characters',
-});

--- a/static-assets/components/cstudio-forms/controls/file-name.js
+++ b/static-assets/components/cstudio-forms/controls/file-name.js
@@ -16,7 +16,7 @@
 
 CStudioForms.Controls.FileName =
   CStudioForms.Controls.FileName ||
-  function (id, form, owner, properties, constraints, readonly, allowEditWithoutWarning, replaceAccent) {
+  function (id, form, owner, properties, constraints, readonly, allowEditWithoutWarning, allowAccent) {
     this.owner = owner;
     this.owner.registerField(this);
     this.errors = [];
@@ -31,7 +31,7 @@ CStudioForms.Controls.FileName =
     this.contentAsFolder = form.definition ? form.definition.contentAsFolder : null;
     this.readonly = readonly;
     this.allowEditWithoutWarning = allowEditWithoutWarning;
-    this.replaceAccent = replaceAccent;
+    this.allowAccent = allowAccent;
     this.defaultValue = '';
     this.showWarnOnEdit = true;
     this.messages = {
@@ -152,7 +152,7 @@ YAHOO.extend(CStudioForms.Controls.FileName, CStudioForms.CStudioFormField, {
   /**
    * don't allow characters which are invalid for file names and check length
    */
-  processKey: function (evt, el, replaceAccent) {
+  processKey: function (evt, el, allowAccent) {
     var invalid = new RegExp('[.!@#$%^&*\\(\\)\\+=\\[\\]\\\\\\\'`;,\\/\\{\\}|":<>\\?~ ]', 'g');
     // Prevent the use of non english characters
     var nonEnglishChar = new RegExp('[^\x00-\x80]', 'g');
@@ -165,7 +165,7 @@ YAHOO.extend(CStudioForms.Controls.FileName, CStudioForms.CStudioFormField, {
         el.selectionEnd = cursorPosition;
       }
     }
-    if (replaceAccent) {
+    if (allowAccent) {
       el.value = el.value.normalize('NFD').replace(/\p{Diacritic}/gu, '');
     }
     var data = el.value;
@@ -292,8 +292,8 @@ YAHOO.extend(CStudioForms.Controls.FileName, CStudioForms.CStudioFormField, {
         this.allowEditWithoutWarning = true;
       }
 
-      if (prop.name == 'replaceAccent' && prop.value == 'true') {
-        this.replaceAccent = true;
+      if (prop.name == 'allowAccent' && prop.value == 'true') {
+        this.allowAccent = true;
       }
     }
 
@@ -329,7 +329,7 @@ YAHOO.extend(CStudioForms.Controls.FileName, CStudioForms.CStudioFormField, {
       inputEl,
       'keyup',
       function(evt, el) {
-        me.processKey(evt, el, me.replaceAccent);
+        me.processKey(evt, el, me.allowAccent);
       },
       inputEl
     );
@@ -338,7 +338,7 @@ YAHOO.extend(CStudioForms.Controls.FileName, CStudioForms.CStudioFormField, {
       'paste',
       function (evt, el) {
         setTimeout(function () {
-          me.processKey(evt, el, me.replaceAccent);
+          me.processKey(evt, el, me.allowAccent);
         }, 100);
       },
       inputEl
@@ -550,7 +550,7 @@ YAHOO.extend(CStudioForms.Controls.FileName, CStudioForms.CStudioFormField, {
       },
       { label: CMgs.format(langBundle, 'readonly'), name: 'readonly', type: 'boolean' },
       { label: CMgs.format(langBundle, 'allowEditWithoutWarning'), name: 'allowEditWithoutWarning', type: 'boolean' },
-      { label: CMgs.format(langBundle, 'replaceAccent'), name: 'replaceAccent', type: 'boolean' },
+      { label: CMgs.format(langBundle, 'allowAccent'), name: 'allowAccent', type: 'boolean' },
     ];
   },
 


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
An option to replace accent/diacritics to English characters from file-name control.
Ex:
Original string: à la carte, pied-à-terre, or crème
Transform string: a-la-carte--pied-a-terre--or-creme
![2022-01-11_14-44](https://user-images.githubusercontent.com/2996543/148901791-24a59f51-4781-4399-8a0a-344b892b19b3.png)
![2022-01-11_14-44_1](https://user-images.githubusercontent.com/2996543/148901795-145246d0-4742-4560-b63f-f87e3a0678ef.png)

