### PR TITLE
[4.1.x][6714] History "Quick Compare" options should always use the same diffing direction

### DIFF
--- a/ui/app/src/components/CompareVersionsDialog/CompareVersionsDialogContainer.tsx
+++ b/ui/app/src/components/CompareVersionsDialog/CompareVersionsDialogContainer.tsx
@@ -101,6 +101,8 @@ export function CompareVersionsDialogContainer(props: CompareVersionsDialogConta
       const selectedADate = new Date(versionsBranch.byId[selected[0]].modifiedDate);
       const selectedBDate = new Date(version.modifiedDate);
 
+      // When comparing versions, we want to show what the new version did to the old. For that, we check for the most
+      // recent version and add it first in the list of versions to compare.
       dispatch(
         compareBothVersions({
           versions:

--- a/ui/app/src/components/CompareVersionsDialog/CompareVersionsDialogContainer.tsx
+++ b/ui/app/src/components/CompareVersionsDialog/CompareVersionsDialogContainer.tsx
@@ -98,7 +98,15 @@ export function CompareVersionsDialogContainer(props: CompareVersionsDialogConta
     if (!selected[0]) {
       dispatch(compareVersion({ id: version.versionNumber }));
     } else if (selected[0] !== version.versionNumber) {
-      dispatch(compareBothVersions({ versions: [selected[0], version.versionNumber] }));
+      const selectedADate = new Date(versionsBranch.byId[selected[0]].modifiedDate);
+      const selectedBDate = new Date(version.modifiedDate);
+
+      dispatch(
+        compareBothVersions({
+          versions:
+            selectedADate > selectedBDate ? [selected[0], version.versionNumber] : [version.versionNumber, selected[0]]
+        })
+      );
     } else {
       dispatch(compareVersion());
     }

--- a/ui/app/src/components/HistoryDialog/HistoryDialogContainer.tsx
+++ b/ui/app/src/components/HistoryDialog/HistoryDialogContainer.tsx
@@ -260,7 +260,7 @@ export function HistoryDialogContainer(props: HistoryDialogContainerProps) {
         break;
       }
       case 'compareToCurrent': {
-        compareBoth([activeItem.versionNumber, current]);
+        compareBoth([current, activeItem.versionNumber]);
         break;
       }
       case 'compareToPrevious': {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6714