### PR TITLE
[5862] Component and Shared Content Node Selectors show incorrect dialog

### DIFF
--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -122,6 +122,7 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
     CStudioAuthoring.Operations.openBrowseFilesDialog({
       path: _self.processPathsForMacros(browsePath),
       multiSelect,
+      allowUpload: false,
       onSuccess: (result) => {
         const items = Array.isArray(result) ? result : [result];
         items.forEach(({ name, path }) => {


### PR DESCRIPTION
- Do not show upload button when browsing items in shared-content datasource

https://github.com/craftercms/craftercms/issues/5862