### PR TITLE
[4.1.x][6643] Node selector datasource configuration results in double slash in path

### DIFF
--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1403,7 +1403,7 @@ var CStudioForms =
               saveDraft = true;
             }
             lastDraft = draft;
-            return entityId;
+            return craftercms.utils.string.ensureSingleSlash(entityId);
           };
 
           //If the form is opened in view mode, we don't need show the warn message or unlock the item


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6643