### PR TITLE
[5140] Undefined imageThumbnail showing in form definition when creating content-types

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -3301,7 +3301,7 @@
           definition.contentType +
           '</content-type>\r\n' +
           '\t<imageThumbnail>' +
-          definition.imageThumbnail +
+          (definition.imageThumbnail ?? '') +
           '</imageThumbnail>\r\n' +
           '\t<quickCreate>' +
           quickCreate +


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5140