### PR TITLE
[5314] Explorer folders on sidebar should start collapsed as the default

### DIFF
--- a/ui/app/src/state/reducers/pathNavigator.ts
+++ b/ui/app/src/state/reducers/pathNavigator.ts
@@ -49,7 +49,7 @@ const reducer = createReducer<LookupTable<PathNavigatorStateProps>>(
   {
     [pathNavigatorInit.type]: (
       state,
-      { payload: { id, path, currentPath, locale = 'en', collapsed = false, limit, keyword, offset, excludes } }
+      { payload: { id, path, currentPath, locale = 'en', collapsed = true, limit, keyword, offset, excludes } }
     ) => {
       return {
         ...state,


### PR DESCRIPTION
craftercms/craftercms#5314