### PR TITLE
[5765] Facilitate identifying items with children on PathNav

### DIFF
--- a/ui/app/src/components/PathNavigator/PathNavigatorItem.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigatorItem.tsx
@@ -124,7 +124,9 @@ function PathNavigatorItem(props: NavItemProps) {
               : over
               ? // Level descriptor doesn't ever have children, so will
                 // always have only one action button.
-                `calc(100% - ${isLevelDescriptor ? 25 : 50}px)`
+                `calc(100% - ${isLevelDescriptor || isLeaf ? 25 : 50}px)`
+              : !isLeaf
+              ? `calc(100% - 25px)`
               : '100%'
           }
         }}


### PR DESCRIPTION
- Fix width styles for items with long names, with and without children, and hover mode #5765

https://github.com/craftercms/craftercms/issues/5765