### PR TITLE
[5576][3.1.x] numeric input' field doesn't work in Firefox 99.0

### DIFF
--- a/static-assets/components/cstudio-forms/controls/numeric-input.js
+++ b/static-assets/components/cstudio-forms/controls/numeric-input.js
@@ -127,8 +127,8 @@
 
     _onChangeVal: function (evt, obj) {
       obj.edited = true;
-      if (this._onChange) {
-        this._onChange(evt, obj);
+      if (obj._onChange) {
+        obj._onChange(evt, obj);
       }
     },
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5576