### PR TITLE
[4.1.x][6670] Extend Upload dialog: Allow post-upload action - CHANGELOG update

### DIFF
--- a/ui/app/src/CHANGELOG.md
+++ b/ui/app/src/CHANGELOG.md
@@ -6,6 +6,9 @@
 * [common-api.js]
   * `CStudioAuthoring.Utils.showConfirmDialog`: Added function overload to receive a `props` style object as first and only argument. The props argument would contain all ConfirmDialog props. Original set of arguments still supported for backward compatibility.
 
+## 4.1.4
+* `UploadDialog`: Added props `endpoint`, `method`, `headers`, `meta`, `allowedMetaFields`, `useFormData`, `fieldName` and `onFileAdded` for additional control over the upload process.
+
 ## 4.1.3
 
 * HostUI removed and merged into Host


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6670