### PR TITLE
[next] Add style_formats config to RTE5

### DIFF
--- a/static-assets/components/cstudio-forms/controls/rte.js
+++ b/static-assets/components/cstudio-forms/controls/rte.js
@@ -223,6 +223,8 @@ CStudioAuthoring.Module.requireModule(
             toolbarConfig2,
             toolbarConfig3,
             toolbarConfig4,
+            styleFormats,
+            styleFormatsMerge,
             templates;
 
           containerEl.id = this.id;
@@ -300,6 +302,14 @@ CStudioAuthoring.Module.requireModule(
               : null;
 
           rteStyleOverride = rteConfig.rteStyleOverride ? rteConfig.rteStyleOverride : null;
+
+          // use tinymce default if not set
+          styleFormats =
+            rteConfig.styleFormats && rteConfig.styleFormats.length !== 0
+            ? Function(`"use strict"; return (${rteConfig.styleFormats})`)()
+            : undefined;
+
+          styleFormatsMerge = rteConfig.styleFormatsMerge === 'true';
 
           const $editorContainer = $(`#${rteId}`).parent(),
             editorContainerWidth = $editorContainer.width(),
@@ -414,6 +424,10 @@ CStudioAuthoring.Module.requireModule(
             code_editor_inline: true,
 
             external_plugins: external,
+
+            style_formats: styleFormats,
+
+            style_formats_merge: styleFormatsMerge,
 
             setup: function (editor) {
               editor.on('init', function (e) {


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/5237

Sample configuration:

```
        <styleFormats>
                <![CDATA[
            [
    {title : 'Bold text', inline : 'b'},
    {title : 'Red text', inline : 'span', styles : {color : '#ff0000'}},
    {title : 'Red header', block : 'h1', styles : {color : '#ff0000'}},
    {title : 'Example 1', inline : 'span', classes : 'example1'},
    {title : 'Example 2', inline : 'span', classes : 'example2'},
    {title : 'Table styles'},
    {title : 'Table row 1', selector : 'tr', classes : 'tablerow1'}
]
]]>
        </styleFormats>
        <styleFormatsMerge>true</styleFormatsMerge>
```