### PR TITLE
[5476] Issues in legacy my recent activity dashlet

### DIFF
--- a/ui/app/src/components/LegacySiteDashboard/RecentActivityDashlet/RecentActivityDashlet.tsx
+++ b/ui/app/src/components/LegacySiteDashboard/RecentActivityDashlet/RecentActivityDashlet.tsx
@@ -97,15 +97,15 @@ export default function RecentActivityDashlet() {
   const { authoringBase } = useEnv();
   const { itemsByPath, isFetching } = useDetailedItems(Object.keys(selectedLookup));
 
-  const isAllChecked = useMemo(
-    () =>
-      items.length > 1
-        ? !items.some((item) => !item.stateMap.deleted && !selectedLookup[item.path])
-        : items[0]
-        ? selectedLookup[items[0].path] ?? false
-        : false,
-    [items, selectedLookup]
-  );
+  const isAllChecked = useMemo(() => {
+    const nonDeletedItems = items.filter((item) => !item.stateMap.deleted);
+    if (nonDeletedItems.length) {
+      // Is there at least one (non deleted item) that's not checked? If so, they're NOT all checked.
+      return !nonDeletedItems.some((item) => !selectedLookup[item.path]);
+    } else {
+      return false;
+    }
+  }, [items, selectedLookup]);
 
   const isIndeterminate = useMemo(
     () => items.some((item) => selectedLookup[item.path] && !isAllChecked),

--- a/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -235,7 +235,7 @@ export function PathNavigator(props: PathNavigatorProps) {
             // updated and becomes navigable (in case that it didn't have children before this event).
             getParentPath(parentPathOfTargetPath) === withoutIndex(state.currentPath)
           ) {
-            dispatch(fetchSandboxItem({ path: parentPathOfTargetPath, force: true }));
+            dispatch(fetchSandboxItem({ path: parentPathOfTargetPath }));
           }
           break;
         }

--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -389,7 +389,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
   // Fetch active item
   useEffect(() => {
     if (currentItemPath && siteId) {
-      dispatch(fetchSandboxItem({ path: currentItemPath, force: true }));
+      dispatch(fetchSandboxItem({ path: currentItemPath }));
     }
   }, [dispatch, currentItemPath, siteId]);
 

--- a/ui/app/src/state/actions/content.ts
+++ b/ui/app/src/state/actions/content.ts
@@ -41,7 +41,7 @@ export const fetchDetailedItemsFailed = /*#__PURE__*/ createAction<AjaxError>('F
 // endregion
 
 // region Sandbox Item
-export type FetchSandboxItemPayload = { path: string; force?: boolean };
+export type FetchSandboxItemPayload = { path: string };
 export const fetchSandboxItem = /*#__PURE__*/ createAction<FetchSandboxItemPayload>('FETCH_SANDBOX_ITEM');
 export const fetchSandboxItemComplete =
   /*#__PURE__*/ createAction<{ item: SandboxItem }>('FETCH_SANDBOX_ITEM_COMPLETE');

--- a/ui/app/src/state/epics/content.ts
+++ b/ui/app/src/state/epics/content.ts
@@ -225,15 +225,6 @@ const content: CrafterCMSEpic[] = [
     action$.pipe(
       ofType(fetchSandboxItem.type),
       withLatestFrom(state$),
-      // Only fetch if force is true or the item isn't loaded
-      filter(
-        ([
-          {
-            payload: { path, force }
-          },
-          state
-        ]) => Boolean(path) && (force || !state.content.itemsByPath[path])
-      ),
       mergeMap(([{ payload }, state]) =>
         fetchSandboxItemService(state.sites.active, payload.path).pipe(
           map((item) => fetchSandboxItemComplete({ item })),


### PR DESCRIPTION
- Fixed grid "all" checkbox showing as checked if all items in the widget are deleted
- Fixed clicking the item menu causing the actions bar of the widget never showing the options
  - Remove `force` option from `fetchSandboxItem` action as we were using it with force everywhere and skipping the load left the state dirty (reducer didn't consider the `force` option, leaving loading state in true forever when skipped)

craftercms/craftercms#5476