### PR TITLE
[5459] A change in non-directly referenced content on a page doesn't trigger reload notification

### DIFF
--- a/ui/app/src/modules/Preview/PreviewConcierge.tsx
+++ b/ui/app/src/modules/Preview/PreviewConcierge.tsx
@@ -1218,7 +1218,11 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
         case contentEvent.type: {
           const { user: person, targetPath } = payload as SocketEventBase;
           const { theme } = upToDateRefs.current;
-          if (guest?.path === targetPath && person.username !== user.username) {
+          if (
+            person.username !== user.username &&
+            guest &&
+            (guest.path === targetPath || guest.modelIdByPath[targetPath])
+          ) {
             enqueueSnackbar(
               formatMessage(guestMessages.contentWasChangedByAnotherUser, {
                 name: getPersonFullName(person)


### PR DESCRIPTION
craftercms/craftercms#5459