### PR TITLE
[5384] The browse window for pickers cuts out the tree when the tree is deep

### DIFF
--- a/templates/web/browse.ftl
+++ b/templates/web/browse.ftl
@@ -58,11 +58,12 @@
         <span class="path"></span>
       </p>
 
-      <div id="cstudio-wcm-search-filter-controls">
+      <div class="content">
+        <div id="cstudio-wcm-search-filter-controls">
           <div id="data" class="demo"></div>
-      </div>
+        </div>
 
-      <div id="cstudio-wcm-search-result">
+        <div id="cstudio-wcm-search-result">
 
           <div class="cstudio-results-actions"></div>
 
@@ -71,6 +72,7 @@
           <div id="cstudio-wcm-search-render-finish">
 
           </div>
+        </div>
       </div>
 
     </div>

--- a/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -31,8 +31,8 @@ import Pagination from '../Pagination';
 import FolderBrowserTreeView from '../FolderBrowserTreeView';
 import Box from '@mui/material/Box';
 import { BrowseFilesDialogUIProps } from './utils';
-import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
+import InputUnstyled from '@mui/base/InputUnstyled';
 
 export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
   const {
@@ -68,16 +68,14 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
         <Box display="flex">
           <section className={classes.leftWrapper}>
             <FolderBrowserTreeView
-              classes={{ treeItemLabel: classes.treeItemLabel }}
+              classes={{ root: classes.treeView, treeItemLabel: classes.treeItemLabel }}
               rootPath={path}
               showPathTextBox={false}
               onPathSelected={onPathSelected}
             />
           </section>
           <section className={classes.rightWrapper}>
-            <Typography component="h2" variant="h6">
-              {currentPath}
-            </Typography>
+            <InputUnstyled value={currentPath} className={classes.currentPath} disabled title={currentPath} />
             <Divider />
             <Box display="flex" alignItems="center" marginTop="16px" marginBottom="16px" gap="8px">
               <SecondaryButton onClick={onUpload}>

--- a/ui/app/src/components/BrowseFilesDialog/styles.ts
+++ b/ui/app/src/components/BrowseFilesDialog/styles.ts
@@ -50,17 +50,32 @@ export const useStyles = makeStyles((theme) =>
       }
     },
     leftWrapper: {
-      width: '200px',
+      width: '220px',
       paddingRight: '16px'
     },
     rightWrapper: {
       flexGrow: 1
+    },
+    treeView: {
+      overflow: 'auto'
     },
     treeItemLabel: {
       width: '100%'
     },
     bodyEmptyState: {
       height: '60vh'
+    },
+    currentPath: {
+      '& input': {
+        width: '100%',
+        background: 'none',
+        border: 'none',
+        fontFamily: theme.typography.fontFamily,
+        fontWeight: theme.typography.fontWeightMedium,
+        color: theme.palette.text.primary,
+        fontSize: '1.25rem',
+        lineHeight: '1.6'
+      }
     }
   })
 );

--- a/ui/scss/src/browse.scss
+++ b/ui/scss/src/browse.scss
@@ -47,11 +47,24 @@ body {
   }
 
   .cstudio-browse-container {
+    display: flex;
+    flex-direction: column;
     width: 100%;
     max-width: 1370px;
     margin: 0 auto;
-    padding: 0 20px 40px;
+    padding: 0px 20px 20px;
     background-color: #fff;
+    height: calc(100vh - 82px);
+
+    .content {
+      flex: 1;
+      overflow: hidden;
+
+      #cstudio-wcm-search-filter-controls,
+      #cstudio-wcm-browse-result {
+        height: 100%;
+      }
+    }
 
     #cstudio-wcm-search-filter-controls {
       [data-display='hidden-node'] {
@@ -67,7 +80,6 @@ body {
       padding: 20px 20px 20px 0;
       border-radius: 5px;
       float: left;
-      height: calc(100vh - 160px);
 
       .jstree-default {
         .jstree-node > .jstree-icon {


### PR DESCRIPTION
- Fixed for old browse dialog (used in s3, cmis, and webdav)
- Fixed issue in new dialog
https://github.com/craftercms/craftercms/issues/5384