### PR TITLE
[5816] Switch to using zxcvbn for password strength management 

### DIFF
--- a/templates/web/common/page-fragments/studio-context.ftl
+++ b/templates/web/common/page-fragments/studio-context.ftl
@@ -46,7 +46,7 @@
     graphQLBaseURI: `${'$'}{origin}/api/1/site/graphql`,
     xsrfHeaderName: "${_csrf.headerName}",
     xsrfParameterName: "${_csrf.parameterName}",
-    passwordRequirementsRegex: "${envConfig.passwordRequirementsRegex?js_string}"
+    passwordRequirementsMinComplexity: ${envConfig.passwordRequirementsMinComplexity}
   };
 
   window.addEventListener(

--- a/templates/web/entry.ftl
+++ b/templates/web/entry.ftl
@@ -28,7 +28,7 @@
 <#include "/templates/web/common/js-next-scripts.ftl" />
 <script>
   CrafterCMSNext.render('#root', 'Global', {
-    passwordRequirementsRegex: '${passwordRequirementsRegex?js_string}',
+    passwordRequirementsMinComplexity: ${passwordRequirementsMinComplexity},
     footerHtml: '${applicationContext.get("crafter.entitlementValidator").getDescription()}'
   }, false);
 </script>

--- a/templates/web/login.ftl
+++ b/templates/web/login.ftl
@@ -49,7 +49,7 @@
           xsrfToken: '${_csrf.token}',
           xsrfParamName: '${_csrf.parameterName}',
           xsrfHeaderName: '${_csrf.headerName}',
-          passwordRequirementsRegex: '${passwordRequirementsRegex}'
+          passwordRequirementsMinComplexity: ${passwordRequirementsMinComplexity}
         })
       ),
       document.querySelector('#root')

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -168,7 +168,8 @@
     "typescript": "^4.1.2",
     "uppy": "^2.10.0",
     "video.js": "^7.20.0",
-    "web-vitals": "^1.0.1"
+    "web-vitals": "^1.0.1",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -180,6 +181,7 @@
     "@types/jquery": "^3.5.11",
     "@types/js-cookie": "^3",
     "@types/prettier": "^2.4.2",
+    "@types/zxcvbn": "^4",
     "babel-plugin-react-intl": "^5.1.16",
     "build-if-changed": "^1.5.5",
     "eslint": "^8.3.0",

--- a/ui/app/src/components/AccountManagement/AccountManagement.tsx
+++ b/ui/app/src/components/AccountManagement/AccountManagement.tsx
@@ -31,16 +31,16 @@ import MenuItem from '@mui/material/MenuItem';
 import FormHelperText from '@mui/material/FormHelperText';
 import Skeleton from '@mui/material/Skeleton';
 import PasswordTextField from '../PasswordTextField/PasswordTextField';
-import PasswordRequirementsDisplay from '../PasswordRequirementsDisplay';
 import PrimaryButton from '../PrimaryButton';
 import { setMyPassword } from '../../services/users';
 import { useDispatch } from 'react-redux';
 import { showErrorDialog } from '../../state/reducers/dialogs/error';
 import { showSystemNotification } from '../../state/actions/system';
 import { useActiveUser } from '../../hooks/useActiveUser';
