### PR TITLE
[6368][4.1.x] Form Engine cuts off calendar when Date Time is the only control

### DIFF
--- a/static-assets/components/cstudio-forms/controls/date-time.js
+++ b/static-assets/components/cstudio-forms/controls/date-time.js
@@ -1153,6 +1153,11 @@ YAHOO.extend(CStudioForms.Controls.DateTime, CStudioForms.CStudioFormField, {
         'click',
         function (e) {
           this.show();
+          if (calEl.getBoundingClientRect().top < 0) {
+            calEl.style.setProperty('top', '0px', 'important');
+          } else {
+            calEl.style.top = null;
+          }
         },
         calendarComponent,
         true


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6368