### PR TITLE
[5940][4.0.3] XB targets won't honor multiple "Components" data sources

### DIFF
--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1143,7 +1143,7 @@ var CStudioForms =
         var _content = content.responseXML ? content.responseXML : content;
         if (_content) {
           try {
-            return _content.querySelector(':scope > internal-name').textContent;
+            return _content?.querySelector?.(':scope > internal-name').textContent;
           } catch (err) {
             console.error(err);
             return '';

--- a/ui/app/src/components/PreviewConcierge/PreviewConcierge.tsx
+++ b/ui/app/src/components/PreviewConcierge/PreviewConcierge.tsx
@@ -40,7 +40,6 @@ import {
   iceZoneSelected,
   initRichTextEditorConfig,
   insertComponentOperation,
-  insertInstanceOperation,
   insertItemOperation,
   insertItemOperationComplete,
   insertItemOperationFailed,
@@ -71,9 +70,11 @@ import {
   updateFieldValueOperationComplete,
   updateFieldValueOperationFailed,
   updateRteConfig,
-  snackGuestMessage
+  snackGuestMessage,
+  InsertComponentOperationPayload
 } from '../../state/actions/preview';
 import {
+  writeInstance,
   deleteItem,
   duplicateItem,
   fetchContentInstance,
@@ -712,73 +713,64 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
           break;
         }
         case insertComponentOperation.type: {
-          const { fieldId, targetIndex, instance, shared } = payload;
+          const {
+            fieldId,
+            targetIndex,
+            instance,
+            shared = false,
+            create = false
+          } = payload as InsertComponentOperationPayload;
           let { modelId, parentModelId } = payload;
           const path = models[modelId ?? parentModelId].craftercms.path;
+          const contentType = contentTypes[instance.craftercms.contentTypeId];
 
           if (isInheritedField(models[modelId], fieldId)) {
             modelId = getModelIdFromInheritedField(models[modelId], fieldId, modelIdByPath);
             parentModelId = findParentModelId(modelId, hierarchyMap, models);
           }
 
-          insertComponent(
-            siteId,
-            modelId,
-            fieldId,
-            targetIndex,
-            contentTypes[instance.craftercms.contentTypeId],
-            instance,
-            models[parentModelId ? parentModelId : modelId].craftercms.path,
-            shared,
-            (instanceFieldId) =>
-              upToDateRefs.current.cdataEscapedFieldPatterns.some((pattern) => Boolean(instanceFieldId.match(pattern)))
-          ).subscribe({
-            next() {
-              issueDescriptorRequest({
-                site: siteId,
-                path: path ?? models[parentModelId].craftercms.path,
-                contentTypes,
-                requestedSourceMapPaths,
-                dispatch,
-                completeAction: fetchGuestModelComplete
-              });
-              hostToGuest$.next(
-                insertOperationComplete({
-                  ...payload,
-                  currentFullUrl: `${guestBase}${upToDateRefs.current.currentUrlPath}`
-                })
+          const shouldSerializeFn = (instanceFieldId) =>
+            upToDateRefs.current.cdataEscapedFieldPatterns.some((pattern) => Boolean(instanceFieldId.match(pattern)));
+
+          // Cases:
+          // - Shared new - shared: true, create: true -> insertComponent
+          // - Shared existing - shared: true, create: false -> insertInstance
+          // - Embedded new - shared: false, create: true -> insertComponent
+          // * Embedded existing - shared: false, create: false -> insertInstance <- This case doesn't go through here as it is the move/sort operation.
+          let serviceObservable = create
+            ? // region insertComponent
+              insertComponent(
+                siteId,
+                modelId,
+                fieldId,
+                targetIndex,
+                contentType,
+                instance,
+                models[parentModelId ? parentModelId : modelId].craftercms.path,
+                shared,
+                shouldSerializeFn
+              )
+            : // endregion
+              // region insertInstance
+              insertInstance(
+                siteId,
+                modelId,
+                fieldId,
+                targetIndex,
+                instance,
+                models[parentModelId ? parentModelId : modelId].craftercms.path
               );
-              updatedModifiedItem(path);
-              enqueueSnackbar(formatMessage(guestMessages.insertOperationComplete));
-            },
-            error(error) {
-              console.error(`${type} failed`, error);
-              hostToGuest$.next(insertOperationFailed());
-              // If write operation fails the items remains locked, so we need to dispatch unlockItem
-              dispatch(unlockItem({ path }));
-              enqueueSnackbar(formatMessage(guestMessages.insertOperationFailed), { variant: 'error' });
-            }
-          });
-          break;
-        }
-        case insertInstanceOperation.type: {
-          const { fieldId, targetIndex, instance } = payload;
-          let { modelId, parentModelId } = payload;
-          const path = models[modelId ?? parentModelId].craftercms.path;
+          // endregion
 
-          if (isInheritedField(models[modelId], fieldId)) {
-            modelId = getModelIdFromInheritedField(models[modelId], fieldId, modelIdByPath);
-            parentModelId = findParentModelId(modelId, hierarchyMap, models);
+          // Writing the xml document only makes sense for shared.
+          if (shared && create) {
+            let postWriteObs = serviceObservable;
+            serviceObservable = writeInstance(siteId, instance, contentType, shouldSerializeFn).pipe(
+              switchMap(() => postWriteObs)
+            );
           }
 
-          insertInstance(
-            siteId,
-            modelId,
-            fieldId,
-            targetIndex,
-            instance,
-            models[parentModelId ? parentModelId : modelId].craftercms.path
-          ).subscribe({
+          serviceObservable.subscribe({
             next() {
               issueDescriptorRequest({
                 site: siteId,
@@ -788,7 +780,6 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
                 dispatch,
                 completeAction: fetchGuestModelComplete
               });
-
               hostToGuest$.next(
                 insertOperationComplete({
                   ...payload,

--- a/ui/app/src/components/PreviewConcierge/PreviewConcierge.tsx
+++ b/ui/app/src/components/PreviewConcierge/PreviewConcierge.tsx
@@ -736,7 +736,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
           // - Shared new - shared: true, create: true -> insertComponent
           // - Shared existing - shared: true, create: false -> insertInstance
           // - Embedded new - shared: false, create: true -> insertComponent
-          // * Embedded existing - shared: false, create: false -> insertInstance <- This case doesn't go through here as it is the move/sort operation.
+          // * Embedded existing - shared: false, create: false -> insertInstance <- This case doesn't go through here, it goes by the move/sort operation.
           let serviceObservable = create
             ? // region insertComponent
               insertComponent(
@@ -762,7 +762,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
               );
           // endregion
 
-          // Writing the xml document only makes sense for shared.
+          // Writing the xml document for the component being inserted only applies to new & shared.
           if (shared && create) {
             let postWriteObs = serviceObservable;
             serviceObservable = writeInstance(siteId, instance, contentType, shouldSerializeFn).pipe(

--- a/ui/app/src/models/ContentType.ts
+++ b/ui/app/src/models/ContentType.ts
@@ -23,15 +23,17 @@ export interface ContentTypeSection {
   expandByDefault: boolean;
 }
 
-export interface ContentTypeFieldValidation {
+export interface ContentTypeFieldValidation<T = any> {
   id: string;
-  value: any;
+  value: T;
   level: 'required' | 'suggestion';
 }
 
 export type ValidationKeys =
   | 'allowedContentTypeTags'
-  | 'allowedContentTypes'
+  | 'allowedContentTypes' // TODO: access removing this validation in favour of keeping allowedEmbeddedContentTypes & allowedSharedContentTypes only
+  | 'allowedEmbeddedContentTypes'
+  | 'allowedSharedContentTypes'
   | 'minCount'
   | 'maxCount'
   | 'maxLength'
@@ -163,9 +165,7 @@ export interface LegacyDataSource {
   title: string; // display name for authors
   type: string; // data source id
   interface: string; // ?
-  properties: {
-    property: LegacyFormDefinitionProperty[] | LegacyFormDefinitionProperty;
-  };
+  properties: { property: LegacyFormDefinitionProperty[] | LegacyFormDefinitionProperty };
 }
 
 export interface LegacyFormDefinition {
@@ -224,6 +224,17 @@ export interface LegacyContentType {
   quickCreatePath: string;
   type: LegacyComponentTypes;
   useRoundedFolder: string;
+}
+
+export interface ComponentsDatasource extends LegacyDataSource {
+  allowEmbedded: boolean;
+  allowShared: boolean;
+  baseBrowsePath: string;
+  baseRepositoryPath: string;
+  contentTypes: string;
+  enableBrowse: boolean;
+  enableSearch: boolean;
+  tags: string;
 }
 
 export default ContentType;

--- a/ui/app/src/models/ContentType.ts
+++ b/ui/app/src/models/ContentType.ts
@@ -31,7 +31,7 @@ export interface ContentTypeFieldValidation<T = any> {
 
 export type ValidationKeys =
   | 'allowedContentTypeTags'
-  | 'allowedContentTypes' // TODO: access removing this validation in favour of keeping allowedEmbeddedContentTypes & allowedSharedContentTypes only
+  | 'allowedContentTypes' // TODO: assess removing this validation in favour of keeping allowedEmbeddedContentTypes & allowedSharedContentTypes only
   | 'allowedEmbeddedContentTypes'
   | 'allowedSharedContentTypes'
   | 'minCount'

--- a/ui/app/src/services/content.ts
+++ b/ui/app/src/services/content.ts
@@ -17,7 +17,15 @@
 import { errorSelectorApi1, get, getBinary, getGlobalHeaders, getText, post, postJSON } from '../utils/ajax';
 import { catchError, map, pluck, switchMap, tap } from 'rxjs/operators';
 import { forkJoin, Observable, of, zip } from 'rxjs';
-import { cdataWrap, createElement, createElements, fromString, getInnerHtml, serialize } from '../utils/xml';
+import {
+  cdataWrap,
+  createElement,
+  createElements,
+  fromString,
+  getInnerHtml,
+  newXMLDocument,
+  serialize
+} from '../utils/xml';
 import { ContentType } from '../models/ContentType';
 import { createLookupTable, nnou, nou, toQueryString } from '../utils/object';
 import { LookupTable } from '../models/LookupTable';
@@ -32,7 +40,12 @@ import { getRequestForgeryToken } from '../utils/auth';
 import { DetailedItem, LegacyItem, SandboxItem } from '../models/Item';
 import { VersionsResponse } from '../models/Version';
 import { GetChildrenOptions } from '../models/GetChildrenOptions';
-import { parseContentXML, parseSandBoxItemToDetailedItem, prepareVirtualItemProps } from '../utils/content';
+import {
+  generateComponentPath,
+  parseContentXML,
+  parseSandBoxItemToDetailedItem,
+  prepareVirtualItemProps
+} from '../utils/content';
 import QuickCreateItem from '../models/content/QuickCreateItem';
 import ApiResponse from '../models/ApiResponse';
 import { fetchContentTypes } from './contentTypes';
@@ -85,6 +98,7 @@ export function fetchDescriptorDOM(
   return fetchDescriptorXML(site, path, options).pipe(map(fromString));
 }
 
+// region fetchSandboxItem
 export function fetchSandboxItem(site: string, path: string): Observable<SandboxItem>;
 export function fetchSandboxItem(
   site: string,
@@ -103,6 +117,7 @@ export function fetchSandboxItem(
 ): Observable<SandboxItem | DetailedItem> {
   return fetchItemsByPath(site, [path], options).pipe(pluck(0));
 }
+// endregion
 
 export function fetchDetailedItem(
   siteId: string,
@@ -143,7 +158,12 @@ export function fetchContentInstance(
   return fetchContentDOM(site, path).pipe(map((doc) => parseContentXML(doc, path, contentTypesLookup, {})));
 }
 
-export function writeContent(site: string, path: string, content: string, options?: { unlock: boolean }) {
+export function writeContent(
+  site: string,
+  path: string,
+  content: string,
+  options?: { unlock: boolean }
+): Observable<boolean> {
   options = Object.assign({ unlock: true }, options);
   return post(
     writeContentUrl({
@@ -155,7 +175,7 @@ export function writeContent(site: string, path: string, content: string, option
     content
   ).pipe(
     map((ajaxResponse) => {
-      if (ajaxResponse.response.result.error) {
+      if (ajaxResponse.response.result?.error) {
         // eslint-disable-next-line no-throw-literal
         throw {
           ...ajaxResponse,
@@ -197,8 +217,56 @@ function writeContentUrl(qs: object): string {
   return `/studio/api/1/services/api/1/content/write-content.json?${qs.toString()}`;
 }
 
-// region Operations
+function createComponentObject(
+  instance: ContentInstance,
+  contentType: ContentType,
+  shouldSerializeValueFn: (fieldId) => boolean
+) {
+  const id = (instance.craftercms.id = instance.craftercms.id ?? uuid());
+  const path = (instance.craftercms.path =
+    instance.craftercms.path ?? generateComponentPath(id, instance.craftercms.contentTypeId));
+  const fileName = getFileNameFromPath(path);
 
+  const serializedInstance = {};
+  for (let key in instance) {
+    if (key !== 'craftercms' && key !== 'fileName' && key !== 'internalName') {
+      serializedInstance[key] =
+        nnou(instance[key]) && !isBlank(instance[key]) && shouldSerializeValueFn?.(key)
+          ? cdataWrap(`${instance[key]}`)
+          : instance[key];
+    }
+  }
+
+  return mergeContentDocumentProps('component', {
+    '@attributes': { id },
+    'content-type': contentType.id,
+    'display-template': contentType.displayTemplate,
+    // TODO: per this, at this point, internal-name is always cdata wrapped, not driven by config.
+    'internal-name': cdataWrap(instance.craftercms.label),
+    'file-name': fileName,
+    objectId: id,
+    ...serializedInstance
+  });
+}
+
+// region writeComponent
+/**
+ * Creates a new content item xml document and writes it to the repo.
+ */
+export function writeInstance(
+  site: string,
+  instance: ContentInstance,
+  contentType: ContentType,
+  shouldSerializeValueFn?: (fieldId: any) => boolean
+): Observable<any> {
+  const doc = newXMLDocument('component');
+  const transferObj = createComponentObject(instance, contentType, shouldSerializeValueFn);
+  createElements(doc.documentElement, transferObj);
+  return writeContent(site, instance.craftercms.path, serialize(doc));
+}
+// endregion
+
+// region updateField
 export function updateField(
   site: string,
   modelId: string,
@@ -237,7 +305,9 @@ export function updateField(
     modelId
   );
 }
+// endregion
 
+// region performMutation
 function performMutation(
   site: string,
   path: string,
@@ -269,9 +339,12 @@ function performMutation(
     })
   );
 }
+// endregion
 
+// region insertComponent
 /**
- * Insert a *new* component on to the document
+ * Inserts a *new* component item on the specified component collection field. In case of shared components, only
+ * updates the target content item field to include the reference, does not create/write the shared component document.
  * */
 export function insertComponent(
   site: string,
@@ -282,59 +355,28 @@ export function insertComponent(
   instance: ContentInstance,
   path: string,
   shared = false,
-  serializeValue?: (instanceFieldId: string) => boolean
+  shouldSerializeValueFn?: (fieldId: string) => boolean
 ): Observable<any> {
   return performMutation(
     site,
     path,
     (element) => {
       const id = instance.craftercms.id;
-      const path = shared ? instance.craftercms.path ?? getComponentPath(id, instance.craftercms.contentTypeId) : null;
+      const path = shared
+        ? instance.craftercms.path ?? generateComponentPath(id, instance.craftercms.contentTypeId)
+        : null;
 
       // Create the new `item` that holds or references (embedded vs shared) the component.
       const newItem = createElement('item');
 
-      delete instance.fileName;
-      delete instance.internalName;
-
-      const serializedInstance = {};
-      for (let key in instance) {
-        if (key !== 'craftercms') {
-          serializedInstance[key] =
-            instance[key] && serializeValue?.(key) ? cdataWrap(`${instance[key]}`) : instance[key];
-        }
-      }
-
-      // Create the new component that will be either embedded into the parent's XML or
-      // shared stored on it's own.
-      const component = mergeContentDocumentProps('component', {
-        '@attributes': { id },
-        'content-type': contentType.id,
-        'display-template': contentType.displayTemplate,
-        // TODO: per this, at this point, internal-name is always cdata wrapped, not driven by config.
-        'internal-name': cdataWrap(instance.craftercms.label),
-        'file-name': `${id}.xml`,
-        objectId: id,
-        ...serializedInstance
-      });
-
       // Add the child elements into the `item` node
       createElements(newItem, {
-        '@attributes': {
-          // TODO: Hardcoded value. Fix.
-          datasource: '',
-          ...(shared ? {} : { inline: true })
-        },
+        '@attributes': { inline: !shared },
         key: shared ? path : id,
         value: cdataWrap(instance.craftercms.label),
         ...(shared
-          ? {
-              include: path,
-              disableFlattening: 'false'
-            }
-          : {
-              component
-            })
+          ? { include: path, disableFlattening: 'false' }
+          : { component: createComponentObject(instance, contentType, shouldSerializeValueFn) })
       });
 
       insertCollectionItem(element, fieldId, targetIndex, newItem);
@@ -342,7 +384,9 @@ export function insertComponent(
     modelId
   );
 }
+// endregion
 
+// region insertInstance
 /**
  * Insert an *existing* (i.e. shared) component on to the document
  * */
@@ -379,7 +423,9 @@ export function insertInstance(
     modelId
   );
 }
+// endregion
 
+// region insertItem
 export function insertItem(
   site: string,
   modelId: string,
@@ -387,7 +433,7 @@ export function insertItem(
   index: string | number,
   instance: InstanceRecord,
   path: string,
-  serializeValue?: (instanceFieldId: string) => boolean
+  shouldSerializeValueFn?: (fieldId: string) => boolean
 ): Observable<any> {
   return performMutation(
     site,
@@ -398,7 +444,7 @@ export function insertItem(
       const serializedInstance = {};
       for (let key in instance) {
         if (key !== 'craftercms') {
-          serializedInstance[key] = serializeValue?.(key) ? cdataWrap(`${instance[key]}`) : instance[key];
+          serializedInstance[key] = shouldSerializeValueFn?.(key) ? cdataWrap(`${instance[key]}`) : instance[key];
         }
       }
       createElements(newItem, serializedInstance);
@@ -407,6 +453,7 @@ export function insertItem(
     modelId
   );
 }
+// endregion
 
 export function duplicateItem(
   site: string,
@@ -628,8 +675,6 @@ export function deleteItem(
   );
 }
 
-// endregion
-
 interface SearchServiceResponse {
   response: ApiResponse;
   result: {
@@ -826,7 +871,7 @@ function extractNode(doc: XMLDocument | Element, fieldId: string, index: string 
   }
 }
 
-function mergeContentDocumentProps(type: string, data: AnyObject): LegacyContentDocumentProps {
+function mergeContentDocumentProps(type: 'page' | 'component', data: AnyObject): LegacyContentDocumentProps {
   // Dasherized props...
   // content-type, display-template, no-template-required, internal-name, file-name
   // merge-strategy, folder-name, parent-descriptor
@@ -845,21 +890,16 @@ function mergeContentDocumentProps(type: string, data: AnyObject): LegacyContent
       objectId: ''
     },
     type === 'page' ? { placeInNav: 'false' as 'false' } : {},
-    data || {}
+    data
   );
 }
 
-function createModifiedDate() {
+function createModifiedDate(): string {
   return new Date().toISOString();
 }
 
-function updateModifiedDateElement(doc: Element) {
+function updateModifiedDateElement(doc: Element): void {
   doc.querySelector(':scope > lastModifiedDate_dt').innerHTML = createModifiedDate();
-}
-
-function getComponentPath(id: string, contentType: string) {
-  const pathBase = `/site/components/${contentType.replace('/component/', '')}s/`.replace(/\/{1,}$/m, '');
-  return `${pathBase}/${id}.xml`;
 }
 
 function insertCollectionItem(

--- a/ui/app/src/services/content.ts
+++ b/ui/app/src/services/content.ts
@@ -230,10 +230,11 @@ function createComponentObject(
   const serializedInstance = {};
   for (let key in instance) {
     if (key !== 'craftercms' && key !== 'fileName' && key !== 'internalName') {
+      let value = instance[key];
       serializedInstance[key] =
-        nnou(instance[key]) && !isBlank(instance[key]) && shouldSerializeValueFn?.(key)
-          ? cdataWrap(`${instance[key]}`)
-          : instance[key];
+        nnou(value) && (typeof value !== 'string' || !isBlank(value)) && shouldSerializeValueFn?.(key)
+          ? cdataWrap(`${value}`)
+          : value;
     }
   }
 
@@ -249,7 +250,7 @@ function createComponentObject(
   });
 }
 
-// region writeComponent
+// region writeInstance
 /**
  * Creates a new content item xml document and writes it to the repo.
  */
@@ -444,7 +445,11 @@ export function insertItem(
       const serializedInstance = {};
       for (let key in instance) {
         if (key !== 'craftercms') {
-          serializedInstance[key] = shouldSerializeValueFn?.(key) ? cdataWrap(`${instance[key]}`) : instance[key];
+          let value = instance[key];
+          serializedInstance[key] =
+            nnou(value) && (typeof value !== 'string' || !isBlank(value)) && shouldSerializeValueFn?.(key)
+              ? cdataWrap(`${value}`)
+              : value;
         }
       }
       createElements(newItem, serializedInstance);

--- a/ui/app/src/services/contentTypes.ts
+++ b/ui/app/src/services/contentTypes.ts
@@ -358,7 +358,7 @@ function parseLegacyFormDefinition(definition: LegacyFormDefinition): Partial<Co
 
   // get receptacles dataSources
   asArray(definition.datasources?.datasource).forEach((datasource: LegacyDataSource) => {
-    // TODO: Delete datasource.properties after props have been added to the root object? Most update code usages of datasource.properties.
+    // TODO: Delete datasource.properties after props have been added to the root object? Must update code usages of datasource.properties.
     const properties = asArray(datasource.properties?.property);
     properties.forEach((property) => {
       let value: any = property.value;

--- a/ui/app/src/services/contentTypes.ts
+++ b/ui/app/src/services/contentTypes.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  ComponentsDatasource,
   ContentType,
   ContentTypeField,
   ContentTypeFieldValidation,
@@ -142,18 +143,41 @@ function getFieldValidations(
     if (systemValidationsNames.includes(key)) {
       if (key === 'itemManager' && dropTargetsLookup) {
         map.itemManager?.value &&
-          map.itemManager.value.split(',').forEach((value) => {
-            if (dropTargetsLookup[value]) {
-              asArray(dropTargetsLookup[value].properties?.property).forEach((prop) => {
-                if (systemValidationsKeysMap[prop.name]) {
-                  validations[systemValidationsKeysMap[prop.name]] = {
-                    id: systemValidationsKeysMap[prop.name],
-                    value: prop.value ? prop.value.split(',') : [],
-                    level: 'required'
+          map.itemManager.value.split(',').forEach((itemManagerId) => {
+            asArray(dropTargetsLookup[itemManagerId]?.properties?.property).forEach((prop) => {
+              let mappedPropName = systemValidationsKeysMap[prop.name];
+              if (mappedPropName) {
+                let value = prop.value ? prop.value.split(',') : [];
+                if (mappedPropName === 'allowedContentTypes') {
+                  const datasource = dropTargetsLookup[itemManagerId] as ComponentsDatasource;
+                  validations.allowedEmbeddedContentTypes = validations.allowedEmbeddedContentTypes ?? {
+                    id: 'allowedEmbeddedContentTypes',
+                    level: 'required',
+                    value: []
                   };
+                  validations.allowedSharedContentTypes = validations.allowedSharedContentTypes ?? {
+                    id: 'allowedSharedContentTypes',
+                    level: 'required',
+                    value: []
+                  };
+                  datasource.allowEmbedded &&
+                    (validations.allowedEmbeddedContentTypes.value =
+                      validations.allowedEmbeddedContentTypes.value.concat(value));
+                  datasource.allowShared &&
+                    (validations.allowedSharedContentTypes.value =
+                      validations.allowedSharedContentTypes.value.concat(value));
+                  // If there is more than one Components DS on this type, make sure they don't override each other as they get parsed
+                  if (validations[mappedPropName]) {
+                    value = validations[mappedPropName].value.concat(value);
+                  }
                 }
-              });
-            }
+                validations[mappedPropName] = {
+                  id: mappedPropName,
+                  value,
+                  level: 'required'
+                };
+              }
+            });
           });
       } else if (systemValidationsNames.includes(key) && !isBlank(map[key]?.value)) {
         validations[systemValidationsKeysMap[key]] = {
@@ -181,19 +205,17 @@ function getFieldDataSourceValidations(
     validations = asArray<LegacyFormDefinitionProperty>(fieldProperty).reduce<LookupTable<ContentTypeFieldValidation>>(
       (table, prop) => {
         if (prop.name === 'imageManager' || prop.name === 'videoManager') {
-          const dataSourcesNames = prop.value !== '' ? prop.value.split(',') : null;
-          if (dataSourcesNames) {
-            dataSourcesNames.forEach((name) => {
-              const dataSource = dataSources.find((datasource) => datasource.id === name);
-              if (dataSource && systemValidationsNames.includes(camelize(dataSource.type))) {
-                table[systemValidationsKeysMap[camelize(dataSource.type)]] = {
-                  id: systemValidationsKeysMap[camelize(dataSource.type)],
-                  value: asArray(dataSource.properties.property).find((prop) => prop.name === 'repoPath').value,
-                  level: 'required'
-                };
-              }
-            });
-          }
+          const dataSourcesIds = prop.value.trim() !== '' ? prop.value.split(',') : null;
+          dataSourcesIds?.forEach((id) => {
+            const dataSource = dataSources.find((datasource) => datasource.id === id);
+            if (dataSource && systemValidationsNames.includes(camelize(dataSource.type))) {
+              table[systemValidationsKeysMap[camelize(dataSource.type)]] = {
+                id: systemValidationsKeysMap[camelize(dataSource.type)],
+                value: asArray(dataSource.properties.property).find((prop) => prop.name === 'repoPath').value,
+                level: 'required'
+              };
+            }
+          });
         }
         return table;
       },
@@ -336,6 +358,24 @@ function parseLegacyFormDefinition(definition: LegacyFormDefinition): Partial<Co
 
   // get receptacles dataSources
   asArray(definition.datasources?.datasource).forEach((datasource: LegacyDataSource) => {
+    // TODO: Delete datasource.properties after props have been added to the root object? Most update code usages of datasource.properties.
+    const properties = asArray(datasource.properties?.property);
+    properties.forEach((property) => {
+      let value: any = property.value;
+      switch (property.type) {
+        case 'boolean':
+          value = property.value.trim().toLowerCase() === 'true';
+          break;
+        case 'int':
+          value = parseInt(property.value);
+          if (isNaN(value)) value = 0;
+        // TODO: There's more `types`. Review getSupportedProperties across different datasources.
+        // case 'minMax':
+        //   value =
+        //   break;
+      }
+      datasource[property.name] = value;
+    });
     if (datasource.type === 'components') dropTargetsLookup[datasource.id] = datasource;
     dataSources[datasource.id] = datasource;
   });

--- a/ui/app/src/state/actions/preview.ts
+++ b/ui/app/src/state/actions/preview.ts
@@ -54,6 +54,8 @@ export const guestCheckIn = /*#__PURE__*/ createAction<{
   path: string;
   site: string;
   documentDomain?: string;
+  // TODO:
+  // version: string;
 }>('GUEST_CHECK_IN');
 export const guestCheckOut = /*#__PURE__*/ createAction<{ path: string }>('GUEST_CHECK_OUT');
 export const fetchGuestModel = /*#__PURE__*/ createAction('FETCH_GUEST_MODEL');
@@ -68,17 +70,17 @@ export const sortItemOperationComplete = /*#__PURE__*/ createAction<{ index: str
   'SORT_ITEM_OPERATION_COMPLETE'
 );
 export const sortItemOperationFailed = /*#__PURE__*/ createAction('SORT_ITEM_OPERATION_FAILED');
-export const insertComponentOperation = /*#__PURE__*/ createAction<
-  {
-    targetIndex: string | number;
-    contentType: ContentType;
-    instance: InstanceRecord;
-    shared: boolean;
-  } & CommonOperationProps
->('INSERT_COMPONENT_OPERATION');
-export const insertInstanceOperation = /*#__PURE__*/ createAction<
-  { targetIndex: string | number; instance: InstanceRecord } & CommonOperationProps
->('INSERT_INSTANCE_OPERATION');
+
+export interface InsertComponentOperationPayload extends CommonOperationProps {
+  targetIndex: string | number;
+  instance: ContentInstance;
+  shared: boolean;
+  create: boolean;
+}
+
+export const insertComponentOperation =
+  /*#__PURE__*/ createAction<InsertComponentOperationPayload>('INSERT_COMPONENT_OPERATION');
+
 export const insertOperationComplete = /*#__PURE__*/ createAction<
   {
     currentFullUrl: string;

--- a/ui/app/src/utils/content.ts
+++ b/ui/app/src/utils/content.ts
@@ -1009,3 +1009,11 @@ export const openItemEditor = (
     );
   }
 };
+
+export function generateComponentBasePath(contentType: string) {
+  return `/site/components/${contentType.replace('/component/', '')}s/`.replace(/\/{1,}$/m, '');
+}
+
+export function generateComponentPath(modelId: string, contentType: string) {
+  return `${generateComponentBasePath(contentType)}/${modelId}.xml`;
+}

--- a/ui/app/src/utils/xml.ts
+++ b/ui/app/src/utils/xml.ts
@@ -30,10 +30,6 @@ export function serialize(doc: Node, options?: { format: boolean }): string {
   return options.format ? beautify(content, { printWidth: +Infinity }) : content;
 }
 
-export function minify(xml: string) {
-  throw new Error('minify error is not implemented.');
-}
-
 interface BeautifyOptions {
   tabWidth: number;
   printWidth: number;
@@ -166,10 +162,10 @@ export function wrapElementInAuxDocument(element: Element): XMLDocument {
   return fromString(`<?xml version="1.0" encoding="UTF-8"?>${element.outerHTML}`);
 }
 
-export function newXMLDocument(): XMLDocument {
+export function newXMLDocument(rootTagName = 'root'): XMLDocument {
   // With the document.implementation.createDocument, new elements then inserted into the xml document
   // end up with an undesirable namespace and serialization looses the case, so sticking with creating from string.
-  return fromString(`<?xml version="1.0" encoding="UTF-8"?><root />`);
+  return fromString(`<?xml version="1.0" encoding="UTF-8"?><${rootTagName} />`);
 }
 
 export function createElement(tagName: string): Element;
@@ -190,7 +186,6 @@ export function deserialize(xml: string | Node, options?: X2jOptionsOptional): a
     ignoreDeclaration: true,
     ...options
   });
-
   if (typeof xml !== 'string') {
     xml = serialize(xml);
   }

--- a/ui/guest/src/models/Operations.ts
+++ b/ui/guest/src/models/Operations.ts
@@ -16,8 +16,7 @@
 
 export interface Operation {
   type: string;
-  args: any;
+  payload: any;
   state?: object;
-
   [id: string]: any;
 }

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -509,7 +509,6 @@ const reducer = createReducer(initialState, {
         validationsLookup
       );
       const highlighted = getHighlighted(dropZones);
-
       return {
         ...state,
         highlighted,
@@ -542,7 +541,9 @@ const reducer = createReducer(initialState, {
         (record: ICERecord, hierarchyMap: ModelHierarchyMap) => {
           const instanceId = instance.craftercms.id;
           return hierarchyMap[record.modelId]?.children.includes(instanceId);
-        }
+        },
+        // This action type ensures we're working with 'shared' components
+        'shared'
       );
       const validationsLookup = iceRegistry.runDropTargetsValidations(dropTargets);
       const { players, siblings, containers, dropZones } = getDragContextFromDropTargets(


### PR DESCRIPTION
Support multiple "components" datasource on the same item selector
Fix datasource baseRepoPath not used to create content on the configured location
Update operations subject emitted actions to use redux actions to benefit from its typechecking
Consolidate insertComponent and insertInstance operations: cleanup & remove code duplicity
Add ICERegistry helpers to check for acceptance of a specific storage format (embedded, shared)

craftercms/craftercms#5940