### PR TITLE
To many refreshes when a large payload is pasted

### DIFF
--- a/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -216,28 +216,26 @@ export function PathNavigator(props: PathNavigatorProps) {
 
   // Item Updates Propagation
   useEffect(() => {
-    const events = [
-      contentEvent.type,
-      deleteContentEvent.type,
-      pluginInstalled.type,
-      workflowEvent.type,
-      publishEvent.type
-    ];
     const hostToHost$ = getHostToHostBus();
-    const subscription = hostToHost$.pipe(filter((e) => events.includes(e.type))).subscribe(({ type, payload }) => {
+    const subscription = hostToHost$.subscribe(({ type, payload }) => {
       switch (type) {
         case contentEvent.type: {
           const targetPath = payload.targetPath;
-          const parentPath = getParentPath(targetPath);
-          if (parentPath === withoutIndex(state.currentPath)) {
-            // If item is direct children of root (in current pathNavigator view)
+          const parentPathOfTargetPath = getParentPath(targetPath);
+          if (
+            // If content event target is a direct child of the current path in the navigator
+            parentPathOfTargetPath === withoutIndex(state.currentPath) ||
+            // If content event target is the current path in the navigator
+            withoutIndex(targetPath) === withoutIndex(state.currentPath)
+          ) {
             dispatch(pathNavigatorBackgroundRefresh({ id }));
-          } else if (withoutIndex(targetPath) === withoutIndex(state.currentPath)) {
-            // If item is root (in current pathNavigator view)
-            dispatch(pathNavigatorBackgroundRefresh({ id }));
-          } else if (getParentPath(parentPath) === withoutIndex(state.currentPath)) {
-            // if item just belongs to parent item
-            dispatch(fetchSandboxItem({ path: parentPath, force: true }));
+          } else if (
+            // If content event target is a child of a child of the current path in the navigator,
+            // then, the parent item of the event target needs refreshing, so it's child count is
+            // updated and becomes navigable (in case that it didn't have children before this event).
+            getParentPath(parentPathOfTargetPath) === withoutIndex(state.currentPath)
+          ) {
+            dispatch(fetchSandboxItem({ path: parentPathOfTargetPath, force: true }));
           }
           break;
         }
@@ -258,7 +256,6 @@ export function PathNavigator(props: PathNavigatorProps) {
           } else if (state.itemsInPath.includes(targetPath)) {
             // current page is last one and only one item in current page
             const goBackOnePage = state.offset >= state.limit && state.total === state.offset + 1;
-
             if (goBackOnePage) {
               dispatch(
                 pathNavigatorChangePage({

--- a/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -42,7 +42,7 @@ import { showEditDialog, showItemMegaMenu, showPreviewDialog } from '../../state
 import { getEditorMode, isEditableViaFormEditor, isFolder, isImage, isNavigable, isPreviewable } from './utils';
 import { StateStylingProps } from '../../models/UiConfig';
 import { getHostToHostBus } from '../../modules/Preview/previewContext';
-import { debounceTime, filter } from 'rxjs/operators';
+import { debounceTime } from 'rxjs/operators';
 import {
   contentEvent,
   deleteContentEvent,
@@ -241,28 +241,17 @@ export function PathNavigator(props: PathNavigatorProps) {
         }
         case deleteContentEvent.type: {
           const targetPath = payload.targetPath;
-
           if (withoutIndex(targetPath) === withoutIndex(path)) {
             // if path being deleted is the rootPath
             dispatch(pathNavigatorRefresh({ id }));
           } else if (withoutIndex(targetPath) === withoutIndex(state.currentPath)) {
             // if path is currentPath (current root path)
-            dispatch(
-              pathNavigatorSetCurrentPath({
-                id,
-                path: getParentPath(withoutIndex(targetPath))
-              })
-            );
+            dispatch(pathNavigatorSetCurrentPath({ id, path: getParentPath(withoutIndex(targetPath)) }));
           } else if (state.itemsInPath.includes(targetPath)) {
             // current page is last one and only one item in current page
             const goBackOnePage = state.offset >= state.limit && state.total === state.offset + 1;
             if (goBackOnePage) {
-              dispatch(
-                pathNavigatorChangePage({
-                  id,
-                  offset: state.offset - state.limit
-                })
-              );
+              dispatch(pathNavigatorChangePage({ id, offset: state.offset - state.limit }));
             } else {
               dispatch(pathNavigatorBackgroundRefresh({ id }));
             }

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -50,7 +50,7 @@ import { useActiveUser } from '../../hooks/useActiveUser';
 import { useItemsByPath } from '../../hooks/useItemsByPath';
 import { useSubject } from '../../hooks/useSubject';
 import { useDetailedItem } from '../../hooks/useDetailedItem';
-import { debounceTime, filter } from 'rxjs/operators';
+import { debounceTime } from 'rxjs/operators';
 import {
   contentEvent,
   deleteContentEvent,
@@ -306,20 +306,12 @@ export default function PathNavigatorTree(props: PathNavigatorTreeProps) {
           const path = node?.id;
           if (path) {
             dispatch(
-              batchActions([
-                ...(state.expanded.includes(targetPath)
-                  ? [
-                      pathNavigatorTreeCollapsePath({
-                        id,
-                        path: targetPath
-                      })
-                    ]
-                  : []),
-                pathNavigatorTreeFetchPathChildren({
-                  id,
-                  path
-                })
-              ])
+              state.expanded.includes(targetPath)
+                ? batchActions([
+                    pathNavigatorTreeCollapsePath({ id, path: targetPath }),
+                    pathNavigatorTreeFetchPathChildren({ id, path })
+                  ])
+                : pathNavigatorTreeFetchPathChildren({ id, path })
             );
           }
           if (targetPath === rootPath) {

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -269,29 +269,20 @@ export default function PathNavigatorTree(props: PathNavigatorTreeProps) {
 
   // region Item Updates Propagation
   useEffect(() => {
-    const events = [
-      contentEvent.type,
-      deleteContentEvent.type,
-      folderRenamed.type,
-      pluginInstalled.type,
-      workflowEvent.type,
-      publishEvent.type
-    ];
     const hostToHost$ = getHostToHostBus();
-    const subscription = hostToHost$.pipe(filter((e) => events.includes(e.type))).subscribe(({ type, payload }) => {
+    const subscription = hostToHost$.subscribe(({ type, payload }) => {
       switch (type) {
         case contentEvent.type: {
           const targetPath = payload.targetPath ?? payload.target;
           const parentPath = getParentPath(targetPath);
-
           if (withoutIndex(targetPath) === rootPath) {
             // If item is root
-            dispatch(
-              pathNavigatorTreeRefresh({
-                id
-              })
-            );
-          } else {
+            dispatch(pathNavigatorTreeRefresh({ id }));
+          } else if (
+            // The target path is rooted in this navigator's root
+            targetPath.startsWith(withoutIndex(rootPath))
+          ) {
+            // TODO: Research improving the reloads here; consider targetPath and opened paths?
             if (user.username === payload.user.username) {
               // if it's current user then reload and expand folder (for example pasting in another folder)
               dispatch(


### PR DESCRIPTION
The tree navigator was beeing too eager loading even when the even was outside of it's scope. Large payloads inside of itself may still trigger many requests based on the socket events.
