### PR TITLE
[6571] Remove logical resource from WorkflowCancellationDialog, update component for it to show empty state if no items

### DIFF
--- a/ui/app/src/CHANGELOG.md
+++ b/ui/app/src/CHANGELOG.md
@@ -14,6 +14,7 @@
     * `LegacyRecentActivityDashlet`
     * `LegacyRecentlyPublishedDashlet`
     * `LegacyUnpublishedDashlet`
+  * `WorkflowCancellationDialogUI`: prop `items` type changed from an async Resource to sync SandboxItem array.
 * [services] Removed services associated with v1 APIs:
   * `fetchLegacyGetGoLiveItems`
   * `fetchLegacyUserActivities`

--- a/ui/app/src/components/WorkflowCancellationDialog/WorkflowCancellationDialogContainer.tsx
+++ b/ui/app/src/components/WorkflowCancellationDialog/WorkflowCancellationDialogContainer.tsx
@@ -15,12 +15,11 @@
  */
 
 import { makeStyles } from 'tss-react/mui';
-import { useLogicResource } from '../../hooks/useLogicResource';
-import { SuspenseWithEmptyState } from '../Suspencified/Suspencified';
 import { FormattedMessage } from 'react-intl';
 import { WorkflowCancellationDialogUI } from './WorkflowCancellationDialogUI';
 import React from 'react';
