### PR TITLE
[470E] Restrict content-type image controller to only images

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-type-propsheet/image.js
+++ b/static-assets/components/cstudio-admin/mods/content-type-propsheet/image.js
@@ -242,7 +242,8 @@ YAHOO.extend(
             CStudioAuthoringContext.site,
             configFilesPath + '/content-types' + CStudioAdminConsole.contentTypeSelected,
             'upload',
-            uploadCb
+            uploadCb,
+            ['image/*']
           );
         };
 


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/412