### PR TITLE
[5673] Empty screen when clicking on item selector of content item dependencies

### DIFF
--- a/ui/app/src/components/DependenciesDialog/DependenciesDialogUI.tsx
+++ b/ui/app/src/components/DependenciesDialog/DependenciesDialogUI.tsx
@@ -32,6 +32,7 @@ import { dependenciesDialogStyles } from './DependenciesDialog';
 import { ApiResponseErrorState } from '../ApiResponseErrorState';
 import { LoadingState } from '../LoadingState';
 import { EmptyState } from '../EmptyState';
+import { getRootPath } from '../../utils/path';
 
 export function DependenciesDialogUI(props: DependenciesDialogUIProps) {
   const {
@@ -67,6 +68,7 @@ export function DependenciesDialogUI(props: DependenciesDialogUIProps) {
             onDropdownClick={() => setOpenSelector(!openSelector)}
             rootPath={rootPath}
             selectedItem={item}
+            disabled={rootPath !== getRootPath(item.path)}
             onItemClicked={(item) => {
               setOpenSelector(false);
               setItem(item);

--- a/ui/app/src/components/SingleItemSelector/SingleItemSelector.tsx
+++ b/ui/app/src/components/SingleItemSelector/SingleItemSelector.tsx
@@ -392,14 +392,6 @@ export function SingleItemSelector(props: SingleItemSelectorProps) {
         elevation: 0
       };
 
-  // const itemsResource = useLogicResource<DetailedItem[], SingleItemSelectorState>(state, {
-  //   shouldResolve: (consumer) => Boolean(consumer.byId) && !consumer.isFetching,
-  //   shouldReject: (consumer) => Boolean(consumer.error),
-  //   shouldRenew: (consumer, resource) => consumer.isFetching && resource.complete,
-  //   resultSelector: (consumer) => consumer.items.map((id) => consumer.byId[id]),
-  //   errorSelector: (consumer) => consumer.error
-  // });
-
   return (
     <Wrapper {...wrapperProps}>
       {!hideUI && (


### PR DESCRIPTION
The problem is changing between Crafter roots (static-assets <=> components <=> pages, etc). This requires more thought, and funture work to improve. For now, disabling the item selector when switching roots to avoid crashes.

craftercms/craftercms#5673