-import { Return, Source, WorkflowCancellationDialogContainerProps } from './utils';
+import { WorkflowCancellationDialogContainerProps } from './utils';
+import { EmptyState } from '../EmptyState';
 
 const useStyles = makeStyles()((theme) => ({
   suspense: {
@@ -37,48 +36,23 @@ const useStyles = makeStyles()((theme) => ({
 }));
 
 export function WorkflowCancellationDialogContainer(props: WorkflowCancellationDialogContainerProps) {
-  const { items, onClose, onContinue } = props;
+  const { items = [], onClose, onContinue } = props;
   const { classes } = useStyles();
-
-  const resource = useLogicResource<Return, Source>(items, {
-    shouldResolve: (source) => Boolean(source),
-    shouldReject: (source) => false,
-    shouldRenew: (source, resource) => resource.complete,
-    resultSelector: (source) => source,
-    errorSelector: (source) => null
-  });
 
   const onContinueClick = (e) => {
     onClose(e, null);
     onContinue();
   };
 
-  return (
-    <SuspenseWithEmptyState
-      resource={resource}
-      withEmptyStateProps={{
-        emptyStateProps: {
-          title: (
-            <FormattedMessage
-              id="workflowCancellationDialog.noAffectedFiles"
-              defaultMessage="There are no affected files"
-            />
-          )
-        }
-      }}
-      loadingStateProps={{
-        classes: {
-          root: classes.suspense
-        }
-      }}
-    >
-      <WorkflowCancellationDialogUI
-        resource={resource}
-        onCloseButtonClick={(e) => onClose(e, null)}
-        onContinue={onContinueClick}
-        classes={classes}
-      />
-    </SuspenseWithEmptyState>
+  return items.length > 0 ? (
+    <WorkflowCancellationDialogUI
+      items={items}
+      onCloseButtonClick={(e) => onClose(e, null)}
+      onContinue={onContinueClick}
+      classes={classes}
+    />
+  ) : (
+    <EmptyState title={<FormattedMessage defaultMessage="No items." />} />
   );
 }
 

--- a/ui/app/src/components/WorkflowCancellationDialog/WorkflowCancellationDialogContainer.tsx
+++ b/ui/app/src/components/WorkflowCancellationDialog/WorkflowCancellationDialogContainer.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles()((theme) => ({
 }));
 
 export function WorkflowCancellationDialogContainer(props: WorkflowCancellationDialogContainerProps) {
-  const { items = [], onClose, onContinue } = props;
+  const { items, onClose, onContinue } = props;
   const { classes } = useStyles();
 
   const onContinueClick = (e) => {
@@ -44,22 +44,26 @@ export function WorkflowCancellationDialogContainer(props: WorkflowCancellationD
     onContinue();
   };
 
-  return items.length > 0 ? (
-    <WorkflowCancellationDialogUI
-      items={items}
-      onCloseButtonClick={(e) => onClose(e, null)}
-      onContinue={onContinueClick}
-      classes={classes}
-    />
+  return items ? (
+    items.length > 0 ? (
+      <WorkflowCancellationDialogUI
+        items={items}
+        onCloseButtonClick={(e) => onClose(e, null)}
+        onContinue={onContinueClick}
+        classes={classes}
+      />
+    ) : (
+      <EmptyState
+        title={
+          <FormattedMessage
+            id="workflowCancellationDialog.noAffectedFiles"
+            defaultMessage="There are no affected files"
+          />
+        }
+      />
+    )
   ) : (
-    <EmptyState
-      title={
-        <FormattedMessage
-          id="workflowCancellationDialog.noAffectedFiles"
-          defaultMessage="There are no affected files"
-        />
-      }
-    />
+    <EmptyState title={<FormattedMessage defaultMessage="No items were provided as input" />} />
   );
 }
 

--- a/ui/app/src/components/WorkflowCancellationDialog/WorkflowCancellationDialogContainer.tsx
+++ b/ui/app/src/components/WorkflowCancellationDialog/WorkflowCancellationDialogContainer.tsx
@@ -52,7 +52,14 @@ export function WorkflowCancellationDialogContainer(props: WorkflowCancellationD
       classes={classes}
     />
   ) : (
-    <EmptyState title={<FormattedMessage defaultMessage="No items." />} />
+    <EmptyState
+      title={
+        <FormattedMessage
+          id="workflowCancellationDialog.noAffectedFiles"
+          defaultMessage="There are no affected files"
+        />
+      }
+    />
   );
 }
 

--- a/ui/app/src/components/WorkflowCancellationDialog/WorkflowCancellationDialogUI.tsx
+++ b/ui/app/src/components/WorkflowCancellationDialog/WorkflowCancellationDialogUI.tsx
@@ -27,8 +27,7 @@ import React from 'react';
 import { WorkflowCancellationDialogUIProps } from './utils';
 
 export function WorkflowCancellationDialogUI(props: WorkflowCancellationDialogUIProps) {
-  const { resource, onCloseButtonClick, onContinue, classes } = props;
-  const items = resource.read();
+  const { items, onCloseButtonClick, onContinue, classes } = props;
   return (
     <>
       <DialogBody>

--- a/ui/app/src/components/WorkflowCancellationDialog/utils.ts
+++ b/ui/app/src/components/WorkflowCancellationDialog/utils.ts
@@ -16,7 +16,6 @@
 
 import { SandboxItem } from '../../models/Item';
 import StandardAction from '../../models/StandardAction';
-import { Resource } from '../../models/Resource';
 import React from 'react';
 import { EnhancedDialogProps } from '../EnhancedDialog';
 import { EnhancedDialogState } from '../../hooks/useEnhancedDialogState';
@@ -25,7 +24,7 @@ export type Source = SandboxItem[];
 export type Return = Omit<Source, 'error'>;
 
 export interface WorkflowCancellationDialogUIProps {
-  resource: Resource<Return>;
+  items: Return;
   classes?: any;
   onCloseButtonClick?(e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void;
   onContinue?(response): void;

--- a/ui/app/src/components/WorkflowCancellationDialog/utils.ts
+++ b/ui/app/src/components/WorkflowCancellationDialog/utils.ts
@@ -20,11 +20,8 @@ import React from 'react';
 import { EnhancedDialogProps } from '../EnhancedDialog';
 import { EnhancedDialogState } from '../../hooks/useEnhancedDialogState';
 
-export type Source = SandboxItem[];
-export type Return = Omit<Source, 'error'>;
-
 export interface WorkflowCancellationDialogUIProps {
-  items: Return;
+  items: SandboxItem[];
   classes?: any;
   onCloseButtonClick?(e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void;
   onContinue?(response): void;


### PR DESCRIPTION
- Remove logical resource from WorkflowCancellationDialog, update component for it to show empty state if no items

https://github.com/craftercms/craftercms/issues/6571