### PR TITLE
[6589] Swap the item lookup preference to prioritise index.xml over folder

### DIFF
--- a/ui/app/src/utils/content.ts
+++ b/ui/app/src/utils/content.ts
@@ -934,7 +934,7 @@ export const createItemActionMap: (availableActions: number) => ItemActionsMap =
 });
 
 export function lookupItemByPath<T = DetailedItem>(path: string, lookupTable: LookupTable<T>): T {
-  return lookupTable[withoutIndex(path)] ?? lookupTable[withIndex(path)];
+  return lookupTable[withIndex(path)] ?? lookupTable[withoutIndex(path)];
 }
 
 export function modelsToLookup(models: ContentInstance[]): LookupTable<ContentInstance> {


### PR DESCRIPTION
craftercms/craftercms#6589

At times, the UI needs to select between a page's _folder_ vs its `index.xml`. We've been defaulting to picking the folder over the index, in case they are both present. Don't have context as the reason it was first implemented this way, it might have been _simply done_ this way. It feels like it makes sense to pick the index over the folder overall, but this bug is a bias. Any thoughts?

Note for testers: This PR changes a util used across the UI. Its impact spans all navigators, create folder dialog, quick create, the item selector that's in several places (e.g. opening the navigator from the preview address bar), and other various places.