### PR TITLE
[4.1.x][6491] Deleting all children of an expanded folder and then uploading an item, will set the folder into loading state

### DIFF
--- a/ui/app/src/state/reducers/pathNavigatorTree.ts
+++ b/ui/app/src/state/reducers/pathNavigatorTree.ts
@@ -162,7 +162,7 @@ export function deleteItemFromState(tree: PathNavigatorTreeStateProps, targetPat
   tree.expanded = tree.expanded.filter(
     // If the parent is left without children, remove from expanded too.
     totalByPath[parentPath] === 0
-      ? (expandedPath) => expandedPath !== targetPath || expandedPath !== parentPath
+      ? (expandedPath) => expandedPath !== targetPath && expandedPath !== parentPath
       : (expandedPath) => expandedPath !== targetPath
   );
 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6491