### PR TITLE
Fix Model component props: remove index

### DIFF
--- a/ui/guest/src/react/Model.tsx
+++ b/ui/guest/src/react/Model.tsx
@@ -17,12 +17,12 @@
 import React, { forwardRef } from 'react';
 import Field, { FieldProps } from './Field';
 
-export type ModelProps<P = {}> = Omit<FieldProps<P>, 'fieldId'>;
+export type ModelProps<P = {}> = Omit<FieldProps<P>, 'fieldId' | 'index'>;
 
 export const Model = forwardRef<any, ModelProps>((props, ref) => {
   return <Field {...(props as FieldProps)} ref={ref} fieldId="__CRAFTERCMS_FAKE_FIELD__" />;
 });
 
-Model.propTypes = (({ fieldId, ...propTypes }) => propTypes)(Field.propTypes);
+Model.propTypes = (({ fieldId, index, ...propTypes }) => propTypes)(Field.propTypes);
 
 export default Model;


### PR DESCRIPTION
The `index` prop is not applicable to models.
