### PR TITLE
[6707] Validate macros in Content Type form before saving

### DIFF
--- a/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/static-assets/components/cstudio-admin/mods/content-types.js
@@ -2302,7 +2302,8 @@
           function (e, el) {
             const invalidMacros = [
               { regex: /{objectId}/, macro: 'objectId' },
-              { regex: /{parentPath(\[[0-9]+])?}/, macro: 'parentPath' }
+              { regex: /{parentPath(\[.*])?}/, macro: 'parentPath' },
+              { regex: /{objectGroupId(2)?}/, macro: 'objectGroupId' }
             ];
             const newPath = el.value;
             const invalidMacrosInPath = [];

--- a/ui/app/src/components/LegacyFormDialog/EmbeddedLegacyContainer.tsx
+++ b/ui/app/src/components/LegacyFormDialog/EmbeddedLegacyContainer.tsx
@@ -74,7 +74,8 @@ export const EmbeddedLegacyContainer = React.forwardRef(function EmbeddedLegacyE
     onClosed,
     iceGroupId,
     newEmbedded,
-    index
+    index,
+    setIframeLoaded
   } = props;
 
   const { formatMessage } = useIntl();
@@ -178,6 +179,7 @@ export const EmbeddedLegacyContainer = React.forwardRef(function EmbeddedLegacyE
           break;
         }
         case EMBEDDED_LEGACY_FORM_RENDERED: {
+          setIframeLoaded(true);
           if (inProgress) {
             dispatch(updateEditDialogConfig({ inProgress: false }));
           }
@@ -257,7 +259,7 @@ export const EmbeddedLegacyContainer = React.forwardRef(function EmbeddedLegacyE
     return () => {
       messagesSubscription.unsubscribe();
     };
-  }, [inProgress, onSave, messages, dispatch, onClose, formatMessage, onMinimize]);
+  }, [inProgress, onSave, messages, dispatch, onClose, formatMessage, onMinimize, setIframeLoaded]);
 
   useUnmount(onClosed);
 

--- a/ui/app/src/components/LegacyFormDialog/LegacyFormDialog.tsx
+++ b/ui/app/src/components/LegacyFormDialog/LegacyFormDialog.tsx
@@ -40,7 +40,7 @@ export function LegacyFormDialog(props: LegacyFormDialogProps) {
   const { open, inProgress, isSubmitting, disableHeader, isMinimized, onMaximize, onMinimize, ...rest } = props;
   const renameContentDialogState = useEnhancedDialogState();
   const [renameContentDialogData, setRenameContentDialogData] = useState(renameContentDialogDataInitialState);
-
+  const [iframeLoaded, setIframeLoaded] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>();
   const messages = fromEvent(window, 'message').pipe(filter((e: any) => e.data && e.data.type));
 
@@ -50,7 +50,7 @@ export function LegacyFormDialog(props: LegacyFormDialogProps) {
     // The form engine is too expensive to load to lose it with an unintentional
     // backdrop click. Disabling backdrop click until form engine 2.
     if ('backdropClick' !== reason && !isSubmitting) {
-      if (inProgress) {
+      if (inProgress || !iframeLoaded) {
         props?.onClose();
       }
       iframeRef.current.contentWindow.postMessage({ type: 'LEGACY_FORM_DIALOG_CANCEL_REQUEST' }, '*');
@@ -112,7 +112,13 @@ export function LegacyFormDialog(props: LegacyFormDialogProps) {
             ]}
           />
         )}
-        <EmbeddedLegacyContainer ref={iframeRef} inProgress={inProgress} onMinimize={onMinimize} {...rest} />
+        <EmbeddedLegacyContainer
+          ref={iframeRef}
+          inProgress={inProgress}
+          onMinimize={onMinimize}
+          setIframeLoaded={setIframeLoaded}
+          {...rest}
+        />
       </Dialog>
       <MinimizedBar open={isMinimized} onMaximize={onMaximize} title={title} />
       <RenameContentDialog

--- a/ui/app/src/components/LegacyFormDialog/utils.ts
+++ b/ui/app/src/components/LegacyFormDialog/utils.ts
@@ -65,4 +65,6 @@ export interface LegacyFormDialogStateProps extends LegacyFormDialogBaseProps {
 
 export interface LegacyFormDialogContainerProps
   extends LegacyFormDialogBaseProps,
-    Pick<LegacyFormDialogProps, 'onMinimize' | 'onClose' | 'onClosed' | 'onSaveSuccess'> {}
+    Pick<LegacyFormDialogProps, 'onMinimize' | 'onClose' | 'onClosed' | 'onSaveSuccess'> {
+  setIframeLoaded(loaded: boolean): void;
+}


### PR DESCRIPTION
- Add `objectGroupId` and `objectGroupId2` to invalid macros in content-type editor
- Fix LegacyFormDialog locked state when there's an error loading th iframe

https://github.com/craftercms/craftercms/issues/6707