### PR TITLE
[6288][4.0.x] File-name control is removing the first char when renaming pages.

### DIFF
--- a/static-assets/components/cstudio-forms/controls/file-name.js
+++ b/static-assets/components/cstudio-forms/controls/file-name.js
@@ -542,8 +542,9 @@ YAHOO.extend(CStudioForms.Controls.FileName, CStudioForms.CStudioFormField, {
         if (path == '') {
           path = '/';
         }
-
-        value = value.substring(1);
+        if (value.startsWith('/')) {
+          value = value.substring(1);
+        }
       } else {
         value = path.substring(path.lastIndexOf('/') + 1).replace('.xml', '');
       }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6288