### PR TITLE
[6491] Avoid expanding items without children in PathNavTree

### DIFF
--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -243,12 +243,15 @@ export function PathNavigatorTree(props: PathNavigatorTreeProps) {
     if (state.expanded.includes(path)) {
       dispatch(pathNavigatorTreeCollapsePath({ id, path }));
     } else {
-      // If the item's children have been loaded, should simply be expanded
-      if (childrenByParentPath[path]) {
-        dispatch(pathNavigatorTreeExpandPath({ id, path }));
-      } else {
-        // Children not fetched yet, should be fetched
-        dispatch(pathNavigatorTreeFetchPathChildren({ id, path }));
+      const childrenCount = itemsByPath[path].childrenCount;
+      if (childrenCount) {
+        // If the item's children have been loaded, should simply be expanded
+        if (childrenByParentPath[path]) {
+          dispatch(pathNavigatorTreeExpandPath({ id, path }));
+        } else {
+          // Children not fetched yet, should be fetched
+          dispatch(pathNavigatorTreeFetchPathChildren({ id, path }));
+        }
       }
     }
   };


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6491