### PR TITLE
[5895] Rename asset dialog dependency edit button doesn't open the right mode for FTL

### DIFF
--- a/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
+++ b/ui/app/src/components/CodeEditorDialog/CodeEditorDialog.tsx
@@ -23,7 +23,7 @@ import EnhancedDialog from '../EnhancedDialog';
 
 export function CodeEditorDialog(props: CodeEditorDialogProps) {
   const { formatMessage } = useIntl();
-  const { mode, path, readonly, contentType, onSuccess, onClose, onMinimize, onFullScreen, ...rest } = props;
+  const { mode = 'text', path, readonly, contentType, onSuccess, onClose, onMinimize, onFullScreen, ...rest } = props;
   const title = formatMessage(translations.title);
   return (
     <EnhancedDialog title={title} omitHeader maxWidth="xl" onMinimize={onMinimize} onClose={onClose} {...rest}>

--- a/ui/app/src/components/CodeEditorDialog/utils.ts
+++ b/ui/app/src/components/CodeEditorDialog/utils.ts
@@ -22,7 +22,7 @@ import { EnhancedDialogState } from '../../hooks/useEnhancedDialogState';
 
 export interface CodeEditorDialogBaseProps {
   path: string;
-  mode: string;
+  mode?: string;
   contentType?: string;
   readonly?: boolean;
 }

--- a/ui/app/src/state/reducers/dialogs/codeEditor.ts
+++ b/ui/app/src/state/reducers/dialogs/codeEditor.ts
@@ -28,7 +28,6 @@ import { changeSite } from '../../actions/sites';
 
 const initialState: CodeEditorDialogStateProps = commonDialogProps({
   path: null,
-  mode: null,
   contentType: null,
   readonly: false,
   isFullScreen: false,

--- a/ui/app/src/utils/content.ts
+++ b/ui/app/src/utils/content.ts
@@ -997,6 +997,15 @@ export const openItemEditor = (
   if (type === 'form') {
     dispatch(showEditDialog({ path: item.path, authoringBase, site: siteId, onSaveSuccess }));
   } else {
-    dispatch(showCodeEditorDialog({ site: siteId, authoringBase, path: item.path, type, onSuccess: onSaveSuccess }));
+    dispatch(
+      showCodeEditorDialog({
+        site: siteId,
+        authoringBase,
+        path: item.path,
+        type,
+        mode: getEditorMode(item.mimeType),
+        onSuccess: onSaveSuccess
+      })
+    );
   }
 };


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5895