### PR TITLE
[4.1.x][6652] Process path for macros when opening search in components datasource

### DIFF
--- a/ui/legacy/src/components/cstudio-forms/data-sources/components.js
+++ b/ui/legacy/src/components/cstudio-forms/data-sources/components.js
@@ -189,7 +189,8 @@
     },
 
     _openSearch: function (control) {
-      const searchPath = craftercms.utils.string.ensureSingleSlash(`${this.baseBrowsePath}/.+`);
+      let searchPath = this._processPathsForMacros(this.baseBrowsePath);
+      searchPath = craftercms.utils.string.ensureSingleSlash(`${searchPath}/.+`);
       const searchContext = {
         path: searchPath,
         searchId: null,


### PR DESCRIPTION
Browse path is being processed for macros when opening the browse option (working correctly). It was failing (not processed) with the search option.

https://github.com/craftercms/craftercms/issues/6652