+import { PasswordStrengthDisplayPopper } from '../PasswordStrengthDisplayPopper';
 
 interface AccountManagementProps {
-  passwordRequirementsRegex?: string;
+  passwordRequirementsMinComplexity?: number;
 }
 
 const translations = defineMessages({
@@ -55,9 +55,7 @@ const translations = defineMessages({
 });
 
 export function AccountManagement(props: AccountManagementProps) {
-  const {
-    passwordRequirementsRegex = '^(?=(?<hasNumbers>.*[0-9]))(?=(?<hasLowercase>.*[a-z]))(?=(?<hasUppercase>.*[A-Z]))(?=(?<hasSpecialChars>.*[~|!`,;/@#$%^&+=]))(?<minLength>.{8,})$'
-  } = props;
+  const { passwordRequirementsMinComplexity = 4 } = props;
 
   const { classes, cx: clsx } = useStyles();
   const user = useActiveUser();
@@ -69,6 +67,7 @@ export function AccountManagement(props: AccountManagementProps) {
   const [validPassword, setValidPassword] = useState(false);
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
+  const [anchorEl, setAnchorEl] = useState(null);
 
   // Retrieve Platform Languages.
   useEffect(() => {
@@ -183,6 +182,9 @@ export function AccountManagement(props: AccountManagementProps) {
                   <FormattedMessage id="accountManagement.passwordInvalid" defaultMessage="Password is invalid." />
                 )
               }
+              onFocus={(e) => setAnchorEl(e.target)}
+              onBlur={() => setAnchorEl(null)}
+              inputProps={{ autoComplete: 'new-password' }}
             />
             <PasswordTextField
               margin="normal"
@@ -203,12 +205,6 @@ export function AccountManagement(props: AccountManagementProps) {
                 )
               }
             />
-            <PasswordRequirementsDisplay
-              value={newPassword}
-              onValidStateChanged={setValidPassword}
-              formatMessage={formatMessage}
-              passwordRequirementsRegex={passwordRequirementsRegex}
-            />
             <PrimaryButton
               disabled={!validPassword || newPassword !== verifiedPassword || currentPassword === ''}
               className={classes.save}
@@ -219,6 +215,15 @@ export function AccountManagement(props: AccountManagementProps) {
           </Box>
         </Paper>
       </Container>
+
+      <PasswordStrengthDisplayPopper
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        placement="top"
+        value={newPassword}
+        passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
+        onValidStateChanged={setValidPassword}
+      />
     </Paper>
   );
 }

--- a/ui/app/src/components/AuthBoundary/AuthBoundary.tsx
+++ b/ui/app/src/components/AuthBoundary/AuthBoundary.tsx
@@ -39,11 +39,7 @@ export function AuthBoundary(props) {
     return (
       <I18nProvider>
         <CrafterThemeProvider>
-          <Login
-            passwordRequirementsRegex="'^(?=(?<hasNumbers>.*[0-9]))(?=(?<hasLowercase>.*[a-z]))(?=(?<hasUppercase>.*[A-Z]))(?=(?<hasSpecialChars>.*[~|!`,;\/@#$%^&+=]))(?<minLength>.{8,})$'"
-            xsrfToken={getRequestForgeryToken()}
-            xsrfParamName="_csrf"
-          />
+          <Login passwordRequirementsMinComplexity={4} xsrfToken={getRequestForgeryToken()} xsrfParamName="_csrf" />
         </CrafterThemeProvider>
       </I18nProvider>
     );

--- a/ui/app/src/components/CreateUserDialog/CreateUserDialog.tsx
+++ b/ui/app/src/components/CreateUserDialog/CreateUserDialog.tsx
@@ -21,7 +21,8 @@ import EnhancedDialog from '../EnhancedDialog';
 import { FormattedMessage } from 'react-intl';
 
 export function CreateUserDialog(props: CreateUserDialogProps) {
-  const { passwordRequirementsRegex, onSubmittingAndOrPendingChange, isSubmitting, onCreateSuccess, ...rest } = props;
+  const { passwordRequirementsMinComplexity, onSubmittingAndOrPendingChange, isSubmitting, onCreateSuccess, ...rest } =
+    props;
   return (
     <EnhancedDialog
       title={<FormattedMessage id="CreateUserDialog.title" defaultMessage="Create User" />}
@@ -29,7 +30,7 @@ export function CreateUserDialog(props: CreateUserDialogProps) {
       {...rest}
     >
       <CreateUserDialogContainer
-        passwordRequirementsRegex={passwordRequirementsRegex}
+        passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
         onCreateSuccess={onCreateSuccess}
         onSubmittingAndOrPendingChange={onSubmittingAndOrPendingChange}
         isSubmitting={isSubmitting}

--- a/ui/app/src/components/CreateUserDialog/utils.ts
+++ b/ui/app/src/components/CreateUserDialog/utils.ts
@@ -18,7 +18,7 @@ import { EnhancedDialogProps } from '../EnhancedDialog';
 import { onSubmittingAndOrPendingChangeProps } from '../../hooks/useEnhancedDialogState';
 
 interface CreateUserDialogBase {
-  passwordRequirementsRegex: string;
+  passwordRequirementsMinComplexity: number;
 }
 
 export interface CreateUserDialogProps extends CreateUserDialogBase, EnhancedDialogProps {

--- a/ui/app/src/components/EditUserDialog/EditUserDialog.tsx
+++ b/ui/app/src/components/EditUserDialog/EditUserDialog.tsx
@@ -20,8 +20,15 @@ import EnhancedDialog from '../EnhancedDialog';
 import EditUserDialogContainer from './EditUserDialogContainer';
 
 export function EditUserDialog(props: EditUserDialogProps) {
-  const { open, user, onUserEdited, passwordRequirementsRegex, onSubmittingAndOrPendingChange, isSubmitting, ...rest } =
-    props;
+  const {
+    open,
+    user,
+    onUserEdited,
+    passwordRequirementsMinComplexity,
+    onSubmittingAndOrPendingChange,
+    isSubmitting,
+    ...rest
+  } = props;
 
   return (
     <EnhancedDialog open={open} omitHeader isSubmitting={isSubmitting} {...rest}>
@@ -30,7 +37,7 @@ export function EditUserDialog(props: EditUserDialogProps) {
         user={user}
         onUserEdited={onUserEdited}
         onSubmittingAndOrPendingChange={onSubmittingAndOrPendingChange}
-        passwordRequirementsRegex={passwordRequirementsRegex}
+        passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
         isSubmitting={isSubmitting}
       />
     </EnhancedDialog>

--- a/ui/app/src/components/EditUserDialog/EditUserDialogContainer.tsx
+++ b/ui/app/src/components/EditUserDialog/EditUserDialogContainer.tsx
@@ -49,8 +49,14 @@ const translations = defineMessages({
 });
 
 export function EditUserDialogContainer(props: EditUserDialogContainerProps) {
-  const { open, onClose, onUserEdited, passwordRequirementsRegex, isSubmitting, onSubmittingAndOrPendingChange } =
-    props;
+  const {
+    open,
+    onClose,
+    onUserEdited,
+    passwordRequirementsMinComplexity,
+    isSubmitting,
+    onSubmittingAndOrPendingChange
+  } = props;
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
   const [user, setUser] = useSpreadState<User>({
@@ -218,7 +224,7 @@ export function EditUserDialogContainer(props: EditUserDialogContainerProps) {
       dirty={dirty}
       sites={mySites}
       rolesBySite={rolesBySite}
-      passwordRequirementsRegex={passwordRequirementsRegex}
+      passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
       onSave={onSave}
       onCloseButtonClick={(e) => onClose(e, null)}
       onDelete={onDelete}

--- a/ui/app/src/components/EditUserDialog/EditUserDialogUI.tsx
+++ b/ui/app/src/components/EditUserDialog/EditUserDialogUI.tsx
@@ -92,7 +92,7 @@ export function EditUserDialogUI(props: EditUserDialogUIProps) {
     openResetPassword,
     sites,
     rolesBySite,
-    passwordRequirementsRegex,
+    passwordRequirementsMinComplexity,
     onSave,
     onCloseButtonClick,
     onDelete,
@@ -324,7 +324,7 @@ export function EditUserDialogUI(props: EditUserDialogUIProps) {
       {managedInStudio && (
         <ResetPasswordDialog
           open={openResetPassword}
-          passwordRequirementsRegex={passwordRequirementsRegex}
+          passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
           user={user}
           onClose={onCloseResetPasswordDialog}
         />

--- a/ui/app/src/components/EditUserDialog/utils.ts
+++ b/ui/app/src/components/EditUserDialog/utils.ts
@@ -23,7 +23,7 @@ import React from 'react';
 
 export interface EditUserBaseProps {
   user: User;
-  passwordRequirementsRegex: string;
+  passwordRequirementsMinComplexity: number;
 }
 
 export interface EditUserDialogProps extends EditUserBaseProps, EnhancedDialogProps {
@@ -45,7 +45,7 @@ export interface EditUserDialogUIProps {
   dirty: boolean;
   openResetPassword: boolean;
   sites: Site[];
-  passwordRequirementsRegex: string;
+  passwordRequirementsMinComplexity: number;
   rolesBySite: LookupTable<string[]>;
   onInputChange(value: object): void;
   onEnableChange(value: object): void;

--- a/ui/app/src/components/GlobalApp/GlobalApp.tsx
+++ b/ui/app/src/components/GlobalApp/GlobalApp.tsx
@@ -48,13 +48,13 @@ const AboutCrafterCMSView = lazy(() => import('../AboutCrafterCMSView'));
 const AccountManagement = lazy(() => import('../AccountManagement'));
 
 interface GlobalAppProps {
-  passwordRequirementsRegex: string;
+  passwordRequirementsMinComplexity: number;
   footerHtml: string;
 }
 
 export function GlobalApp(props: GlobalAppProps) {
   const { classes } = useStyles();
-  const { passwordRequirementsRegex, footerHtml } = props;
+  const { passwordRequirementsMinComplexity, footerHtml } = props;
   const [width, setWidth] = useState(240);
   const globalNavigation = useGlobalNavigation();
   const [{ openSidebar }] = useGlobalAppState();
@@ -138,7 +138,7 @@ export function GlobalApp(props: GlobalAppProps) {
             <Route path="/sites" component={SiteManagement} />
             <Route
               path="/users"
-              render={() => <UserManagement passwordRequirementsRegex={passwordRequirementsRegex} />}
+              render={() => <UserManagement passwordRequirementsMinComplexity={passwordRequirementsMinComplexity} />}
             />
             <Route path="/groups" component={GroupManagement} />
             <Route path="/audit" component={AuditManagement} />
@@ -150,7 +150,7 @@ export function GlobalApp(props: GlobalAppProps) {
             <Route path="/about-us" component={AboutCrafterCMSView} />
             <Route
               path="/settings"
-              render={() => <AccountManagement passwordRequirementsRegex={passwordRequirementsRegex} />}
+              render={() => <AccountManagement passwordRequirementsMinComplexity={passwordRequirementsMinComplexity} />}
             />
             <Route path="/globalMenu/:id" render={(props) => <Redirect to={`/${props.match.params.id}`} />} />
             <Route exact path="/">

--- a/ui/app/src/components/LoginView/LoginView.tsx
+++ b/ui/app/src/components/LoginView/LoginView.tsx
@@ -44,9 +44,9 @@ import { buildStoredLanguageKey, dispatchLanguageChange, getCurrentLocale, setSt
 import CrafterCMSLogo from '../../icons/CrafterCMSLogo';
 import LanguageRounded from '@mui/icons-material/LanguageRounded';
 import Menu from '@mui/material/Menu';
-import PasswordRequirementsDisplay from '../PasswordRequirementsDisplay';
 import { useMount } from '../../hooks/useMount';
 import { useDebouncedInput } from '../../hooks/useDebouncedInput';
+import { PasswordStrengthDisplayPopper } from '../PasswordStrengthDisplayPopper';
 
 export interface SystemLang {
   id: string;
@@ -62,7 +62,7 @@ interface LanguageDropDownProps {
 export interface LoginViewProps {
   xsrfToken: string;
   xsrfParamName: string;
-  passwordRequirementsRegex: string;
+  passwordRequirementsMinComplexity: number;
 }
 
 type Modes = 'login' | 'recover' | 'reset';
@@ -71,7 +71,7 @@ type SubViewProps = React.PropsWithChildren<{
   token?: string;
   language?: string;
   setMode?: React.Dispatch<React.SetStateAction<Modes>>;
-  passwordRequirementsRegex?: string;
+  passwordRequirementsMinComplexity?: number;
   children: React.ReactNode;
   isFetching: boolean;
   onSubmit: React.Dispatch<React.SetStateAction<boolean>>;
@@ -329,13 +329,23 @@ function RecoverView(props: SubViewProps) {
 }
 
 function ResetView(props: SubViewProps) {
-  const { children, isFetching, onSubmit, classes, formatMessage, onSnack, setMode, token, passwordRequirementsRegex } =
-    props;
+  const {
+    children,
+    isFetching,
+    onSubmit,
+    classes,
+    formatMessage,
+    onSnack,
+    setMode,
+    token,
+    passwordRequirementsMinComplexity
+  } = props;
   const [newPassword, setNewPassword] = useState('');
   const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
   const [isValid, setValid] = useState<boolean>(null);
   const [passwordsMismatch, setPasswordMismatch] = useState(false);
   const [error, setError] = useState('');
+  const [anchorEl, setAnchorEl] = useState(null);
   useEffect(() => {
     if (isBlank(newPasswordConfirm) || newPasswordConfirm === newPassword) {
       setPasswordMismatch(false);
@@ -386,11 +396,13 @@ function ResetView(props: SubViewProps) {
             />
           }
         />
-        <PasswordRequirementsDisplay
+        <PasswordStrengthDisplayPopper
+          open={Boolean(anchorEl)}
+          anchorEl={anchorEl}
+          placement="top"
           value={newPassword}
+          passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
           onValidStateChanged={setValid}
-          formatMessage={formatMessage}
-          passwordRequirementsRegex={passwordRequirementsRegex}
         />
         <PasswordTextField
           id="resetFormPasswordField"
@@ -400,6 +412,9 @@ function ResetView(props: SubViewProps) {
           onChange={(e) => setNewPassword(e.target.value)}
           className={classes.resetPassword}
           placeholder={formatMessage(translations.resetPasswordFieldPlaceholderLabel)}
+          onFocus={(e) => setAnchorEl(e.target)}
+          onBlur={() => setAnchorEl(null)}
+          inputProps={{ autoComplete: 'new-password' }}
         />
         <PasswordTextField
           id="resetFormPasswordConfirmField"
@@ -490,7 +505,7 @@ export function LoginViewContainer(props: LoginViewProps) {
   const { formatMessage } = useIntl();
   const { classes, cx } = useStyles();
   const token = parse(window.location.search).token as string;
-  const { passwordRequirementsRegex, xsrfToken, xsrfParamName } = props;
+  const { xsrfToken, xsrfParamName, passwordRequirementsMinComplexity } = props;
 
   const [mode, setMode] = useState<Modes>(token ? 'reset' : 'login');
   const [language, setLanguage] = useState(() => getCurrentLocale());
@@ -511,7 +526,7 @@ export function LoginViewContainer(props: LoginViewProps) {
     classes,
     onSubmit,
     onSnack,
-    passwordRequirementsRegex,
+    passwordRequirementsMinComplexity,
     setLanguage,
     onRecover: () => setMode('recover'),
     xsrfToken,

--- a/ui/app/src/components/PasswordStrengthDisplay/PasswordStrengthDisplay.tsx
+++ b/ui/app/src/components/PasswordStrengthDisplay/PasswordStrengthDisplay.tsx
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import Typography from '@mui/material/Typography';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import { ListItem } from '@mui/material';
+import ListItemText from '@mui/material/ListItemText';
+import { FullSxRecord, PartialSxRecord } from '../../models';
+import Divider from '@mui/material/Divider';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded';
+import StarOutlineRoundedIcon from '@mui/icons-material/StarOutlineRounded';
+import Collapse from '@mui/material/Collapse';
+import { isBlank } from '../../utils/string';
+import { nou } from '../../utils/object';
+
+export type PasswordStrengthDisplayClassKey =
+  | 'container'
+  | 'scoreList'
+  | 'scoreListItem'
+  | 'scoreListItemDisplay'
+  | 'scoreListItemText'
+  | 'scoreActive20'
+  | 'scoreActive40'
+  | 'scoreActive60'
+  | 'scoreActive80'
+  | 'scoreActive100'
+  | 'yourScoreText'
+  | 'yourScoreIcon'
+  | 'yourScoreTextInvalid'
+  | 'yourScoreTextValid'
+  | 'feedbackContainer'
+  | 'divider';
+
+export type PasswordStrengthDisplayFullSx = FullSxRecord<PasswordStrengthDisplayClassKey>;
+
+export type PasswordStrengthDisplayPartialSx = PartialSxRecord<PasswordStrengthDisplayClassKey>;
+
+export interface PasswordStrengthDisplayProps {
+  value: string;
+  passwordRequirementsMinComplexity: number;
+  onValidStateChanged: (isValid: boolean) => void;
+  sxs?: PasswordStrengthDisplayPartialSx;
+}
+
+function getStyles(sx?: PasswordStrengthDisplayPartialSx): PasswordStrengthDisplayFullSx {
+  return {
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      width: '330px'
+    },
+    scoreList: {
+      display: 'flex',
+      flexDirection: 'row',
+      padding: 0,
+      columnGap: '5px',
+      marginTop: (theme) => theme.spacing(1),
+      marginBottom: '5px',
+      ...sx?.scoreList
+    },
+    scoreListItem: {
+      width: 'auto',
+      padding: 0,
+      ...sx?.scoreListItem
+    },
+    scoreListItemDisplay: {
+      width: '40px',
+      textAlign: 'center',
+      borderTop: '4px solid',
+      borderColor: (theme) => theme.palette.grey.A400,
+      ...sx?.scoreListItemDisplay
+    },
+    scoreListItemText: {
+      margin: 0,
+      ...sx?.scoreListItemText
+    },
+    scoreActive20: {
+      borderColor: (theme) => theme.palette.error.light,
+      ...sx?.scoreActive20
+    },
+    scoreActive40: {
+      borderColor: '#FB8C00',
+      ...sx?.scoreActive40
+    },
+    scoreActive60: {
+      borderColor: '#FFB400',
+      ...sx?.scoreActive60
+    },
+    scoreActive80: {
+      borderColor: (theme) => theme.palette.info.light,
+      ...sx?.scoreActive80
+    },
+    scoreActive100: {
+      borderColor: (theme) => theme.palette.success.light,
+      ...sx?.scoreActive100
+    },
+    yourScoreText: {
+      display: 'flex',
+      alignItems: 'center',
+      ...sx?.yourScoreText
+    },
+    yourScoreTextInvalid: {
+      color: (theme) => theme.palette.error.main,
+      ...sx?.yourScoreTextInvalid
+    },
+    yourScoreTextValid: {
+      color: (theme) => theme.palette.success.main,
+      ...sx?.yourScoreTextValid
+    },
+    yourScoreIcon: {
+      fontSize: '15px',
+      marginRight: (theme) => theme.spacing(1),
+      ...sx?.yourScoreIcon
+    },
+    feedbackContainer: {
+      width: '100%',
+      alignItems: 'center',
+      ...sx?.feedbackContainer
+    },
+    divider: {
+      width: '40%',
+      margin: (theme) => `${theme.spacing(1)} auto`,
+      ...sx?.divider
+    }
+  };
+}
+
+const messages = defineMessages({
+  '0': {
+    id: 'passwordStrengthDisplay.tooGuessable',
+    defaultMessage: 'Too guessable'
+  },
+  '1': {
+    id: 'passwordStrengthDisplay.veryGuessable',
+    defaultMessage: 'Very guessable'
+  },
+  '2': {
+    id: 'passwordStrengthDisplay.somewhatGuessable',
+    defaultMessage: 'Somewhat guessable'
+  },
+  '3': {
+    id: 'passwordStrengthDisplay.safelyUnguessable',
+    defaultMessage: 'Safely unguessable'
+  },
+  '4': {
+    id: 'passwordStrengthDisplay.veryUnguessable',
+    defaultMessage: 'Very unguessable'
+  }
+});
+
+function getDisplayScore(score) {
+  return (score + 1) * 20;
+}
+
+export function PasswordStrengthDisplay(props: PasswordStrengthDisplayProps) {
+  const { value, passwordRequirementsMinComplexity, onValidStateChanged, sxs } = props;
+  const sx = getStyles(sxs);
+  const minScore = getDisplayScore(passwordRequirementsMinComplexity);
+  const [password, setPassword] = useState(null);
+  const passwordScore = value === '' || nou(password) ? 0 : getDisplayScore(password.score);
+  const { formatMessage } = useIntl();
+  const onChangeTimeoutRef = useRef<any>(null);
+
+  useEffect(() => {
+    clearTimeout(onChangeTimeoutRef.current);
+    onChangeTimeoutRef.current = setTimeout(() => {
+      import('zxcvbn').then(({ default: zxcvbn }) => {
+        const pass = zxcvbn(value);
+        setPassword(pass);
+        onValidStateChanged(isBlank(value) ? null : pass.score >= passwordRequirementsMinComplexity);
+      });
+    }, 200);
+  }, [value, onValidStateChanged, passwordRequirementsMinComplexity]);
+
+  return (
+    <Box sx={sx.container}>
+      <Typography variant="subtitle2">
+        <FormattedMessage id="passwordStrengthDisplay.passwordStrengthTitle" defaultMessage="Password Strength Score" />
+      </Typography>
+      <Typography variant="body2">
+        <FormattedMessage
+          id="passwordStrengthDisplay.minimumScore"
+          defaultMessage="Minimum score {minScore}"
+          values={{ minScore }}
+        />
+      </Typography>
+      <Box>
+        <List sx={sx.scoreList}>
+          {new Array(5).fill(null).map((x, i) => (
+            <ListItem sx={sx.scoreListItem} key={i}>
+              {/* @ts-ignore - spread styles not recognized as valid */}
+              <Box
+                sx={{
+                  ...sx.scoreListItemDisplay,
+                  ...(passwordScore >= getDisplayScore(i) && {
+                    ...sx[`scoreActive${getDisplayScore(i)}`]
+                  })
+                }}
+              >
+                <ListItemText primary={getDisplayScore(i)} sx={sx.scoreListItemText} />
+              </Box>
+            </ListItem>
+          ))}
+        </List>
+      </Box>
+      <Typography
+        variant="body2"
+        /* @ts-ignore - spread styles not recognized as valid */
+        sx={{
+          ...sx.yourScoreText,
+          ...(passwordScore > 0 && passwordScore < minScore
+            ? { ...sx.yourScoreTextInvalid }
+            : passwordScore >= minScore
+            ? { ...sx.yourScoreTextValid }
+            : {})
+        }}
+      >
+        {passwordScore === minScore ? (
+          <CheckCircleOutlineRoundedIcon sx={sx.yourScoreIcon} />
+        ) : passwordScore === 100 ? (
+          <StarOutlineRoundedIcon sx={sx.yourScoreIcon} />
+        ) : (
+          <InfoOutlinedIcon sx={sx.yourScoreIcon} />
+        )}
+        <FormattedMessage
+          id="passwordStrengthDisplay.passwordScore"
+          defaultMessage="Your score: {score}"
+          values={{ score: passwordScore }}
+        />
+      </Typography>
+      <Collapse in={passwordScore > 0 && passwordScore < minScore} sx={sx.feedbackContainer}>
+        <Divider sx={sx.divider} />
+        <Box style={{ textAlign: 'left' }}>
+          {password && (
+            <>
+              <Typography variant="body2">
+                {formatMessage(messages[password.score])}.{' '}
+                {password.feedback.warning ? `${password.feedback.warning}.` : ''}
+              </Typography>
+              {password?.feedback.suggestions.map((suggestion, i) => (
+                <Typography variant="body2" key={i}>
+                  - {suggestion}
+                </Typography>
+              ))}
+            </>
+          )}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}
+
+export default PasswordStrengthDisplay;

--- a/ui/app/src/components/PasswordStrengthDisplay/index.ts
+++ b/ui/app/src/components/PasswordStrengthDisplay/index.ts
@@ -14,36 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { makeStyles } from 'tss-react/mui';
+export { default } from './PasswordStrengthDisplay';
 
-const useStyles = makeStyles()((theme) => ({
-  sectionTitle: {
-    marginBottom: '20px'
-  },
-  paper: {
-    padding: '20px',
-    margin: '20px 0',
-    background: theme.palette.background.default,
-    '& .mt20': {
-      marginTop: '20px'
-    }
-  },
-  container: {},
-  avatar: {
-    marginRight: '30px',
-    width: '90px',
-    height: '90px'
-  },
-  save: {
-    marginLeft: 'auto'
-  },
-  passwordStrengthPopper: {
-    zIndex: theme.zIndex.modal
-  },
-  passwordStrengthPaper: {
-    padding: '10px',
-    margin: '10px 0'
-  }
-}));
-
-export default useStyles;
+export * from './PasswordStrengthDisplay';

--- a/ui/app/src/components/PasswordStrengthDisplayPopper/PasswordStrengthDisplayPopper.tsx
+++ b/ui/app/src/components/PasswordStrengthDisplayPopper/PasswordStrengthDisplayPopper.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { FullSxRecord } from '../../models';
+import { PasswordStrengthDisplay, PasswordStrengthDisplayProps } from '../PasswordStrengthDisplay';
+import Popper, { PopperProps } from '@mui/material/Popper';
+import Paper from '@mui/material/Paper';
+
+export type PasswordStrengthDisplayPopperClassKey = 'root' | 'paper';
+export type PasswordStrengthDisplayPopperFullSx = FullSxRecord<PasswordStrengthDisplayPopperClassKey>;
+
+export interface PasswordStrengthDisplayPopperProps extends PasswordStrengthDisplayProps, PopperProps {}
+
+function getStyles(): PasswordStrengthDisplayPopperFullSx {
+  return {
+    root: {
+      zIndex: (theme) => theme.zIndex.modal
+    },
+    paper: {
+      padding: '10px',
+      margin: '10px 0'
+    }
+  };
+}
+
+export function PasswordStrengthDisplayPopper(props: PasswordStrengthDisplayPopperProps) {
+  const { value, passwordRequirementsMinComplexity, onValidStateChanged, sxs, ...rest } = props;
+  const sx = getStyles();
+
+  return (
+    <Popper {...rest} sx={sx.root}>
+      <Paper elevation={3} sx={sx.paper}>
+        <PasswordStrengthDisplay
+          value={value}
+          passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
+          onValidStateChanged={onValidStateChanged}
+          sxs={sxs}
+        />
+      </Paper>
+    </Popper>
+  );
+}
+
+export default PasswordStrengthDisplayPopper;

--- a/ui/app/src/components/PasswordStrengthDisplayPopper/index.ts
+++ b/ui/app/src/components/PasswordStrengthDisplayPopper/index.ts
@@ -14,36 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { makeStyles } from 'tss-react/mui';
+export { default } from './PasswordStrengthDisplayPopper';
 
-const useStyles = makeStyles()((theme) => ({
-  sectionTitle: {
-    marginBottom: '20px'
-  },
-  paper: {
-    padding: '20px',
-    margin: '20px 0',
-    background: theme.palette.background.default,
-    '& .mt20': {
-      marginTop: '20px'
-    }
-  },
-  container: {},
-  avatar: {
-    marginRight: '30px',
-    width: '90px',
-    height: '90px'
-  },
-  save: {
-    marginLeft: 'auto'
-  },
-  passwordStrengthPopper: {
-    zIndex: theme.zIndex.modal
-  },
-  passwordStrengthPaper: {
-    padding: '10px',
-    margin: '10px 0'
-  }
-}));
-
-export default useStyles;
+export * from './PasswordStrengthDisplayPopper';

--- a/ui/app/src/components/ResetPasswordDialog/ResetPasswordDialog.tsx
+++ b/ui/app/src/components/ResetPasswordDialog/ResetPasswordDialog.tsx
@@ -28,14 +28,14 @@ import { setPassword } from '../../services/users';
 import { showErrorDialog } from '../../state/reducers/dialogs/error';
 import { useDispatch } from 'react-redux';
 import { showSystemNotification } from '../../state/actions/system';
-import PasswordRequirementsDisplay from '../PasswordRequirementsDisplay';
 import PasswordTextField from '../PasswordTextField/PasswordTextField';
+import { PasswordStrengthDisplayPopper } from '../PasswordStrengthDisplayPopper';
 
 interface ResetPasswordDialogProps {
   open: boolean;
   onClose(): void;
   user: User;
-  passwordRequirementsRegex: string;
+  passwordRequirementsMinComplexity: number;
 }
 
 const translations = defineMessages({
@@ -55,10 +55,11 @@ export function ResetPasswordDialog(props: ResetPasswordDialogProps) {
 }
 
 function ResetPasswordDialogUI(props: ResetPasswordDialogProps) {
-  const { onClose, user, passwordRequirementsRegex } = props;
+  const { onClose, user, passwordRequirementsMinComplexity } = props;
   const [newPassword, setNewPassword] = useState('');
   const [isValid, setValid] = useState<boolean>(null);
   const [updating, setUpdating] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
 
@@ -105,12 +106,17 @@ function ResetPasswordDialogUI(props: ResetPasswordDialogProps) {
           onChange={(e) => {
             setNewPassword(e.target.value);
           }}
+          onFocus={(e) => setAnchorEl(e.target)}
+          onBlur={() => setAnchorEl(null)}
+          inputProps={{ autoComplete: 'new-password' }}
         />
-        <PasswordRequirementsDisplay
+        <PasswordStrengthDisplayPopper
+          open={Boolean(anchorEl)}
+          anchorEl={anchorEl}
+          placement="top"
           value={newPassword}
+          passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
           onValidStateChanged={setValid}
-          formatMessage={formatMessage}
-          passwordRequirementsRegex={passwordRequirementsRegex}
         />
       </DialogBody>
       <DialogFooter>

--- a/ui/app/src/components/UserManagement/UserManagement.tsx
+++ b/ui/app/src/components/UserManagement/UserManagement.tsx
@@ -36,13 +36,11 @@ import { useEnhancedDialogState } from '../../hooks/useEnhancedDialogState';
 import { useWithPendingChangesCloseRequest } from '../../hooks/useWithPendingChangesCloseRequest';
 
 export interface UserManagementProps {
-  passwordRequirementsRegex?: string;
+  passwordRequirementsMinComplexity?: number;
 }
 
 export function UserManagement(props: UserManagementProps) {
-  const {
-    passwordRequirementsRegex = '^(?=(?<hasNumbers>.*[0-9]))(?=(?<hasLowercase>.*[a-z]))(?=(?<hasUppercase>.*[A-Z]))(?=(?<hasSpecialChars>.*[~|!`,;/@#$%^&+=]))(?<minLength>.{8,})$'
-  } = props;
+  const { passwordRequirementsMinComplexity = 4 } = props;
   const [offset, setOffset] = useState(0);
   const [limit, setLimit] = useState(10);
   const [fetching, setFetching] = useState(false);
@@ -184,7 +182,7 @@ export function UserManagement(props: UserManagementProps) {
         open={createUserDialogState.open}
         onCreateSuccess={onUserCreated}
         onClose={createUserDialogState.onClose}
-        passwordRequirementsRegex={passwordRequirementsRegex}
+        passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
         isSubmitting={createUserDialogState.isSubmitting}
         isMinimized={createUserDialogState.isMinimized}
         hasPendingChanges={createUserDialogState.hasPendingChanges}
@@ -200,7 +198,7 @@ export function UserManagement(props: UserManagementProps) {
         isSubmitting={editUserDialogState.isSubmitting}
         isMinimized={editUserDialogState.isMinimized}
         hasPendingChanges={editUserDialogState.hasPendingChanges}
-        passwordRequirementsRegex={passwordRequirementsRegex}
+        passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
         onWithPendingChangesCloseRequest={editUserDialogPendingChangesCloseRequest}
         onSubmittingAndOrPendingChange={editUserDialogState.onSubmittingAndOrPendingChange}
       />

--- a/ui/app/src/components/index.ts
+++ b/ui/app/src/components/index.ts
@@ -165,6 +165,7 @@ export * from './PaddingModeSwitchListItem';
 export * from './PagesSearchAhead';
 export * from './Pagination';
 export * from './PasswordRequirementsDisplay';
+export * from './PasswordStrengthDisplay';
 export * from './PasswordTextField';
 export * from './PathNavigator';
 export * from './PathNavigatorTree';

--- a/ui/app/src/env/studioUI.ts
+++ b/ui/app/src/env/studioUI.ts
@@ -220,6 +220,7 @@ export const components = {
   PagesSearchAhead: lazy(() => import('../components/PagesSearchAhead')),
   Pagination: lazy(() => import('../components/Pagination')),
   PasswordRequirementsDisplay: lazy(() => import('../components/PasswordRequirementsDisplay')),
+  PasswordStrengthDisplay: lazy(() => import('../components/PasswordStrengthDisplay')),
   PasswordTextField: lazy(() => import('../components/PasswordTextField')),
   PathNavigator: lazy(() => import('../components/PathNavigator')),
   PathNavigatorTree: lazy(() => import('../components/PathNavigatorTree')),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4043,6 +4043,7 @@ __metadata:
     "@types/react-dom": ^18.0.5
     "@types/react-swipeable-views": ^0.13.1
     "@types/video.js": ^7.3.27
+    "@types/zxcvbn": ^4
     "@videojs/vhs-utils": ^2.3.0
     autosuggest-highlight: ^3.2.1
     babel-plugin-react-intl: ^5.1.16
@@ -4090,6 +4091,7 @@ __metadata:
     uppy: ^2.10.0
     video.js: ^7.20.0
     web-vitals: ^1.0.1
+    zxcvbn: ^4.4.2
   languageName: unknown
   linkType: soft
 
@@ -6612,6 +6614,13 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "*"
   checksum: f0673cbfc08e17239dc58952a88350d6c4db04a027a28a06fbad27d87b670e909f9cd9e66f9c64cebdd5071d1096261e33454a55868395f125297e5c50992ca8
+  languageName: node
+  linkType: hard
+
+"@types/zxcvbn@npm:^4":
+  version: 4.4.1
+  resolution: "@types/zxcvbn@npm:4.4.1"
+  checksum: 71c484f1aa049921997ee6471604725a7fb00b9899e7753c6e94275a2b135e1088ed3f2f2ba77d189715d1ec61bed65b06899ba03e061b07ffc32c2a9296501b
   languageName: node
   linkType: hard
 
@@ -19950,5 +19959,12 @@ typescript@^4.1.2:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zxcvbn@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "zxcvbn@npm:4.4.2"
+  checksum: 76ab32c066082ac73491b7cd7f93ad0595c59b6d45ae80a0745e9e1661237388beb2f0c2ba0ae3dc330ca3ecdb87edcb7a21e0c09137ab81d5b32e584cda1e5d
   languageName: node
   linkType: hard


### PR DESCRIPTION
* Initial work - Switch to using zxcvbn for password strength management #5816

* Create PasswordStrengthDisplay component #5816

* Remove passwordRequirementsRegex all over the code #5816

* Update components to use PasswordStrengthDisplay #5816

* Check blank before running the password complexity fn #5816

* Update components to use PasswordStrengthDisplayPopper #5816

* Debounce password strength calculation #5816

* Place PasswordStrengthDisplayPopper on top of fields #5816

* Revert section to form in CreateUserDialogContainer #5816

* Merge effects #5816

* Restore PasswordRequirementsDisplay #5816

* Restore PasswordRequirementsDisplay #5816

### Ticket reference or full description of what's in the PR

https://github.com/craftercms/craftercms/issues/5816
