### PR TITLE
[4502] Item retrieval APIs (item_by*, children_by*) return systemType 'unknown' for config files

### DIFF
--- a/ui/app/src/components/ItemTypeIcon/ItemTypeIcon.tsx
+++ b/ui/app/src/components/ItemTypeIcon/ItemTypeIcon.tsx
@@ -33,6 +33,7 @@ import FontIcon from '@mui/icons-material/FontDownloadOutlined';
 import TextIcon from '@mui/icons-material/SubjectRounded';
 import FolderIcon from '@mui/icons-material/FolderOpenRounded';
 import TaxonomyIcon from '@mui/icons-material/LocalOfferOutlined';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import { DetailedItem, SandboxItem } from '../../models/Item';
 import { IntlFormatters, useIntl } from 'react-intl';
 import { messages } from './translations';
@@ -58,6 +59,7 @@ export function ItemTypeIcon(props: ItemTypeIconProps) {
   switch (item.systemType) {
     case 'file':
     case 'asset':
+    case 'content type':
       if (item.mimeType.includes('image/')) {
         TheIcon = ImageIcon;
       } else if (item.mimeType.includes('video/')) {
@@ -127,6 +129,9 @@ export function ItemTypeIcon(props: ItemTypeIconProps) {
       break;
     case 'taxonomy':
       TheIcon = TaxonomyIcon;
+      break;
+    case 'configuration':
+      TheIcon = SettingsOutlinedIcon;
       break;
   }
   return (

--- a/ui/app/src/components/ItemTypeIcon/translations.tsx
+++ b/ui/app/src/components/ItemTypeIcon/translations.tsx
@@ -49,6 +49,9 @@ export const messages = defineMessages({
     id: 'systemType.taxonomy',
     defaultMessage: 'Taxonomy'
   },
+  configuration: {
+    defaultMessage: 'Configuration'
+  },
   unknown: {
     id: 'words.unknown',
     defaultMessage: 'Unknown'

--- a/ui/app/src/models/SystemType.ts
+++ b/ui/app/src/models/SystemType.ts
@@ -25,7 +25,8 @@ export type SystemType =
   | 'page'
   | 'renderingTemplate'
   | 'script'
-  | 'taxonomy';
+  | 'taxonomy'
+  | 'configuration';
 
 export type FilterSystemTypeGroups = 'all' | 'item' | 'asset' | 'contentType' | 'template' | 'script' | 'other';
 


### PR DESCRIPTION
- Update types and icons for config and content type files 

https://github.com/craftercms/craftercms/issues/4502