### PR TITLE
Stability

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -11,9 +11,4 @@
     </option>
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK" />
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
 </project>

--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -2109,7 +2109,7 @@ var CStudioForms =
                 onDone();
               } else {
                 jQuery
-                  .getScript(script)
+                  .getScript({ url: script, cache: false })
                   .done(onDone)
                   .fail(
                     (function (datasourceDef) {

--- a/ui/app/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/ui/app/src/components/DateTimePicker/DateTimePicker.tsx
@@ -258,7 +258,9 @@ function DateTimePicker(props: DateTimePickerProps) {
       {controls.includes('timeZone') && (
         <Autocomplete
           options={timeZones}
-          getOptionLabel={(timezone) => `${timezone.name} (GMT${timezone.offset})`}
+          getOptionLabel={(timezone) =>
+            typeof timezone === 'string' ? timezone : `${timezone.name} (GMT${timezone.offset})`
+          }
           defaultValue={currentTimeZoneDesc}
           onChange={handleTimezoneChange}
           size="small"

--- a/ui/app/src/components/GraphiQL/GraphiQL.tsx
+++ b/ui/app/src/components/GraphiQL/GraphiQL.tsx
@@ -118,7 +118,7 @@ function Graphi(props: GraphiQLProps) {
     <Box display="flex" flexDirection="column" height="100vh">
       {!embedded && (
         <GlobalAppToolbar
-          title={<FormattedMessage id="GraphiQL.title" defaultMessage="GraphiQL" />}
+          title={<FormattedMessage id="words.graphQL" defaultMessage="GraphQL" />}
           showAppsButton={showAppsButton}
         />
       )}


### PR DESCRIPTION
- .idea updates
- avoid cache buster when loading plugins in form engine
- DateTimePicker: change in prep for mui upgrades to avoid compilation errors
- Consistent title of the GraphQL sidebar entry with the screen title
