### PR TITLE
Stability updates

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-type-propsheet/range.js
+++ b/static-assets/components/cstudio-admin/mods/content-type-propsheet/range.js
@@ -113,7 +113,10 @@ YAHOO.extend(
       YAHOO.util.Event.on(switchCtrl, 'click', switchFn, switchCtrl);
 
       // Update the model with the same value but with the correct format ( see valueToJsonString )
-      updateFn(null, { fieldName: this.fieldName, value: this.valueToJsonString(this.fieldValue) });
+      const newValue = this.valueToJsonString(this.fieldValue);
+      if (value !== newValue) {
+        updateFn(null, { fieldName: this.fieldName, value: newValue });
+      }
     },
 
     createControl: function (label, updateFn) {

--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -2696,7 +2696,7 @@
 
           var updatePropertyFn = function (name, value) {
             for (var l = item.properties.length - 1; l >= 0; l--) {
-              if (item.properties[l].name === name) {
+              if (item.properties[l].name === name && item.properties[l].value !== value) {
                 onSetDirty(true);
                 item.properties[l].value =
                   typeof value == 'object' && !Array.isArray(value) ? JSON.stringify(value) : value;

--- a/ui/app/src/components/CreateSiteDialog/GitForm.tsx
+++ b/ui/app/src/components/CreateSiteDialog/GitForm.tsx
@@ -176,7 +176,12 @@ function GitForm(props: GitFormProps) {
       </Grid>
       <Grid item xs={12}>
         <div className={classes.formControl}>
-          <GitAuthForm inputs={inputs} setInputs={setInputs} handleInputChange={handleInputChange} />
+          <GitAuthForm
+            inputs={inputs}
+            setInputs={setInputs}
+            handleInputChange={handleInputChange}
+            onKeyPress={onKeyPress}
+          />
         </div>
       </Grid>
       <Grid item xs={12} sx={{ mb: 2 }}>

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -42,23 +42,34 @@ export function initTinyMCE(
   const { field, model } = iceRegistry.getReferentialEntries(record.iceIds[0]);
   const type = field?.type;
   const inlineElsRegex =
-    /B|BIG|I|SMALL|TT|ABBR|ACRINYM|CITE|CODE|DFN|EM|KBD|STRONG|SAMP|VAR|A|BDO|BR|IMG|MAP|OBJECT|Q|SCRIPT|SPAN|SUB|SUP|BUTTON|INPUT|LABEL|SELECT|TEXTAREA/;
+    /^B$|^BIG$|^I$|^SMALL$|^TT$|^ABBR$|^ACRINYM$|^CITE$|^CODE$|^DFN$|^EM$|^KBD$|^STRONG$|^SAMP$|^VAR$|^A$|^BDO$|^BR$|^IMG$|^MAP$|^OBJECT$|^Q$|^SCRIPT$|^SPAN$|^SUB$|^SUP$|^BUTTON$|^INPUT$|^LABEL$|^SELECT$|^TEXTAREA$/;
   let rteEl = record.element;
   const isRecordElInline = record.element.tagName.match(inlineElsRegex);
 
   // If record element is of type inline (doesn't matter the display prop), replace it with a block element (div).
   if (isRecordElInline) {
+    const recordEl = record.element;
     const blockEl = document.createElement('div');
-    blockEl.innerHTML = record.element.innerHTML;
+    blockEl.innerHTML = recordEl.innerHTML;
+
+    // Copy original element inline styles (copying all styles causes issues with XB styles because they end up all
+    // being inline styles).
+    const inlineStyles = recordEl.style;
+    blockEl.style.cssText = Array.from(inlineStyles).reduce((str, property) => {
+      return `${str}${property}:${inlineStyles.getPropertyValue(property)};`;
+    }, '');
+
+    // Copy original element className
+    blockEl.className = recordEl.className;
     blockEl.style.display = 'inline-block';
 
-    blockEl.style.minHeight = record.element.offsetHeight + 'px';
+    blockEl.style.minHeight = recordEl.offsetHeight + 'px';
     blockEl.style.minWidth = '10px';
     rteEl = blockEl;
 
     // Hide original element
-    record.element.style.display = 'none';
-    record.element.parentNode.insertBefore(rteEl, record.element);
+    recordEl.style.display = 'none';
+    recordEl.parentNode.insertBefore(rteEl, recordEl);
   }
 
   const openEditForm = () => {

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -47,6 +47,8 @@ export function initTinyMCE(
   const isRecordElInline = record.element.tagName.match(inlineElsRegex);
 
   // If record element is of type inline (doesn't matter the display prop), replace it with a block element (div).
+  // This is because of an issue happening with inline elements (for example a span tag even with 'display: block' style
+  // was still causing an issue, and also for example a div element with 'display: inline' doesn't present the issue).
   if (isRecordElInline) {
     const recordEl = record.element;
     const blockEl = document.createElement('div');

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -42,20 +42,25 @@ export function initTinyMCE(
   const { field, model } = iceRegistry.getReferentialEntries(record.iceIds[0]);
   const type = field?.type;
   const inlineElsRegex =
-    /^B$|^BIG$|^I$|^SMALL$|^TT$|^ABBR$|^ACRINYM$|^CITE$|^CODE$|^DFN$|^EM$|^KBD$|^STRONG$|^SAMP$|^VAR$|^A$|^BDO$|^BR$|^IMG$|^MAP$|^OBJECT$|^Q$|^SCRIPT$|^SPAN$|^SUB$|^SUP$|^BUTTON$|^INPUT$|^LABEL$|^SELECT$|^TEXTAREA$/;
+    /^(B|BIG|I|SMALL|TT|ABBR|ACRINYM|CITE|CODE|DFN|EM|KBD|STRONG|SAMP|VAR|A|BDO|BR|IMG|MAP|OBJECT|Q|SCRIPT|SPAN|SUB|SUP|BUTTON|INPUT|LABEL|SELECT|TEXTAREA)$/;
   let rteEl = record.element;
   const isRecordElInline = record.element.tagName.match(inlineElsRegex);
 
   // If record element is of type inline (doesn't matter the display prop), replace it with a block element (div).
   // This is because of an issue happening with inline elements (for example a span tag even with 'display: block' style
   // was still causing an issue, and also for example a div element with 'display: inline' doesn't present the issue).
+  // https://github.com/craftercms/craftercms/issues/5212
   if (isRecordElInline) {
     const recordEl = record.element;
     const blockEl = document.createElement('div');
     blockEl.innerHTML = recordEl.innerHTML;
 
-    // Copy original element inline styles (copying all styles causes issues with XB styles because they end up all
-    // being inline styles).
+    /*
+     * Get and copy only the inline styles (from the 'style' prop) of the element. If we want to retrieve all the styles
+     * (inline styles and styles applied from css files, etc.) we would use `window.getComputedStyle(element)`, but
+     * that may cause an issue because all the styles would become inline styles and have higher precedence than other
+     * styles (for example styles applied by XB).
+     * */
     const inlineStyles = recordEl.style;
     blockEl.style.cssText = Array.from(inlineStyles).reduce((str, property) => {
       return `${str}${property}:${inlineStyles.getPropertyValue(property)};`;


### PR DESCRIPTION
- Fix - pressing enter key on token form of create site dialog doesn’t progress the dialog
- Fix - open content type, without having modified anything, click on an image-picker control, “Close” button becomes “Cancel”, pressing cancel shows “Content Type has been modified, are you sure you want to discard your changes?” despite not changing anything. 
- Fix - In XB when an RTE is initialised, it creates a clone element that doesn’t keep the original’s classes which breaks styles (e.g. above bp, try to edit the marquees). research maintaining styles and scroll position which in a really long RTE content, it scrolls you up to the top of that rte.