### PR TITLE
[5394] Content type variables with hyphens not handled appropriately for correct ftl syntax

### DIFF
--- a/ui/app/src/components/CodeEditorDialog/utils.ts
+++ b/ui/app/src/components/CodeEditorDialog/utils.ts
@@ -62,9 +62,11 @@ export function getContentModelSnippets(
 ): { label: string; value: string }[] {
   return Object.keys(fields).map((key) => ({
     label: fields[key].name,
-    value: contentModel.value.replace(
-      'VARIABLE_NAME',
-      contentTypePropsMap[fields[key].id] ? `"${contentTypePropsMap[fields[key].id]}"` : fields[key].id
-    )
+    value: contentModel.value
+      .replace(
+        'VARIABLE_NAME',
+        contentTypePropsMap[fields[key].id] ? `["${contentTypePropsMap[fields[key].id]}"]` : fields[key].id
+      )
+      .replace('.[', '[')
   }));
 }


### PR DESCRIPTION
craftercms/craftercms#5394