### PR TITLE
[4.1.x][6491] Avoid expanding items without children in PathNavTree

### DIFF
--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -243,12 +243,15 @@ export function PathNavigatorTree(props: PathNavigatorTreeProps) {
     if (state.expanded.includes(path)) {
       dispatch(pathNavigatorTreeCollapsePath({ id, path }));
     } else {
+      const childrenCount = itemsByPath[path].childrenCount;
       // If the item's children have been loaded, should simply be expanded
-      if (childrenByParentPath[path]) {
-        dispatch(pathNavigatorTreeExpandPath({ id, path }));
-      } else {
-        // Children not fetched yet, should be fetched
-        dispatch(pathNavigatorTreeFetchPathChildren({ id, path }));
+      if (childrenCount) {
+        if (childrenByParentPath[path]) {
+          dispatch(pathNavigatorTreeExpandPath({ id, path }));
+        } else {
+          // Children not fetched yet, should be fetched
+          dispatch(pathNavigatorTreeFetchPathChildren({ id, path }));
+        }
       }
     }
   };

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -244,8 +244,8 @@ export function PathNavigatorTree(props: PathNavigatorTreeProps) {
       dispatch(pathNavigatorTreeCollapsePath({ id, path }));
     } else {
       const childrenCount = itemsByPath[path].childrenCount;
-      // If the item's children have been loaded, should simply be expanded
       if (childrenCount) {
+        // If the item's children have been loaded, should simply be expanded
         if (childrenByParentPath[path]) {
           dispatch(pathNavigatorTreeExpandPath({ id, path }));
         } else {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6491