### PR TITLE
'Project Config Tools' changed into 'Content Type Editor Config' in configuration list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@
 # auto-import.
 # .idea/artifacts
 # .idea/compiler.xml
-.idea/jarRepositories.xml
+# .idea/jarRepositories.xml
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@
 # auto-import.
 # .idea/artifacts
 # .idea/compiler.xml
-# .idea/jarRepositories.xml
+.idea/jarRepositories.xml
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules

--- a/ui/app/src/components/SiteConfigurationManagement/translations.ts
+++ b/ui/app/src/components/SiteConfigurationManagement/translations.ts
@@ -134,7 +134,7 @@ export const translations = defineMessages({
   confTabSiteConf: { id: 'siteConfigurationManagement.confTabSiteConf', defaultMessage: 'Content Type Editor Config' },
   confTabSiteConfDesc: {
     id: 'siteConfigurationManagement.confTabSiteConfDesc',
-    defaultMessage: 'Defines the list of admin tools available'
+    defaultMessage: 'Defines controls and datasources available for content type editing'
   },
   confTabWorkflowConf: {
     id: 'siteConfigurationManagement.confTabWorkflowConf',

--- a/ui/app/src/components/SiteConfigurationManagement/translations.ts
+++ b/ui/app/src/components/SiteConfigurationManagement/translations.ts
@@ -131,7 +131,7 @@ export const translations = defineMessages({
     id: 'siteConfigurationManagement.confTabSiteConfigurationDesc',
     defaultMessage: 'Defines the general project configuration'
   },
-  confTabSiteConf: { id: 'siteConfigurationManagement.confTabSiteConf', defaultMessage: 'Project Config Tools' },
+  confTabSiteConf: { id: 'siteConfigurationManagement.confTabSiteConf', defaultMessage: 'Content Type Editor Config' },
   confTabSiteConfDesc: {
     id: 'siteConfigurationManagement.confTabSiteConfDesc',
     defaultMessage: 'Defines the list of admin tools available'

--- a/ui/app/src/translations/locales/en.json
+++ b/ui/app/src/translations/locales/en.json
@@ -1399,7 +1399,7 @@
   "siteConfigurationManagement.confTabRoleMappingsDesc": "Defines a list of roles available in project",
   "siteConfigurationManagement.confTabSidebarConf": "Sidebar Configuration",
   "siteConfigurationManagement.confTabSidebarConfDesc": "Defines modules on the sidebar",
-  "siteConfigurationManagement.confTabSiteConf": "Project Config Tools",
+  "siteConfigurationManagement.confTabSiteConf": "Content Type Editor Config",
   "siteConfigurationManagement.confTabSiteConfDesc": "Defines the list of admin tools available",
   "siteConfigurationManagement.confTabSiteConfiguration": "Project Configuration",
   "siteConfigurationManagement.confTabSiteConfigurationDesc": "Defines the general project configuration",

--- a/ui/app/src/translations/locales/en.json
+++ b/ui/app/src/translations/locales/en.json
@@ -1400,7 +1400,7 @@
   "siteConfigurationManagement.confTabSidebarConf": "Sidebar Configuration",
   "siteConfigurationManagement.confTabSidebarConfDesc": "Defines modules on the sidebar",
   "siteConfigurationManagement.confTabSiteConf": "Content Type Editor Config",
-  "siteConfigurationManagement.confTabSiteConfDesc": "Defines the list of admin tools available",
+  "siteConfigurationManagement.confTabSiteConfDesc": "Defines controls and datasources available for content type editing",
   "siteConfigurationManagement.confTabSiteConfiguration": "Project Configuration",
   "siteConfigurationManagement.confTabSiteConfigurationDesc": "Defines the general project configuration",
   "siteConfigurationManagement.confTabSitePolicyConf": "Project Policy Configuration",


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5699
'Project Config Tools' changed into 'Content Type Editor Config' in configuration list
