### PR TITLE
[6368][4.2.x] Form Engine cuts off calendar when Date Time is the only control

### DIFF
--- a/static-assets/components/cstudio-forms/controls/date-time.js
+++ b/static-assets/components/cstudio-forms/controls/date-time.js
@@ -1155,6 +1155,8 @@ YAHOO.extend(CStudioForms.Controls.DateTime, CStudioForms.CStudioFormField, {
           this.show();
           if (calEl.getBoundingClientRect().top < 0) {
             calEl.style.setProperty('top', '0px', 'important');
+          } else {
+            calEl.style.top = null;
           }
         },
         calendarComponent,

--- a/static-assets/components/cstudio-forms/controls/date-time.js
+++ b/static-assets/components/cstudio-forms/controls/date-time.js
@@ -1153,6 +1153,9 @@ YAHOO.extend(CStudioForms.Controls.DateTime, CStudioForms.CStudioFormField, {
         'click',
         function (e) {
           this.show();
+          if (calEl.getBoundingClientRect().top < 0) {
+            calEl.style.setProperty('top', '0px', 'important');
+          }
         },
         calendarComponent,
         true


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6368