### PR TITLE
Stability

### DIFF
--- a/ui/app/src/components/PathNavigator/PathNavigatorItem.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigatorItem.tsx
@@ -104,7 +104,6 @@ function PathNavigatorItem(props: NavItemProps) {
           sx={{ p: 0.75 }}
           size="small"
           color="primary"
-          className={classes.navItemCheckbox}
           onClick={(e) => e.stopPropagation()}
           onChange={(e) => {
             onItemChecked(item, e.currentTarget.checked);

--- a/ui/app/src/components/PathNavigator/PathNavigatorItem.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigatorItem.tsx
@@ -17,7 +17,7 @@
 import { DetailedItem } from '../../models/Item';
 import React, { useState } from 'react';
 import { useStyles } from './styles';
-import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
 import Checkbox from '@mui/material/Checkbox';
 import IconButton from '@mui/material/IconButton';
 import MoreVertIcon from '@mui/icons-material/MoreVertRounded';
@@ -88,17 +88,12 @@ function PathNavigatorItem(props: NavItemProps) {
   const previewable = isPreviewable(item);
   const folder = isFolder(item);
   const isLeaf = item.childrenCount === 0;
-
   return (
-    <ListItem
+    <ListItemButton
       selected={isActive}
-      button={!isSelectMode as true}
-      className={clsx(
-        classes.navItem,
-        isSelectMode && 'noLeftPadding',
-        isLevelDescriptor && classes.navItemLevelDescriptor,
-        isCurrentPath && classes.currentPathItem
-      )}
+      // TODO: must update this to support select mode
+      // button={!isSelectMode as true}
+      className={clsx(classes.navItem, isSelectMode && classes.noLeftPadding, isCurrentPath && classes.currentPathItem)}
       onMouseOver={onMouseOver}
       onMouseLeave={onMouseLeave}
       onClick={onClick}
@@ -106,28 +101,21 @@ function PathNavigatorItem(props: NavItemProps) {
     >
       {isSelectMode && (
         <Checkbox
+          sx={{ p: 0.75 }}
           size="small"
-          color="default"
+          color="primary"
           className={classes.navItemCheckbox}
           onClick={(e) => e.stopPropagation()}
           onChange={(e) => {
             onItemChecked(item, e.currentTarget.checked);
           }}
-          value="primary"
         />
       )}
       <ItemDisplay
         styles={{
           root: {
-            maxWidth: isSelectMode
-              ? 'calc(100% - 32px)'
-              : over
-              ? // Level descriptor doesn't ever have children, so will
-                // always have only one action button.
-                `calc(100% - ${isLevelDescriptor || isLeaf ? 25 : 50}px)`
-              : !isLeaf
-              ? `calc(100% - 25px)`
-              : '100%'
+            flex: 1,
+            minWidth: 0
           }
         }}
         item={item}
@@ -135,52 +123,45 @@ function PathNavigatorItem(props: NavItemProps) {
         showWorkflowState={!isSelectMode}
         labelTypographyProps={{ variant: 'body2' }}
       />
-      {(onOpenItemMenu || showItemNavigateToButton) && (
-        <div className={classes.optionsWrapper}>
-          {onOpenItemMenu && (
-            <Tooltip
-              title={formatMessage(translations.itemMenu)}
-              className={clsx(classes.itemMenu, over && classes.itemMenuOver)}
-            >
-              <IconButton
-                aria-label={formatMessage(translations.itemMenu)}
-                className={classes.itemIconButton}
-                data-item-menu
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onOpenItemMenu(event.currentTarget, item);
-                }}
-                size="large"
-              >
-                <MoreVertIcon className={classes.icon} />
-              </IconButton>
-            </Tooltip>
-          )}
-          {showItemNavigateToButton && !isLevelDescriptor && !isLeaf && (
-            <Tooltip title={formatMessage(translations.viewChildren)}>
-              <IconButton
-                aria-label={formatMessage(translations.viewChildren)}
-                className={classes.itemIconButton}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  if (isLeaf) {
-                    return;
-                  } else if (navigable || folder) {
-                    onChangeParent?.(item);
-                  } else if (previewable) {
-                    onPreview?.(item);
-                  }
-                }}
-                size="large"
-              >
-                <ChevronRightRoundedIcon className={classes.icon} />
-              </IconButton>
-            </Tooltip>
-          )}
-        </div>
+      {over && onOpenItemMenu && (
+        <Tooltip title={formatMessage(translations.itemMenu)}>
+          <IconButton
+            aria-label={formatMessage(translations.itemMenu)}
+            className={classes.itemIconButton}
+            data-item-menu
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpenItemMenu(event.currentTarget, item);
+            }}
+            size="large"
+          >
+            <MoreVertIcon className={classes.icon} />
+          </IconButton>
+        </Tooltip>
       )}
-    </ListItem>
+      {over && showItemNavigateToButton && !isLevelDescriptor && !isLeaf && (
+        <Tooltip title={formatMessage(translations.viewChildren)}>
+          <IconButton
+            aria-label={formatMessage(translations.viewChildren)}
+            className={classes.itemIconButton}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              if (isLeaf) {
+                return;
+              } else if (navigable || folder) {
+                onChangeParent?.(item);
+              } else if (previewable) {
+                onPreview?.(item);
+              }
+            }}
+            size="large"
+          >
+            <ChevronRightRoundedIcon className={classes.icon} />
+          </IconButton>
+        </Tooltip>
+      )}
+    </ListItemButton>
   );
 }
 

