### PR TITLE
[5479] Quick Create path form field is too short to hold long paths

### DIFF
--- a/static-assets/themes/cstudioTheme/css/console.css
+++ b/static-assets/themes/cstudioTheme/css/console.css
@@ -589,6 +589,10 @@ input[type='checkbox'].content-type-selector--checkbox {
   background-color: #ffffff;
 }
 
+.property-label + div .text-prop {
+  width: 100%;
+}
+
 .property-label + input:disabled {
   color: #bbbbbb;
 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5479