### PR TITLE
[5785] Have UM migrate 3.1 form definitions to 4.0 definitions

### DIFF
--- a/ui/app/src/env/i18n-legacy.ts
+++ b/ui/app/src/env/i18n-legacy.ts
@@ -555,7 +555,7 @@ export const simpleTaxonomyDSMessages = defineMessages({
   },
   simpleTaxonomy: {
     id: 'simpleTaxonomyDS.simpleTaxonomy',
-    defaultMessage: 'Site Taxonomy'
+    defaultMessage: 'Simple Taxonomy'
   }
 });
 


### PR DESCRIPTION
- Fix Simple Taxonomy label 

https://github.com/craftercms/craftercms/issues/5785