### PR TITLE
PathNavTree & ItemDisplay Crash

### DIFF
--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -95,6 +95,10 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
     ...rest
   } = props;
   const classes = useStyles(props.styles);
+  if (!item) {
+    // Avoids crashing if the item is nullish. This prevents the crash.
+    return null;
+  }
   const inWorkflow = isInWorkflow(item.stateMap) || item.systemType === 'folder';
   return (
     <span ref={ref} {...rest} className={clsx(classes.root, propClasses?.root, rest?.className)}>

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -96,7 +96,7 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
   } = props;
   const classes = useStyles(props.styles);
   if (!item) {
-    // Avoids crashing if the item is nullish. This prevents the crash.
+    // Prevents crashing if the item is nullish
     return null;
   }
   const inWorkflow = isInWorkflow(item.stateMap) || item.systemType === 'folder';

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -166,7 +166,7 @@ export default function PathNavigatorTree(props: PathNavigatorTreeProps) {
     // Adding uiConfig as means to stop navigator from trying to
     // initialize with previous state information when switching sites
     if (!state && uiConfig.currentSite === siteId && rootPath) {
-      nodesByPathRef.current[rootPath] = undefined;
+      nodesByPathRef.current = {};
       const { expanded, collapsed, keywordByPath } = storedState;
       dispatch(
         pathNavigatorTreeInit({
@@ -379,34 +379,18 @@ export default function PathNavigatorTree(props: PathNavigatorTreeProps) {
   };
 
   const onToggleNodeClick = (path: string) => {
-    // If the path is already expanded should be collapsed
+    // If the path is already expanded, should be collapsed
     if (state.expanded.includes(path)) {
-      dispatch(
-        pathNavigatorTreeCollapsePath({
-          id,
-          path
-        })
-      );
+      dispatch(pathNavigatorTreeCollapsePath({ id, path }));
     } else {
-      // If the item have children should be expanded
+      // If the item's children have been loaded, should simply be expanded
       if (childrenByParentPath[path]) {
-        dispatch(
-          pathNavigatorTreeExpandPath({
-            id,
-            path
-          })
-        );
+        dispatch(pathNavigatorTreeExpandPath({ id, path }));
       } else {
-        // Otherwise the item doesn't have children and should be fetched
-        dispatch(
-          pathNavigatorTreeFetchPathChildren({
-            id,
-            path
-          })
-        );
+        // Children not fetched yet, should be fetched
+        dispatch(pathNavigatorTreeFetchPathChildren({ id, path }));
       }
     }
-    dispatch(pathNavigatorTreeBackgroundRefresh({ id }));
   };
 
   const onHeaderButtonClick = (element: Element) => {


### PR DESCRIPTION
When switching between sites in preview and navigating to the same path as on the previous site, the tree state wasn't properly cleared and it thought it had the path loaded when in reality it was state leftovers from a previous site. The ItemDisplay component crashed as upon changing sites, all the items where wiped and got null items.
