### PR TITLE
[6578] Sending full path to write configuration service writes the file in a nested location

### DIFF
--- a/ui/app/src/components/CodeEditorDialog/CodeEditorDialogContainer.tsx
+++ b/ui/app/src/components/CodeEditorDialog/CodeEditorDialogContainer.tsx
@@ -96,7 +96,7 @@ export function CodeEditorDialogContainer(props: CodeEditorDialogContainerProps)
       const isConfig = path.startsWith('/config');
       const module = isConfig ? (path.split('/')[2] as 'studio') : null;
       const service$ = isConfig
-        ? writeConfiguration(site, path, module, value)
+        ? writeConfiguration(site, path.replace(`/config/${module}`, ''), module, value)
         : writeContent(site, path, value, { unlock: false });
       service$.subscribe({
         next() {

--- a/ui/app/src/services/configuration.ts
+++ b/ui/app/src/services/configuration.ts
@@ -76,9 +76,17 @@ export function fetchConfigurationJSON(
   );
 }
 
+/**
+ * Persists the content of a configuration file.
+ * @param site {string} The site id from which to fetch the configuration from.
+ * @param partialPath {string} The path *inside the module*, excluding root (/config) and module (/studio|engine). If full path is `/config/studio/ui.xml`, partial path `/ui.xml`.
+ * @param module {engine | studio} The module that owns this configuration file.
+ * @param content {string} The content to write.
+ * @param environment {string} Optional environment to write to.
+ **/
 export function writeConfiguration(
   site: string,
-  path: string,
+  partialPath: string,
   module: CrafterCMSModules,
   content: string,
   environment?: string
@@ -86,7 +94,7 @@ export function writeConfiguration(
   return postJSON('/studio/api/2/configuration/write_configuration', {
     siteId: site,
     module,
-    path,
+    path: partialPath,
     content,
     ...(environment && { environment })
   }).pipe(map(() => true));


### PR DESCRIPTION
craftercms/craftercms#6578

e.g. sending `/config/studio/content-types/page/article/config.xml` writes to `/config/studio/config/studio/content-types/page/article/config.xml`