### PR TITLE
[5438] Path Navigator refreshes twice with skeletonization unlike Tree Navigator

### DIFF
--- a/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -232,10 +232,10 @@ export function PathNavigator(props: PathNavigatorProps) {
           const parentPath = getParentPath(targetPath);
           if (parentPath === withoutIndex(state.currentPath)) {
             // If item is direct children of root (in current pathNavigator view)
-            dispatch(pathNavigatorRefresh({ id }));
+            dispatch(pathNavigatorBackgroundRefresh({ id }));
           } else if (withoutIndex(targetPath) === withoutIndex(state.currentPath)) {
             // If item is root (in current pathNavigator view)
-            dispatch(pathNavigatorRefresh({ id }));
+            dispatch(pathNavigatorBackgroundRefresh({ id }));
           } else if (getParentPath(parentPath) === withoutIndex(state.currentPath)) {
             // if item just belongs to parent item
             dispatch(fetchSandboxItem({ path: parentPath, force: true }));
@@ -247,7 +247,7 @@ export function PathNavigator(props: PathNavigatorProps) {
 
           if (withoutIndex(targetPath) === withoutIndex(path)) {
             // if path being deleted is the rootPath
-            dispatch(pathNavigatorRefresh({ id }));
+            dispatch(pathNavigatorBackgroundRefresh({ id }));
           } else if (withoutIndex(targetPath) === withoutIndex(state.currentPath)) {
             // if path is currentPath (current root path)
             dispatch(
@@ -257,7 +257,7 @@ export function PathNavigator(props: PathNavigatorProps) {
               })
             );
           } else if (state.itemsInPath.includes(targetPath)) {
-            dispatch(pathNavigatorRefresh({ id }));
+            dispatch(pathNavigatorBackgroundRefresh({ id }));
           }
           break;
         }

--- a/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -247,7 +247,7 @@ export function PathNavigator(props: PathNavigatorProps) {
 
           if (withoutIndex(targetPath) === withoutIndex(path)) {
             // if path being deleted is the rootPath
-            dispatch(pathNavigatorBackgroundRefresh({ id }));
+            dispatch(pathNavigatorRefresh({ id }));
           } else if (withoutIndex(targetPath) === withoutIndex(state.currentPath)) {
             // if path is currentPath (current root path)
             dispatch(


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5438