--- a/ui/app/src/components/PathNavigator/styles.ts
+++ b/ui/app/src/components/PathNavigator/styles.ts
@@ -37,12 +37,6 @@ export const useStyles = makeStyles()((theme) => ({
     display: 'flex',
     position: 'absolute'
   },
-  itemMenu: {
-    visibility: 'hidden'
-  },
-  itemMenuOver: {
-    visibility: 'visible'
-  },
   headerTitle: {
     flexGrow: 1
   },
@@ -153,19 +147,18 @@ export const useStyles = makeStyles()((theme) => ({
     padding: '0 0 0 5px',
     marginLeft: 15,
     width: 'calc(100% - 15px)',
-    '&.noLeftPadding': {
-      paddingLeft: 0
-    },
     '&:hover': {
       backgroundColor: theme.palette.mode === 'dark' ? theme.palette.action.hover : theme.palette.grey['A200']
     }
+  },
+  noLeftPadding: {
+    paddingLeft: 0
   },
   currentPathItem: {
     paddingLeft: 0,
     marginLeft: 10,
     width: 'auto'
   },
-  navItemLevelDescriptor: {},
   navItemText: {
     color: theme.palette.mode === 'dark' ? palette.teal.tint : palette.teal.shade,
     padding: 0,
@@ -181,8 +174,7 @@ export const useStyles = makeStyles()((theme) => ({
     }
   },
   navItemCheckbox: {
-    padding: '6px',
-    color: theme.palette.primary.main
+    padding: '6px'
   }
   // endregion
 }));

--- a/ui/app/src/components/PathNavigator/styles.ts
+++ b/ui/app/src/components/PathNavigator/styles.ts
@@ -158,23 +158,6 @@ export const useStyles = makeStyles()((theme) => ({
     paddingLeft: 0,
     marginLeft: 10,
     width: 'auto'
-  },
-  navItemText: {
-    color: theme.palette.mode === 'dark' ? palette.teal.tint : palette.teal.shade,
-    padding: 0,
-    marginRight: 'auto',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    '&.opacity': {
-      opacity: '0.7'
-    },
-    '&.select-mode, &.non-navigable': {
-      color: theme.palette.text.primary
-    }
-  },
-  navItemCheckbox: {
-    padding: '6px'
   }
   // endregion
 }));

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -40,7 +40,7 @@ import {
   isPdfDocument
 } from '../PathNavigator/utils';
 import ContextMenu, { ContextMenuOption } from '../ContextMenu/ContextMenu';
-import { getNumOfMenuOptionsForItem } from '../../utils/content';
+import { getNumOfMenuOptionsForItem, lookupItemByPath } from '../../utils/content';
 import { previewItem } from '../../state/actions/preview';
 import { getOffsetLeft, getOffsetTop } from '@mui/material/Popover';
 import { showEditDialog, showItemMegaMenu, showPreviewDialog } from '../../state/actions/dialogs';
@@ -159,7 +159,7 @@ export function PathNavigatorTree(props: PathNavigatorTreeProps) {
   const keywordByPath = state?.keywordByPath;
   const totalByPath = state?.totalByPath;
   const childrenByParentPath = state?.childrenByParentPath;
-  const rootItem = itemsByPath[rootPath];
+  const rootItem = lookupItemByPath(rootPath, itemsByPath);
 
   useEffect(() => {
     // Adding uiConfig as means to stop navigator from trying to

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
@@ -143,19 +143,6 @@ const useStyles = makeStyles<void, 'content' | 'labelContainer'>()((theme, _para
   focused: {
     background: 'none !important'
   },
-  optionsWrapper: {
-    top: 0,
-    right: 0,
-    visibility: 'hidden',
-    position: 'absolute',
-    marginLeft: 'auto',
-    display: 'flex',
-    minHeight: '23.5px',
-    alignItems: 'center'
-  },
-  optionsWrapperOver: {
-    visibility: 'visible'
-  },
   loading: {
     display: 'flex',
     alignItems: 'center',
@@ -340,7 +327,8 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
             <ItemDisplay
               styles={{
                 root: {
-                  width: over ? 'calc(100% - 60px)' : '100%',
+                  flex: 1,
+                  minWidth: 0,
                   minHeight: '23.5px'
                 }
               }}
@@ -350,78 +338,74 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
               showPublishingTarget={showPublishingTarget}
               showWorkflowState={showWorkflowState}
             />
-            <section className={cx(classes.optionsWrapper, over && classes.optionsWrapperOver)}>
-              {showItemMenu && onOpenItemMenu && (
-                <Tooltip title={<FormattedMessage id="words.options" defaultMessage="Options" />}>
-                  <IconButton
-                    size="small"
-                    className={classes.iconButton}
-                    data-item-menu
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onOpenItemMenu(e.currentTarget, path);
-                    }}
-                  >
-                    <MoreVertRoundedIcon />
-                  </IconButton>
-                </Tooltip>
-              )}
-              {(Boolean(children.length) || showFilter) && (
-                <Tooltip title={<FormattedMessage id="words.filter" defaultMessage="Filter" />}>
-                  <IconButton
-                    size="small"
-                    className={classes.iconButton}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onClearKeywords();
-                      onFilterButtonClick();
-                    }}
-                  >
-                    <SearchRoundedIcon color={showFilter ? 'primary' : 'action'} />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </section>
-          </section>
-          {showFilter && (
-            <>
-              <section className={classes.filterSection}>
-                <SearchBar
-                  autoFocus
-                  onClick={(e) => e.stopPropagation()}
-                  onChange={(keyword) => {
-                    setKeyword(keyword);
-                    onFilterChange(keyword, path);
-                  }}
-                  keyword={keyword}
-                  placeholder={formatMessage(translations.filter)}
-                  onActionButtonClick={(e, input) => {
-                    e.stopPropagation();
-                    onClearKeywords();
-                    input.focus();
-                  }}
-                  showActionButton={keyword && true}
-                  classes={{
-                    root: cx(classes.searchRoot, props.classes?.searchRoot),
-                    inputInput: cx(classes.searchInput, props.classes?.searchInput),
-                    actionIcon: cx(classes.searchCloseIcon, props.classes?.searchCleanButton)
-                  }}
-                />
+            {over && showItemMenu && onOpenItemMenu && (
+              <Tooltip title={<FormattedMessage id="words.options" defaultMessage="Options" />}>
                 <IconButton
                   size="small"
+                  className={classes.iconButton}
+                  data-item-menu
                   onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onOpenItemMenu(e.currentTarget, path);
+                  }}
+                >
+                  <MoreVertRoundedIcon />
+                </IconButton>
+              </Tooltip>
+            )}
+            {over && (showFilter || Boolean(children.length)) && (
+              <Tooltip title={<FormattedMessage id="words.filter" defaultMessage="Filter" />}>
+                <IconButton
+                  size="small"
+                  className={classes.iconButton}
+                  onClick={(e) => {
+                    e.preventDefault();
                     e.stopPropagation();
                     onClearKeywords();
-                    setShowFilter(false);
+                    onFilterButtonClick();
                   }}
-                  className={cx(classes.searchCloseButton, props.classes?.searchCloseButton)}
                 >
-                  <CloseIconRounded />
+                  <SearchRoundedIcon color={showFilter ? 'primary' : 'action'} />
                 </IconButton>
-              </section>
-            </>
+              </Tooltip>
+            )}
+          </section>
+          {showFilter && (
+            <section className={classes.filterSection}>
+              <SearchBar
+                autoFocus
+                onClick={(e) => e.stopPropagation()}
+                onChange={(keyword) => {
+                  setKeyword(keyword);
+                  onFilterChange(keyword, path);
+                }}
+                keyword={keyword}
+                placeholder={formatMessage(translations.filter)}
+                onActionButtonClick={(e, input) => {
+                  e.stopPropagation();
+                  onClearKeywords();
+                  input.focus();
+                }}
+                showActionButton={keyword && true}
+                classes={{
+                  root: cx(classes.searchRoot, props.classes?.searchRoot),
+                  inputInput: cx(classes.searchInput, props.classes?.searchInput),
+                  actionIcon: cx(classes.searchCloseIcon, props.classes?.searchCleanButton)
+                }}
+              />
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClearKeywords();
+                  setShowFilter(false);
+                }}
+                className={cx(classes.searchCloseButton, props.classes?.searchCloseButton)}
+              >
+                <CloseIconRounded />
+              </IconButton>
+            </section>
           )}
         </>
       }

--- a/ui/app/src/services/users.ts
+++ b/ui/app/src/services/users.ts
@@ -66,10 +66,6 @@ export function fetchAll(options?: Partial<PaginationOptions & { keyword?: strin
   );
 }
 
-export function byId(): Observable<User> {
-  return null;
-}
-
 export function enable(username: string): Observable<User>;
 export function enable(usernames: string[]): Observable<User[]>;
 export function enable(usernames: string | string[]): Observable<User | User[]> {

--- a/ui/app/src/styles/theme.tsx
+++ b/ui/app/src/styles/theme.tsx
@@ -105,6 +105,11 @@ export function createDefaultThemeOptions({ mode }: { mode: ThemeOptions['palett
         defaultProps: {
           variant: 'outlined'
         }
+      },
+      MuiTooltip: {
+        defaultProps: {
+          disableInteractive: true
+        }
       }
     }
   };


### PR DESCRIPTION
- Avoid PathNavTree not loading when config path has no `index.xml`
- Default tooltips to not be interactive to avoid them covering other sequential elements around them
- Remove empty method skeleton
