### PR TITLE
[5567] Save & Close option is showing up in Choose Content Type window after saving and closing Content Type Modelling

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -85,11 +85,6 @@
         $('#createNewContentTypeButton').click(() => {
           this.onNewClick();
         });
-
-        CStudioAuthoring.ContextualNav.AdminConsoleNav.initActions([
-          { name: CMgs.format(langBundle, 'openExistingType'), context: this, method: this.onOpenExistingClick },
-          { name: CMgs.format(langBundle, 'createNewType'), context: this, method: this.onNewClick }
-        ]);
       },
 
       componentsValidation: function (formDef) {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5567