### PR TITLE
[4.1.x/6635] Fix path instead of previewUrl being used to insert links on RTE "Insert > Link" feature

### DIFF
--- a/static-assets/components/cstudio-forms/controls/rte.js
+++ b/static-assets/components/cstudio-forms/controls/rte.js
@@ -711,7 +711,12 @@ CStudioAuthoring.Module.requireModule(
           if (datasource && datasource.add) {
             datasource.add(
               {
+                // Search backend doesn't populate `previewUrl` so we're computing the previewUrl in the callback.
+                // returnProp: 'previewUrl',
                 insertItem: function (fileData) {
+                  if (typeof fileData === 'string') {
+                    fileData = craftercms.utils.path.getPreviewURLFromPath(fileData);
+                  }
                   cb(fileData, {});
                 },
                 failure: function (message) {

--- a/ui/app/src/utils/path.ts
+++ b/ui/app/src/utils/path.ts
@@ -48,8 +48,20 @@ export function getPathFromPreviewURL(previewURL: string): string {
   return `/site/website${pagePath}`;
 }
 
+/**
+ * Computes and returns the preview URL from a path. Notice non-previewable paths will not be transformed.
+ * @param path {string} The path to compute the preview URL from
+ * @returns {string} The preview URL
+ */
 export function getPreviewURLFromPath(path: string): string {
-  return withoutIndex(path).replace('/site/website', '') || '/';
+  // Transform only paths that start with `/site/website`. Preview url and path for static assets is the same.
+  // Non-previewable paths are not transformed by this function.
+  // It is known that for some existing platform users, paths do not end with `/index.xml`. For example in
+  // `/site/website/folder/article.xml` previewUrl should be `/folder/article`. In these cases, the file
+  // name cannot be striped off.
+  return /^\/site\/website/.test(path)
+    ? path.replace(/^\/site\/website|\/(index|default).xml$|.xml$/g, '') || '/'
+    : path;
 }
 
 export function getFileNameFromPath(path: string): string {

--- a/ui/app/src/utils/path.ts
+++ b/ui/app/src/utils/path.ts
@@ -60,7 +60,10 @@ export function getPreviewURLFromPath(path: string): string {
   // `/site/website/folder/article.xml` previewUrl should be `/folder/article`. In these cases, the file
   // name cannot be striped off.
   return /^\/site\/website/.test(path)
-    ? path.replace(/^\/site\/website|\/(index|default).xml$|.xml$/g, '') || '/'
+    ? path
+        .replace(/^\/site\/website/, '')
+        .replace(/\/(index|default).xml$/, '')
+        .replace(/(.xml|\/)$/, '') || '/'
     : path;
 }
 


### PR DESCRIPTION
craftercms/craftercms#6635
