### PR TITLE
[5300] Experience builder: In preview mode, when double clicking on a region that has in-context editing enabled, edit mode and move mode stops working

### DIFF
--- a/ui/guest/src/react/ExperienceBuilder.tsx
+++ b/ui/guest/src/react/ExperienceBuilder.tsx
@@ -181,9 +181,14 @@ function ExperienceBuilderInternal(props: InternalGuestProps) {
             }
             // Click & dblclick require stopping as early as possible to avoid
             // navigation or other click defaults.
-            if (type === 'click' || 'dblclick' === type) {
+            if (['click', 'dblclick'].includes(type)) {
               event.preventDefault();
               event.stopPropagation();
+            }
+            // Doing a dblclick already do two clicks, one for start editing and another one for leave editing
+            // returning false on dblclick prevents issues related to normal editing flow
+            if (type === 'dblclick') {
+              return false;
             }
             dispatch({ type, payload: { event, record } });
             return true;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5300

### Ticket reference or full description of what's in the PR
