### PR TITLE
[6670] Extend Upload dialog: Allow post-upload action - CHANGELOG update

### DIFF
--- a/ui/app/src/CHANGELOG.md
+++ b/ui/app/src/CHANGELOG.md
@@ -18,6 +18,7 @@
   * `WorkflowCancellationDialogUI`: prop `items` type changed from an async Resource to sync SandboxItem array.
   * `AuthorFilter` removed, merged with ActivityDashlet
   * `UsersAutocomplete` removed
+  * `UploadDialog`: Added `autoProceed` prop to enable/disable automatic upload after file selection
   * `DropDownMenuButton` component:
     * Internal structure changed so that ListItem wraps the ListItemButton
     * `listItemProps` are routed to the list `ListItem` component instead of the `ListItemButton`
@@ -40,6 +41,9 @@
 ## 4.1.5
 * [common-api.js]
   * `CStudioAuthoring.Utils.showConfirmDialog`: Added function overload to receive a `props` style object as first and only argument. The props argument would contain all ConfirmDialog props. Original set of arguments still supported for backward compatibility.
+
+## 4.1.4
+  * `UploadDialog`: Added props `endpoint`, `method`, `headers`, `meta`, `allowedMetaFields`, `useFormData`, `fieldName` and `onFileAdded` for additional control over the upload process.
 
 ## 4.1.3
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6670