### PR TITLE
[stability] Disable backdrop click and escape keydown in ConfirmDialog

### DIFF
--- a/ui/app/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/ui/app/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -27,6 +27,8 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
   const { formatMessage } = useIntl();
   return (
     <AlertDialog
+      disableBackdropClick
+      disableEscapeKeyDown
       {...rest}
       buttons={
         <>


### PR DESCRIPTION
disable backdrop click and escape keydown in ConfirmDialog