### PR TITLE
Roles & Permissions Fixes

### DIFF
--- a/static-assets/components/cstudio-forms/controls/node-selector.js
+++ b/static-assets/components/cstudio-forms/controls/node-selector.js
@@ -330,101 +330,119 @@ YAHOO.extend(CStudioForms.Controls.NodeSelector, CStudioForms.CStudioFormField, 
     }
 
     var items = this.items;
-    const hasLegacyPrefix = items.some((item) => Object.keys(item).filter((key) => key.includes('_mvs')).length > 0);
-    // only if true -> set value - for backward compatibility
-    if (hasLegacyPrefix) {
-      this.useMVS = true;
-    }
+
+    const sharedItems = [];
+    let hasLegacyPrefix = false;
+    items.forEach((item) => {
+      // If it is a path, it is a shared item, otherwise, it will be a guid and it is an embedded item.
+      if (item.key.trim().startsWith('/')) {
+        sharedItems.push(item.key);
+      }
+      if (!hasLegacyPrefix) {
+        hasLegacyPrefix = Object.keys(item).some((key) => key.includes('_mvs'));
+        // only if true -> set value - for backward compatibility
+        if (hasLegacyPrefix) this.useMVS = true;
+      }
+    });
 
     itemsContainerEl.innerHTML = '';
     var tar = new YAHOO.util.DDTarget(itemsContainerEl);
-    for (var i = 0; i < items.length; i++) {
-      const item = items[i];
-      const itemIndex = i;
-      var itemEl = document.createElement('div');
-      if (this.readonly != true) {
-        var dd = new NodeSelectorDragAndDropDecorator(itemEl);
-      }
 
-      YAHOO.util.Dom.addClass(itemEl, 'cstudio-form-control-node-selector-item');
-      itemEl.style.backgroundColor = '#F0F0F0'; // stylesheet not working due to proxy?
-      itemEl.style.overflowWrap = 'break-word';
-      itemEl._index = i;
-      itemEl.context = this;
+    // Retrieve all SandboxItems to determine if the user has the edit permissions.
+    craftercms.services.content
+      .fetchItemsByPath(CStudioAuthoringContext.site, sharedItems)
+      .subscribe((sandboxItems) => {
+        const itemsByPath = craftercms.utils.object.createLookupTable(sandboxItems, 'path');
 
-      $(itemEl).append(`<span class="name">${item.value}</span>`);
-      if (item.include) {
-        $(itemEl).append(`<span class="path">${item.include}</span>`);
-      } else if (item.inline === 'true') {
-        $(itemEl).append(
-          `<span class="path">(${this.formatMessage(this.formEngineMessages.embeddedComponent)})</span>`
-        );
-      } else {
-        $(itemEl).append(`<span class="path">${item.key}</span>`);
-      }
+        for (var i = 0; i < items.length; i++) {
+          const item = items[i];
+          const itemIndex = i;
+          var itemEl = document.createElement('div');
+          if (this.readonly != true) {
+            var dd = new NodeSelectorDragAndDropDecorator(itemEl);
+          }
 
-      if (this.readonly === true) {
-        itemEl.classList.add('disabled');
-      }
+          YAHOO.util.Dom.addClass(itemEl, 'cstudio-form-control-node-selector-item');
+          itemEl.style.backgroundColor = '#F0F0F0'; // stylesheet not working due to proxy?
+          itemEl.style.overflowWrap = 'break-word';
+          itemEl._index = i;
+          itemEl.context = this;
 
-      const isComponent = item.key.startsWith('/site') || item.inline;
-      const editBtnLabel = this.readonly ? 'View' : 'Edit';
-      const editBtnIconClass = this.readonly ? 'fa-eye' : 'fa-pencil';
+          $(itemEl).append(`<span class="name">${item.value}</span>`);
+          if (item.include) {
+            $(itemEl).append(`<span class="path">${item.include}</span>`);
+          } else if (item.inline === 'true') {
+            $(itemEl).append(
+              `<span class="path">(${this.formatMessage(this.formEngineMessages.embeddedComponent)})</span>`
+            );
+          } else {
+            $(itemEl).append(`<span class="path">${item.key}</span>`);
+          }
 
-      const $actionsContainer = $(`<span class="actions-container ml-auto" />`);
-      const editBtn = $(
-        `<span class="fa ${editBtnIconClass} node-selector-item-icon" title="${editBtnLabel}" aria-label="${editBtnLabel}" role="button" data-index="${i}"></span>`
-      );
-      const deleteBtn = $(
-        '<span class="fa fa-trash node-selector-item-icon" title="Delete" aria-label="Delete" role="button"></span>'
-      );
-      const isEditable = this.allowEdit && (isComponent || craftercms.utils.content.isEditableAsset(item.key));
-      if (isEditable) {
-        if (isComponent || !this.readonly) {
-          $actionsContainer.append(editBtn);
-          editBtn.on('click', function () {
-            const elIndex = $(this).data('index');
-            let selectedDatasource =
-              _self.datasources.find((item) => item.id === _self.items[elIndex].datasource) || _self.datasources[0];
-            selectedDatasource.edit(item.key, _self, elIndex, {
-              failure: function (error) {
-                if (error.status === 404) {
-                  CStudioAuthoring.Utils.showConfirmDialog({
-                    body: _self.formatMessage(_self.formEngineMessages.nodeSelectorItemNotFound, {
-                      internalName: _self.items[elIndex].value
-                    }),
-                    onOk: () => {
-                      _self.deleteItem(elIndex);
-                    },
-                    okButtonText: _self.formatMessage(_self.formEngineMessages.removeItemFromNodeSelector, {
-                      controlLabel: _self.fieldDef.title
-                    }),
-                    cancelButtonText: _self.formatMessage(_self.formEngineMessages.keepItemInNodeSelector)
-                  });
-                } else {
-                  craftercms.getStore().dispatch({
-                    type: 'SHOW_ERROR_DIALOG',
-                    payload: { error: error.response.response }
-                  });
-                }
-              }
+          if (this.readonly === true) {
+            itemEl.classList.add('disabled');
+          }
+
+          const isComponent = item.key.startsWith('/site') || item.inline;
+          const hasWritePermission = !(item.key in itemsByPath) || itemsByPath[item.key].availableActionsMap.edit;
+          const editBtnLabel = this.readonly || !hasWritePermission ? 'View' : 'Edit';
+          const editBtnIconClass = this.readonly || !hasWritePermission ? 'fa-eye' : 'fa-pencil';
+
+          const $actionsContainer = $(`<span class="actions-container ml-auto" />`);
+          const editBtn = $(
+            `<button class="fa ${editBtnIconClass} node-selector-item-icon" title="${editBtnLabel}" aria-label="${editBtnLabel}" role="button" data-index="${i}"></button>`
+          );
+          const deleteBtn = $(
+            '<button class="fa fa-trash node-selector-item-icon" title="Delete" aria-label="Delete" role="button"></button>'
+          );
+          const isEditable = this.allowEdit && (isComponent || craftercms.utils.content.isEditableAsset(item.key));
+          if (isEditable) {
+            if (isComponent || !this.readonly) {
+              $actionsContainer.append(editBtn);
+              editBtn.on('click', function () {
+                const elIndex = $(this).data('index');
+                let selectedDatasource =
+                  _self.datasources.find((item) => item.id === _self.items[elIndex].datasource) || _self.datasources[0];
+                selectedDatasource.edit(item.key, _self, elIndex, {
+                  failure: function (error) {
+                    if (error.status === 404) {
+                      CStudioAuthoring.Utils.showConfirmDialog({
+                        body: _self.formatMessage(_self.formEngineMessages.nodeSelectorItemNotFound, {
+                          internalName: _self.items[elIndex].value
+                        }),
+                        onOk: () => {
+                          _self.deleteItem(elIndex);
+                        },
+                        okButtonText: _self.formatMessage(_self.formEngineMessages.removeItemFromNodeSelector, {
+                          controlLabel: _self.fieldDef.title
+                        }),
+                        cancelButtonText: _self.formatMessage(_self.formEngineMessages.keepItemInNodeSelector)
+                      });
+                    } else {
+                      craftercms.getStore().dispatch({
+                        type: 'SHOW_ERROR_DIALOG',
+                        payload: { error: error.response.response }
+                      });
+                    }
+                  }
+                });
+              });
+            }
+          }
+          if (this.readonly != true) {
+            $actionsContainer.append(deleteBtn);
+            deleteBtn.on('click', function () {
+              _self.deleteItem(itemIndex);
+              _self._renderItems();
             });
-          });
+          }
+
+          $(itemEl).append($actionsContainer);
+          itemEl._onMouseDown = function () {};
+
+          itemsContainerEl.appendChild(itemEl);
         }
-      }
-      if (this.readonly != true) {
-        $actionsContainer.append(deleteBtn);
-        deleteBtn.on('click', function () {
-          _self.deleteItem(itemIndex);
-          _self._renderItems();
-        });
-      }
-
-      $(itemEl).append($actionsContainer);
-      itemEl._onMouseDown = function () {};
-
-      itemsContainerEl.appendChild(itemEl);
-    }
+      });
   },
 
   getItemsLeftCount: function () {

--- a/static-assets/components/cstudio-forms/data-sources/shared-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/shared-content.js
@@ -267,17 +267,19 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
 
   edit: function (key, control, index, callback) {
     var _self = this;
-    const readonly = control.readonly;
-    const action = readonly ? CStudioAuthoring.Operations.viewContent : CStudioAuthoring.Operations.editContent;
-
-    CStudioAuthoring.Service.lookupContentItem(CStudioAuthoringContext.site, key, {
-      success: function (contentTO) {
+    craftercms.services.content.fetchSandboxItem(CStudioAuthoringContext.site, key).subscribe({
+      next(sandboxItem) {
+        const readonly = control.readonly;
+        const action =
+          readonly || !sandboxItem.availableActionsMap.edit
+            ? CStudioAuthoring.Operations.viewContent
+            : CStudioAuthoring.Operations.editContent;
         action(
-          contentTO.item.contentType,
+          sandboxItem.contentTypeId,
           CStudioAuthoringContext.siteId,
-          contentTO.item.mimeType,
-          contentTO.item.nodeRef,
-          contentTO.item.uri,
+          sandboxItem.mimeType,
+          null,
+          sandboxItem.path,
           false,
           {
             success: function (contentTO, editorId, name, value, draft, action) {
@@ -305,7 +307,7 @@ YAHOO.extend(CStudioForms.Datasources.SharedContent, CStudioForms.CStudioFormDat
           }
         );
       },
-      failure: function () {}
+      error() {}
     });
   },
 

--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1656,8 +1656,10 @@ var CStudioForms =
                         'studioDialog'
                       );
                     } catch (e) {
-                      const error = err.response,
-                        errorMessage = error.message ? error.message : CMgs.format(formsLangBundle, 'errSaveFailed');
+                      const error = err.response ?? err;
+                      const errorMessage = error.message
+                        ? error.message
+                        : CMgs.format(formsLangBundle, 'errSaveFailed');
 
                       CStudioAuthoring.Operations.showSimpleDialog(
                         'error-dialog',

--- a/static-assets/themes/cstudioTheme/css/forms-default.css
+++ b/static-assets/themes/cstudioTheme/css/forms-default.css
@@ -1624,6 +1624,11 @@ body.yui-skin-cstudioTheme.masked {
   align-items: center;
 }
 
+button.node-selector-item-icon {
+  border: none;
+  background: none;
+}
+
 .node-selector-item-icon {
   color: #7c7c80;
   padding: 2px 7px;

--- a/ui/app/src/CHANGELOG.md
+++ b/ui/app/src/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 4.1.5
 * [common-api.js]
   * `CStudioAuthoring.Utils.showConfirmDialog`: Added function overload to receive a `props` style object as first and only argument. The props argument would contain all ConfirmDialog props. Original set of arguments still supported for backward compatibility.
+* `pathNavigatorTreeFetchPathChildrenFailed` action creator payload requires a `path` property.
 
 ## 4.1.4
 * `UploadDialog`: Added props `endpoint`, `method`, `headers`, `meta`, `allowedMetaFields`, `useFormData`, `fieldName` and `onFileAdded` for additional control over the upload process.

--- a/ui/app/src/components/EditModeSwitch/EditModeSwitch.tsx
+++ b/ui/app/src/components/EditModeSwitch/EditModeSwitch.tsx
@@ -96,7 +96,7 @@ export function EditModeSwitch(props: EditModeSwitchProps) {
   const write = Boolean(item?.availableActionsMap.edit);
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-  const editMode = useSelection((state) => state.preview.editMode) && !isLocked && write;
+  const editMode = useSelection((state) => state.preview.editMode);
 
   const onChange = (e) => {
     dispatch(setPreviewEditMode({ editMode: e.target.checked }));

--- a/ui/app/src/components/EditModesSwitcher/EditModesSwitcher.tsx
+++ b/ui/app/src/components/EditModesSwitcher/EditModesSwitcher.tsx
@@ -16,8 +16,6 @@
 
 import * as React from 'react';
 import EditModesSwitcherUI from './EditModesSwitcherUI';
-import { useActiveUser } from '../../hooks/useActiveUser';
-import { isItemLockedForMe } from '../../utils/content';
 import { useDispatch } from 'react-redux';
 import { setPreviewEditMode } from '../../state/actions/preview';
 import { DetailedItem } from '../../models/Item';
@@ -29,17 +27,13 @@ export interface EditModesSwitcherProps {
 }
 
 export function EditModesSwitcher(props: EditModesSwitcherProps) {
-  const { item, disabled } = props;
-  const user = useActiveUser();
-  const isLocked = isItemLockedForMe(item, user.username);
-  const write = Boolean(item?.availableActionsMap.edit);
-  const dispatch = useDispatch();
+  const { disabled } = props;
   const { editMode, highlightMode } = usePreviewState();
+  const dispatch = useDispatch();
   const onChange = (editMode, highlightMode) => dispatch(setPreviewEditMode({ editMode, highlightMode }));
-  const isDisabled = disabled || !write || isLocked;
   return (
     <EditModesSwitcherUI
-      disabled={isDisabled}
+      disabled={disabled}
       isEditMode={editMode}
       highlightMode={highlightMode}
       onEditModeChange={onChange}

--- a/ui/app/src/components/EditModesSwitcher/EditModesSwitcherUI.tsx
+++ b/ui/app/src/components/EditModesSwitcher/EditModesSwitcherUI.tsx
@@ -38,13 +38,13 @@ export function EditModesSwitcherUI(props: EditModesSwitcherUIProps) {
   const { isEditMode, highlightMode, onEditModeChange, size = 'small', activeSxShadow = 1, disabled = false } = props;
   const isAllHighlightMode = isEditMode && highlightMode === 'all';
   const isMoveHighlightMode = isEditMode && !isAllHighlightMode;
-  const getStyle = () => ({
+  const commonModeButtonStyle = {
     boxShadow: activeSxShadow,
     bgcolor: 'background.default',
     ':hover': {
       cursor: 'default'
     }
-  });
+  };
   return (
     <Box
       sx={{
@@ -96,7 +96,7 @@ export function EditModesSwitcherUI(props: EditModesSwitcherUIProps) {
           disabled={disabled}
           size={size}
           onClick={() => onEditModeChange(true, 'all')}
-          sx={isAllHighlightMode ? getStyle() : UNDEFINED}
+          sx={isAllHighlightMode ? commonModeButtonStyle : UNDEFINED}
         >
           <EditRoundedIcon />
         </IconButton>
@@ -111,7 +111,7 @@ export function EditModesSwitcherUI(props: EditModesSwitcherUIProps) {
           disabled={disabled}
           size={size}
           onClick={() => onEditModeChange(true, 'move')}
-          sx={isMoveHighlightMode ? getStyle() : UNDEFINED}
+          sx={isMoveHighlightMode ? commonModeButtonStyle : UNDEFINED}
         >
           <DragIndicatorRoundedIcon />
         </IconButton>

--- a/ui/app/src/components/ItemMegaMenu/ItemMegaMenu.tsx
+++ b/ui/app/src/components/ItemMegaMenu/ItemMegaMenu.tsx
@@ -29,6 +29,7 @@ import { useSelection } from '../../hooks/useSelection';
 import { useActiveSiteId } from '../../hooks/useActiveSiteId';
 import { useEnv } from '../../hooks/useEnv';
 import { useItemsByPath } from '../../hooks/useItemsByPath';
+import { lookupItemByPath } from '../../utils/content';
 
 export interface ItemMegaMenuBaseProps {
   path: string;
@@ -64,7 +65,7 @@ export function ItemMegaMenu(props: ItemMegaMenuProps) {
   const site = useActiveSiteId();
   const items = useItemsByPath();
   const clipboard = useSelection((state) => state.content.clipboard);
-  const item = items[path];
+  const item = lookupItemByPath(path, items);
   const contentTypes = useSelection((state) => state.contentTypes);
   const itemContentType = contentTypes?.byId?.[item?.contentTypeId]?.name;
   const { authoringBase } = useEnv();

--- a/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -51,7 +51,7 @@ import PathNavigatorSkeleton from './PathNavigatorSkeleton';
 import GlobalState from '../../models/GlobalState';
 import { SystemIconDescriptor } from '../SystemIcon';
 import { getOffsetLeft, getOffsetTop } from '@mui/material/Popover';
-import { getNumOfMenuOptionsForItem } from '../../utils/content';
+import { getNumOfMenuOptionsForItem, lookupItemByPath } from '../../utils/content';
 import { useSelection } from '../../hooks/useSelection';
 import { useEnv } from '../../hooks/useEnv';
 import { useItemsByPath } from '../../hooks/useItemsByPath';
@@ -316,7 +316,7 @@ export function PathNavigator(props: PathNavigatorProps) {
         path: path,
         anchorReference: 'anchorPosition',
         anchorPosition: { top, left },
-        loaderItems: getNumOfMenuOptionsForItem(itemsByPath[path])
+        loaderItems: getNumOfMenuOptionsForItem(lookupItemByPath(path, itemsByPath))
       })
     );
   };

--- a/ui/app/src/components/PathNavigator/PathNavigatorUI.tsx
+++ b/ui/app/src/components/PathNavigator/PathNavigatorUI.tsx
@@ -155,7 +155,7 @@ export function PathNavigatorUI(props: PathNavigatorUIProps) {
     onRowsPerPageChange
   } = props;
   // endregion
-  const items = state.itemsInPath?.flatMap((path) => itemsByPath[path] ?? []) ?? [];
+  const items = state.itemsInPath?.flatMap((path) => lookupItemByPath(path, itemsByPath) ?? []) ?? [];
   const levelDescriptor = itemsByPath[state.levelDescriptor];
   return (
     <Accordion

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
@@ -35,13 +35,12 @@ import ArrowDropDownRoundedIcon from '@mui/icons-material/ArrowDropDownRounded';
 import { isBlank } from '../../utils/string';
 import ErrorOutlineRounded from '@mui/icons-material/ErrorOutlineRounded';
 import { lookupItemByPath } from '../../utils/content';
+import { PathNavigatorTreeStateProps } from './PathNavigatorTree';
 
-export interface PathNavigatorTreeItemProps {
+export interface PathNavigatorTreeItemProps
+  extends Pick<PathNavigatorTreeStateProps, 'keywordByPath' | 'totalByPath' | 'childrenByParentPath' | 'errorByPath'> {
   path: string;
   itemsByPath: LookupTable<DetailedItem>;
-  keywordByPath: LookupTable<string>;
-  totalByPath: LookupTable<number>;
-  childrenByParentPath: LookupTable<string[]>;
   active?: Record<string, boolean>;
   classes?: Partial<Record<PathNavigatorTreeBreadcrumbsClassKey, string>>;
   showNavigableAsLinks?: boolean;
@@ -182,6 +181,7 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
     itemsByPath,
     keywordByPath,
     totalByPath,
+    errorByPath,
     childrenByParentPath,
     active = {},
     showNavigableAsLinks = true,
@@ -242,6 +242,7 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
         keywordByPath={keywordByPath}
         totalByPath={totalByPath}
         childrenByParentPath={childrenByParentPath}
+        errorByPath={errorByPath}
         active={active}
         onLabelClick={onLabelClick}
         onIconClick={onIconClick}
@@ -274,12 +275,23 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
       );
   } else if (totalByPath[path] > 0 && !childrenByParentPath.length) {
     propsForTreeItem.children.push(
-      <div key="loading" className={classes.loading}>
-        <CircularProgress size={14} />
-        <Typography variant="caption" color="textSecondary">
-          <FormattedMessage id="words.loading" defaultMessage="Loading" />
-        </Typography>
-      </div>
+      errorByPath[path] ? (
+        <div key="loading" className={classes.loading}>
+          <Typography variant="caption" color="error.main">
+            <FormattedMessage
+              defaultMessage="Error: {message}"
+              values={{ message: errorByPath[path]?.response?.message ?? errorByPath[path].message }}
+            />
+          </Typography>
+        </div>
+      ) : (
+        <div key="loading" className={classes.loading}>
+          <CircularProgress size={14} />
+          <Typography variant="caption" color="textSecondary">
+            <FormattedMessage id="words.loading" defaultMessage="Loading" />
+          </Typography>
+        </div>
+      )
     );
   } else if (!isBlank(keywordByPath[path]) && totalByPath[path] === 0) {
     propsForTreeItem.children.push(

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeUI.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeUI.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { TreeView } from '@mui/x-tree-view/TreeView';
 import { makeStyles } from 'tss-react/mui';
 import Accordion from '@mui/material/Accordion';
-import Header from '../PathNavigator/PathNavigatorHeader';
+import PathNavigatorHeader from '../PathNavigator/PathNavigatorHeader';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import { StateStylingProps } from '../../models/UiConfig';
 import PathNavigatorTreeItem, { PathNavigatorTreeItemProps } from './PathNavigatorTreeItem';
@@ -32,7 +32,14 @@ import { ErrorState } from '../ErrorState';
 export interface PathNavigatorTreeUIProps
   extends Pick<
     PathNavigatorTreeItemProps,
-    'showNavigableAsLinks' | 'showPublishingTarget' | 'showWorkflowState' | 'showItemMenu'
+    | 'showNavigableAsLinks'
+    | 'showPublishingTarget'
+    | 'showWorkflowState'
+    | 'showItemMenu'
+    | 'keywordByPath'
+    | 'totalByPath'
+    | 'childrenByParentPath'
+    | 'errorByPath'
   > {
   title: string;
   icon?: SystemIconDescriptor;
@@ -40,9 +47,6 @@ export interface PathNavigatorTreeUIProps
   rootPath: string;
   isRootPathMissing: boolean;
   itemsByPath: LookupTable<DetailedItem>;
-  keywordByPath: LookupTable<string>;
-  totalByPath: LookupTable<number>;
-  childrenByParentPath: LookupTable<string[]>;
   onIconClick(path: string): void;
   onLabelClick(event: React.MouseEvent<Element, MouseEvent>, path: string): void;
   onChangeCollapsed(collapsed: boolean): void;
@@ -92,6 +96,7 @@ export function PathNavigatorTreeUI(props: PathNavigatorTreeUIProps) {
     itemsByPath,
     keywordByPath,
     childrenByParentPath,
+    errorByPath,
     totalByPath,
     onIconClick,
     onLabelClick,
@@ -128,7 +133,7 @@ export function PathNavigatorTreeUI(props: PathNavigatorTreeUIProps) {
         ...(container ? (isCollapsed ? container.collapsedStyle : container.expandedStyle) : void 0)
       }}
     >
-      <Header
+      <PathNavigatorHeader
         icon={icon}
         title={title}
         locale={null}
@@ -159,6 +164,7 @@ export function PathNavigatorTreeUI(props: PathNavigatorTreeUIProps) {
               keywordByPath={keywordByPath}
               totalByPath={totalByPath}
               childrenByParentPath={childrenByParentPath}
+              errorByPath={errorByPath}
               onIconClick={onIconClick}
               onLabelClick={onLabelClick}
               onFilterChange={onFilterChange}

--- a/ui/app/src/components/PreviewConcierge/PreviewConcierge.tsx
+++ b/ui/app/src/components/PreviewConcierge/PreviewConcierge.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import React, { MutableRefObject, PropsWithChildren, useEffect, useRef, useState } from 'react';
 import {
   changeCurrentUrl,
   clearSelectedZones,
@@ -30,6 +30,7 @@ import {
   fetchContentTypes,
   fetchGuestModel,
   fetchGuestModelComplete,
+  fetchGuestModelsComplete,
   fetchPrimaryGuestModelComplete,
   guestCheckIn,
   guestCheckOut,
@@ -116,10 +117,8 @@ import {
 import EditFormPanel from '../EditFormPanel/EditFormPanel';
 import {
   createModelHierarchyDescriptorMap,
-  getComputedEditMode,
   getInheritanceParentIdsForField,
   getNumOfMenuOptionsForItem,
-  hasEditAction,
   isItemLockedForMe,
   normalizeModel,
   normalizeModelsLookup,
@@ -185,11 +184,21 @@ import { getOffsetLeft, getOffsetTop } from '@mui/material/Popover';
 import { isSameDay } from '../../utils/datetime';
 import compatibilityList from './compatibilityList';
 import ContentType from '../../models/ContentType';
+import { Dispatch } from 'redux';
+import { ActionCreatorWithOptionalPayload } from '@reduxjs/toolkit';
 
 const originalDocDomain = document.domain;
 
-// region const issueDescriptorRequest = () => {...}
-const issueDescriptorRequest = (props) => {
+const issueDescriptorRequest = (props: {
+  site: string;
+  path: string;
+  contentTypes: Record<string, ContentType>;
+  requestedSourceMapPaths: MutableRefObject<Record<string, boolean>>;
+  flatten?: boolean;
+  dispatch: Dispatch;
+  completeActionCreator: ActionCreatorWithOptionalPayload<any>;
+  permissions: string[];
+}) => {
   const {
     site,
     path,
@@ -197,7 +206,7 @@ const issueDescriptorRequest = (props) => {
     requestedSourceMapPaths,
     flatten = true,
     dispatch,
-    completeAction,
+    completeActionCreator,
     permissions
   } = props;
   const hostToGuest$ = getHostToGuestBus();
@@ -279,7 +288,7 @@ const issueDescriptorRequest = (props) => {
 
       dispatch(
         batchActions([
-          completeAction({
+          completeActionCreator({
             model: normalizedModel,
             modelLookup: normalizedModels,
             modelIdByPath: modelIdByPath,
@@ -288,9 +297,8 @@ const issueDescriptorRequest = (props) => {
           updateItemsByPath({ items: sandboxItems })
         ])
       );
-      hostToGuest$.next({
-        type: 'FETCH_GUEST_MODEL_COMPLETE',
-        payload: {
+      hostToGuest$.next(
+        fetchGuestModelComplete({
           path,
           model: normalizedModel,
           modelLookup: normalizedModels,
@@ -298,11 +306,10 @@ const issueDescriptorRequest = (props) => {
           modelIdByPath: modelIdByPath,
           sandboxItems,
           permissions
-        }
-      });
+        })
+      );
     });
 };
-// endregion
 
 const dataSourceActionsListInitialState = {
   show: false,
@@ -329,7 +336,6 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
   const models = guest?.models;
   const modelIdByPath = guest?.modelIdByPath;
   const hierarchyMap = guest?.hierarchyMap;
-  const mainModelModifier = guest?.mainModelModifier;
   const requestedSourceMapPaths = useRef({});
   const currentItemPath = guest?.path;
   const uiConfig = useSiteUIConfig();
@@ -343,16 +349,14 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
   const [dataSourceActionsListState, setDataSourceActionsListState] = useSpreadState<DataSourcesActionsListProps>(
     dataSourceActionsListInitialState
   );
-  const conditionallyToggleEditMode = (nextHighlightMode?: HighlightMode) => {
-    if (item && !isItemLockedForMe(item, username) && hasEditAction(item.availableActions)) {
-      dispatch(
-        setPreviewEditMode({
-          // If switching from highlight modes (all vs move), we just want to switch modes without turning off edit mode.
-          editMode: nextHighlightMode !== highlightMode ? true : !editMode,
-          highlightMode: nextHighlightMode
-        })
-      );
-    }
+  const toggleEditMode = (nextHighlightMode?: HighlightMode) => {
+    dispatch(
+      setPreviewEditMode({
+        // If switching from highlight modes (all vs move), we just want to switch modes without turning off edit mode.
+        editMode: nextHighlightMode !== highlightMode ? true : !editMode,
+        highlightMode: nextHighlightMode
+      })
+    );
   };
   const env = useEnv();
   const upToDateRefs = useUpdateRefs({
@@ -377,7 +381,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
     enqueueSnackbar,
     editModePadding,
     cdataEscapedFieldPatterns,
-    conditionallyToggleEditMode,
+    toggleEditMode,
     keyboardShortcutsDialogState,
     setDataSourceActionsListState,
     showToolsPanel,
@@ -387,10 +391,10 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
       const key = event.key;
       switch (key) {
         case 'e':
-          upToDateRefs.current.conditionallyToggleEditMode('all');
+          upToDateRefs.current.toggleEditMode('all');
           break;
         case 'm':
-          upToDateRefs.current.conditionallyToggleEditMode('move');
+          upToDateRefs.current.toggleEditMode('move');
           break;
         case 'p':
           upToDateRefs.current.dispatch(toggleEditModePadding());
@@ -407,7 +411,9 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
             showEditDialog({
               site: upToDateRefs.current.siteId,
               path: upToDateRefs.current.guest.path,
-              readonly: isItemLockedForMe(upToDateRefs.current.item, upToDateRefs.current.user.username),
+              readonly:
+                !upToDateRefs.current.item.availableActionsMap.edit ||
+                isItemLockedForMe(upToDateRefs.current.item, upToDateRefs.current.user.username),
               authoringBase: upToDateRefs.current.authoringBase
             })
           );
@@ -480,12 +486,9 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
   useEffect(() => {
     // FYI. Path navigator refresh triggers this effect too due to item changing.
     if (item) {
-      const mode =
-        getComputedEditMode({ item, username: username, editMode }) &&
-        (mainModelModifier == null || mainModelModifier.username === username);
-      getHostToGuestBus().next(setPreviewEditMode({ editMode: mode }));
+      getHostToGuestBus().next(setPreviewEditMode({ editMode }));
     }
-  }, [item, editMode, username, dispatch, mainModelModifier]);
+  }, [item, editMode]);
 
   // Fetch active item
   useEffect(() => {
@@ -615,7 +618,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
               contentTypes,
               requestedSourceMapPaths,
               dispatch,
-              completeAction: fetchPrimaryGuestModelComplete,
+              completeActionCreator: fetchPrimaryGuestModelComplete,
               permissions
             });
           });
@@ -682,7 +685,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
                 contentTypes,
                 requestedSourceMapPaths,
                 dispatch,
-                completeAction: fetchPrimaryGuestModelComplete,
+                completeActionCreator: fetchPrimaryGuestModelComplete,
                 permissions
               });
             });
@@ -698,7 +701,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
                 contentTypes,
                 requestedSourceMapPaths,
                 dispatch,
-                completeAction: fetchGuestModelComplete,
+                completeActionCreator: fetchGuestModelsComplete,
                 permissions
               });
             });
@@ -745,7 +748,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
                 contentTypes,
                 requestedSourceMapPaths,
                 dispatch,
-                completeAction: fetchGuestModelComplete,
+                completeActionCreator: fetchGuestModelsComplete,
                 permissions
               });
               hostToHost$.next(sortItemOperationComplete(payload));
@@ -832,7 +835,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
                 contentTypes,
                 requestedSourceMapPaths,
                 dispatch,
-                completeAction: fetchGuestModelComplete,
+                completeActionCreator: fetchGuestModelsComplete,
                 permissions
               });
               hostToGuest$.next(
@@ -885,7 +888,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
                 contentTypes,
                 requestedSourceMapPaths,
                 dispatch,
-                completeAction: fetchPrimaryGuestModelComplete,
+                completeActionCreator: fetchPrimaryGuestModelComplete,
                 permissions
               });
               hostToGuest$.next(duplicateItemOperationComplete());
@@ -980,7 +983,7 @@ export function PreviewConcierge(props: PropsWithChildren<{}>) {
                 contentTypes,
                 requestedSourceMapPaths,
                 dispatch,
-                completeAction: fetchGuestModelComplete,
+                completeActionCreator: fetchGuestModelsComplete,
                 permissions
               });
 

--- a/ui/app/src/models/Search.ts
+++ b/ui/app/src/models/Search.ts
@@ -73,6 +73,7 @@ export interface SearchItem {
   lastModified: string;
   size: number;
   snippets: any;
+  additionalFields?: Record<string, unknown>;
 }
 
 export interface SearchFacet {

--- a/ui/app/src/models/SimpleAjaxError.tsx
+++ b/ui/app/src/models/SimpleAjaxError.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import ApiResponse from './ApiResponse';
+
+/**
+ * Essentially a redeclaration of `Omit<AjaxError, 'request' | 'xhr'>`. Mainly removes
+ * non-serializables from AjaxError and allows typing of the `response` property.
+ **/
+export interface SimpleAjaxError<T = ApiResponse> {
+  message: string;
+  name: string;
+  response: T;
+  responseType: string;
+  status: number;
+}
+
+export default SimpleAjaxError;

--- a/ui/app/src/models/index.ts
+++ b/ui/app/src/models/index.ts
@@ -76,3 +76,4 @@ export * from './monitoring/LogEvent';
 export * from './monitoring/Memory';
 export * from './monitoring/Status';
 export * from './monitoring/Version';
+export * from './SimpleAjaxError';

--- a/ui/app/src/services/content.ts
+++ b/ui/app/src/services/content.ts
@@ -98,7 +98,7 @@ export function fetchDescriptorDOM(
   return fetchDescriptorXML(site, path, options).pipe(map(fromString));
 }
 
-// region fetchSandboxItem
+// region fetchSandboxItem(...
 export function fetchSandboxItem(site: string, path: string): Observable<SandboxItem>;
 export function fetchSandboxItem(
   site: string,
@@ -115,7 +115,7 @@ export function fetchSandboxItem(
   path: string,
   options?: FetchItemsByPathOptions
 ): Observable<SandboxItem | DetailedItem> {
-  return fetchItemsByPath(site, [path], options).pipe(pluck(0));
+  return fetchItemsByPath(site, [path], options).pipe(map((items) => items[0]));
 }
 // endregion
 
@@ -1252,6 +1252,7 @@ export function fetchChildrenByPaths(
       );
 }
 
+// region export function fetchItemsByPath(...
 export function fetchItemsByPath(siteId: string, paths: string[]): Observable<FetchItemsByPathArray<SandboxItem>>;
 export function fetchItemsByPath(
   siteId: string,
@@ -1289,7 +1290,9 @@ export function fetchItemsByPath(
     )
   );
 }
+// endregion
 
+// region export function fetchItemByPath(...
 export function fetchItemByPath(siteId: string, path: string): Observable<SandboxItem>;
 export function fetchItemByPath(
   siteId: string,
@@ -1333,6 +1336,7 @@ export function fetchItemByPath(
     pluck(0)
   );
 }
+// endregion
 
 export function fetchItemWithChildrenByPath(
   siteId: string,

--- a/ui/app/src/state/actions/pathNavigatorTree.ts
+++ b/ui/app/src/state/actions/pathNavigatorTree.ts
@@ -21,6 +21,7 @@ import { GetChildrenResponse } from '../../models/GetChildrenResponse';
 import { GetChildrenOptions } from '../../models/GetChildrenOptions';
 import LookupTable from '../../models/LookupTable';
 import SystemType from '../../models/SystemType';
+import SimpleAjaxError from '../../models/SimpleAjaxError';
 
 type PayloadWithId<P> = P & { id: string };
 
@@ -130,7 +131,8 @@ export const pathNavigatorTreeBulkFetchPathChildrenComplete =
 
 export const pathNavigatorTreeFetchPathChildrenFailed = /*#__PURE__*/ createAction<{
   id: string;
-  error: Omit<AjaxError, 'request' | 'xhr'>;
+  path: string;
+  error: SimpleAjaxError;
 }>('PATH_NAV_TREE_FETCH_PATH_CHILDREN_FAILED');
 
 export const pathNavigatorTreeBulkFetchPathChildrenFailed = /*#__PURE__*/ createAction<{

--- a/ui/app/src/state/actions/preview.ts
+++ b/ui/app/src/state/actions/preview.ts
@@ -31,6 +31,7 @@ import { ContentEventPayload, WidgetDescriptor } from '../../models';
 import LookupTable from '../../models/LookupTable';
 import { DetailedItem, SandboxItem } from '../../models/Item';
 import GlobalState, { HighlightMode } from '../../models/GlobalState';
+import { ModelHierarchyMap } from '../../utils/content';
 
 interface CommonOperationProps {
   modelId: string;
@@ -294,10 +295,22 @@ export const fetchPrimaryGuestModelComplete = /*#__PURE__*/ createAction<{
 
 // This action is meant for the other Guest models that aren't the main.
 // The reducer will shouldn't set the guest.modelId.
-export const fetchGuestModelComplete = /*#__PURE__*/ createAction<{
+export const fetchGuestModelsComplete = /*#__PURE__*/ createAction<{
   modelLookup: LookupTable<ContentInstance>;
   hierarchyMap: LookupTable<string[]>;
 }>('FETCH_GUEST_MODELS_COMPLETE');
+
+// TODO: Do we really need these two (↑ and ↓) separate actions? Asses consolidate under a single action with a better name.
+
+export const fetchGuestModelComplete = /*#__PURE__*/ createAction<{
+  path: string;
+  model: ContentInstance;
+  modelLookup: Record<string, ContentInstance>;
+  hierarchyMap: ModelHierarchyMap;
+  modelIdByPath: Record<string, string>;
+  sandboxItems: SandboxItem[];
+  permissions: string[];
+}>('FETCH_GUEST_MODEL_COMPLETE');
 
 export const guestModelUpdated = /*#__PURE__*/ createAction<{ model: ContentInstance }>('GUEST_MODEL_UPDATED');
 

--- a/ui/app/src/state/epics/pathNavigatorTree.ts
+++ b/ui/app/src/state/epics/pathNavigatorTree.ts
@@ -288,7 +288,7 @@ export default [
               options: finalOptions
             })
           ),
-          catchAjaxError((error) => pathNavigatorTreeFetchPathChildrenFailed({ error, id }))
+          catchAjaxError((error) => pathNavigatorTreeFetchPathChildrenFailed({ error, id, path }))
         );
       })
     ),
@@ -341,7 +341,7 @@ export default [
         const options = createGetChildrenOptions(chunk, { keyword });
         return fetchChildrenByPath(state.sites.active, path, options).pipe(
           map((children) => pathNavigatorTreeFetchPathChildrenComplete({ id, parentPath: path, children, options })),
-          catchAjaxError((error) => pathNavigatorTreeFetchPathChildrenFailed({ error, id }))
+          catchAjaxError((error) => pathNavigatorTreeFetchPathChildrenFailed({ error, id, path }))
         );
       })
     ),

--- a/ui/app/src/state/reducers/pathNavigatorTree.ts
+++ b/ui/app/src/state/reducers/pathNavigatorTree.ts
@@ -25,6 +25,7 @@ import {
   pathNavigatorTreeExpandPath,
   pathNavigatorTreeFetchPathChildren,
   pathNavigatorTreeFetchPathChildrenComplete,
+  pathNavigatorTreeFetchPathChildrenFailed,
   pathNavigatorTreeFetchPathPage,
   pathNavigatorTreeFetchPathPageComplete,
   pathNavigatorTreeInit,
@@ -193,6 +194,7 @@ const reducer = createReducer<LookupTable<PathNavigatorTreeStateProps>>(
         limit,
         expanded,
         childrenByParentPath: {},
+        errorByPath: {},
         offsetByPath: {},
         keywordByPath,
         totalByPath: {},
@@ -217,10 +219,14 @@ const reducer = createReducer<LookupTable<PathNavigatorTreeStateProps>>(
     },
     [pathNavigatorTreeFetchPathChildren.type]: (state, action) => {
       const { expand = true } = action.payload;
+      delete state[action.payload.id].errorByPath[action.payload.path];
       expand && expandPath(state, action);
     },
     [pathNavigatorTreeFetchPathChildrenComplete.type]: (state, { payload: { id, parentPath, children, options } }) => {
       updatePath(state, { id, parentPath, children, options });
+    },
+    [pathNavigatorTreeFetchPathChildrenFailed.type]: (state, action) => {
+      state[action.payload.id].errorByPath[action.payload.path] = action.payload.error;
     },
     [pathNavigatorTreeBulkFetchPathChildren.type]: (
       state,

--- a/ui/app/src/state/reducers/preview.ts
+++ b/ui/app/src/state/reducers/preview.ts
@@ -31,7 +31,7 @@ import {
   fetchComponentsByContentType,
   fetchComponentsByContentTypeComplete,
   fetchComponentsByContentTypeFailed,
-  fetchGuestModelComplete,
+  fetchGuestModelsComplete,
   fetchPrimaryGuestModelComplete,
   guestCheckIn,
   guestCheckOut,
@@ -335,7 +335,7 @@ const reducer = createReducer<GlobalState['preview']>(initialState, {
     return nextState;
   },
   [fetchPrimaryGuestModelComplete.type]: fetchGuestModelsCompleteHandler,
-  [fetchGuestModelComplete.type]: fetchGuestModelsCompleteHandler,
+  [fetchGuestModelsComplete.type]: fetchGuestModelsCompleteHandler,
   [guestModelUpdated.type]: (state, { payload: { model } }) => ({
     ...state,
     guest: {

--- a/ui/app/src/utils/content.ts
+++ b/ui/app/src/utils/content.ts
@@ -149,6 +149,7 @@ export function isBlobUrl(url: string): boolean {
 }
 
 /**
+ * TODO: Remove?
  * Returns the boolean intersection of editMode, lock status and the item's edit permission
  */
 export function getComputedEditMode({
@@ -969,6 +970,14 @@ export const createItemActionMap: (availableActions: number) => ItemActionsMap =
   rejectPublish: hasPublishRejectAction(value)
 });
 
+/**
+ * Given an item lookup table, tries to find the path with and without the "/index.xml" portion of the path.
+ * This reconciles path differences when working with pages between folder and index (i.e. /site/website vs /site/website/index.xml),
+ * which refer to the same item in most contexts.
+ * path {string} The path to look for
+ * lookupTable {Record<string, T>} The map-like object containing all items in which to look the path up
+ * @returns {T} The item if found, undefined otherwise
+ **/
 export function lookupItemByPath<T = DetailedItem>(path: string, lookupTable: LookupTable<T>): T {
   return lookupTable[withIndex(path)] ?? lookupTable[withoutIndex(path)];
 }

--- a/ui/app/src/utils/path.ts
+++ b/ui/app/src/utils/path.ts
@@ -82,7 +82,7 @@ export function parseQueryString(): ParsedQuery {
 }
 
 export function withoutIndex(path: string): string {
-  return path.replace('/index.xml', '');
+  return path?.replace('/index.xml', '');
 }
 
 export function withIndex(path: string): string {

--- a/ui/guest/src/contentController.ts
+++ b/ui/guest/src/contentController.ts
@@ -29,6 +29,7 @@ import {
   deleteItemOperation,
   duplicateItemOperation,
   fetchGuestModel,
+  fetchGuestModelComplete,
   insertComponentOperation,
   insertItemOperation,
   moveItemOperation,
@@ -44,7 +45,7 @@ import { parseDescriptor, preParseSearchResults } from '@craftercms/content';
 import { crafterConf } from '@craftercms/classes';
 import { getDefaultValue } from '@craftercms/studio-ui/utils/contentType';
 import { ModelHierarchyDescriptor, ModelHierarchyMap, modelsToLookup } from '@craftercms/studio-ui/utils/content';
-import { SandboxItem } from '@craftercms/studio-ui/models';
+import { SandboxItem, StandardAction } from '@craftercms/studio-ui/models';
 
 // if (process.env.NODE_ENV === 'development') {
 // TODO: Notice
@@ -204,7 +205,7 @@ export function fetchByPath(
   return of('nothing').pipe(
     tap(() => post(fetchGuestModel({ path }))),
     switchMap(() =>
-      fromTopic('FETCH_GUEST_MODEL_COMPLETE').pipe(
+      fromTopic(fetchGuestModelComplete.type).pipe(
         pluck('payload'),
         filter((payload) => payload.path === path),
         take(1)
@@ -746,11 +747,9 @@ export function deleteItem(modelId: string, fieldId: string, index: number | str
 }
 
 // Host sends over all content types upon Guest check in.
-fromTopic(contentTypesResponse.type)
-  .pipe(pluck('payload'))
-  .subscribe(({ contentTypes }) => {
-    contentTypes$.next(Array.isArray(contentTypes) ? createLookupTable(contentTypes) : contentTypes);
-  });
+fromTopic(contentTypesResponse.type).subscribe(({ payload: { contentTypes } }) => {
+  contentTypes$.next(Array.isArray(contentTypes) ? createLookupTable(contentTypes) : contentTypes);
+});
 
 export interface FetchGuestModelCompletePayload {
   path: string;
@@ -762,43 +761,39 @@ export interface FetchGuestModelCompletePayload {
   permissions: string[];
 }
 
-fromTopic('FETCH_GUEST_MODEL_COMPLETE')
-  .pipe(pluck('payload'))
-  .subscribe(
-    ({ modelLookup, hierarchyMap, modelIdByPath, sandboxItems, permissions }: FetchGuestModelCompletePayload) => {
-      Object.keys(modelIdByPath).forEach((path) => {
-        requestedPaths[path] = true;
-      });
-      const mhm = modelHierarchyMap;
-      // TODO: Must understand the differences when a model comes multiple times in the `hierarchyMap` coming from Host
-      //  parentId has been seen populated as part of a bigger request but null when model loaded in isolation
-      Object.keys(hierarchyMap).forEach((id) => {
-        if (mhm[id]) {
-          mhm[id].modelId = hierarchyMap[id].modelId;
-          mhm[id].parentId = mhm[id].parentId ?? hierarchyMap[id].parentId;
-          mhm[id].parentContainerFieldPath =
-            mhm[id].parentContainerFieldPath ?? hierarchyMap[id].parentContainerFieldPath;
-          mhm[id].parentContainerFieldIndex =
-            mhm[id].parentContainerFieldIndex ?? hierarchyMap[id].parentContainerFieldIndex;
-          mhm[id].children = mhm[id].children ?? hierarchyMap[id].children;
-        } else {
-          mhm[id] = hierarchyMap[id];
-        }
-      });
-      const nextModels: Record<string, ContentInstance> = { ...models$.value };
-      // Partial models (non-flattened references) can create instability.
-      // Take only those that seem complete and let the system fetch those that aren't.
-      Object.entries(modelLookup).forEach(([id, instance]) => {
-        if ((instance.craftercms.id || instance.craftercms.path) && instance.craftercms.contentTypeId) {
-          nextModels[id] = instance;
-        }
-      });
-      models$.next(nextModels);
-      paths$.next({ ...paths$.value, ...modelIdByPath });
-      items$.next({ ...items$.value, ...createLookupTable(sandboxItems, 'path') });
-      permissions$.next(permissions);
+fromTopic(fetchGuestModelComplete.type).subscribe((action: StandardAction<FetchGuestModelCompletePayload>) => {
+  const { modelLookup, hierarchyMap, modelIdByPath, sandboxItems, permissions } = action.payload;
+  Object.keys(modelIdByPath).forEach((path) => {
+    requestedPaths[path] = true;
+  });
+  const mhm = modelHierarchyMap;
+  // TODO: Must understand the differences when a model comes multiple times in the `hierarchyMap` coming from Host
+  //  parentId has been seen populated as part of a bigger request but null when model loaded in isolation
+  Object.keys(hierarchyMap).forEach((id) => {
+    if (mhm[id]) {
+      mhm[id].modelId = hierarchyMap[id].modelId;
+      mhm[id].parentId = mhm[id].parentId ?? hierarchyMap[id].parentId;
+      mhm[id].parentContainerFieldPath = mhm[id].parentContainerFieldPath ?? hierarchyMap[id].parentContainerFieldPath;
+      mhm[id].parentContainerFieldIndex =
+        mhm[id].parentContainerFieldIndex ?? hierarchyMap[id].parentContainerFieldIndex;
+      mhm[id].children = mhm[id].children ?? hierarchyMap[id].children;
+    } else {
+      mhm[id] = hierarchyMap[id];
     }
-  );
+  });
+  const nextModels: Record<string, ContentInstance> = { ...models$.value };
+  // Partial models (non-flattened references) can create instability.
+  // Take only those that seem complete and let the system fetch those that aren't.
+  Object.entries(modelLookup).forEach(([id, instance]) => {
+    if ((instance.craftercms.id || instance.craftercms.path) && instance.craftercms.contentTypeId) {
+      nextModels[id] = instance;
+    }
+  });
+  models$.next(nextModels);
+  paths$.next({ ...paths$.value, ...modelIdByPath });
+  items$.next({ ...items$.value, ...createLookupTable(sandboxItems, 'path') });
+  permissions$.next(permissions);
+});
 
 fromTopic(updateFieldValueOperationComplete.type)
   .pipe(pluck('payload'))

--- a/ui/guest/src/elementRegistry.ts
+++ b/ui/guest/src/elementRegistry.ts
@@ -378,7 +378,7 @@ export function getDragContextFromDropTargets(
   dropTargets: ICERecord[],
   validationsLookup?: LookupTable<LookupTable<ValidationResult>>,
   currentRecord?: ElementRecord
-): { dropZones: any; siblings: any; players: any; containers: any } {
+): { dropZones: DropZone[]; siblings: Element[]; players: Element[]; containers: Element[] } {
   const response = {
     dropZones: [],
     siblings: [],
@@ -391,7 +391,7 @@ export function getDragContextFromDropTargets(
     const dropZonesFiltered = currentRecord
       ? dropZones.filter((dropZone) => dropZone.children.includes(currentRecord.element))
       : null;
-    (dropZonesFiltered && dropZonesFiltered.length ? dropZonesFiltered : dropZones).forEach((dropZone) => {
+    (dropZonesFiltered?.length ? dropZonesFiltered : dropZones).forEach((dropZone) => {
       dropZone.origin = null;
       dropZone.origin = currentRecord ? dropZone.children.includes(currentRecord.element) : null;
       dropZone.validations = validationsLookup?.[id] ?? {};

--- a/ui/guest/src/react/ExperienceBuilder.tsx
+++ b/ui/guest/src/react/ExperienceBuilder.tsx
@@ -17,9 +17,16 @@
 import React, { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react';
 import $ from 'jquery';
 import { fromEvent, interval, merge } from 'rxjs';
-import { filter, pluck, take, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
+import { filter, take, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 import * as iceRegistry from '../iceRegistry';
-import { contentTypes$, FetchGuestModelCompletePayload, flushRequestedPaths, operations$ } from '../contentController';
+import {
+  contentTypes$,
+  flushRequestedPaths,
+  getCachedModels,
+  getCachedSandboxItems,
+  modelHierarchyMap,
+  operations$
+} from '../contentController';
 import * as elementRegistry from '../elementRegistry';
 import { GuestContextProvider, GuestReduxContext, useDispatch, useSelector } from './GuestContext';
 import CrafterCMSPortal from './CrafterCMSPortal';
@@ -54,6 +61,7 @@ import {
   contentTreeFieldSelected,
   contentTreeSwitchFieldInstance,
   contentTypeDropTargetsRequest,
+  fetchGuestModelComplete,
   guestCheckIn,
   guestCheckOut,
   highlightModeChanged,
@@ -74,7 +82,7 @@ import { GuestState } from '../store/models/GuestStore';
 import { nnou, nullOrUndefined } from '@craftercms/studio-ui/utils/object';
 import { scrollToDropTargets } from '../utils/dom';
 import { checkIfLockedOrModified, dragOk } from '../store/util';
-import { createLocationArgument } from '../utils/util';
+import { createLocationArgument, isEditActionAvailable } from '../utils/util';
 import FieldInstanceSwitcher from './FieldInstanceSwitcher';
 import LookupTable from '@craftercms/studio-ui/models/LookupTable';
 import { Snackbar, SnackbarProps, ThemeOptions, ThemeProvider } from '@mui/material';
@@ -93,7 +101,6 @@ import {
   dropzoneEnter,
   dropzoneLeave,
   setDropPosition,
-  setLockedItems,
   startListening
 } from '../store/actions';
 import DragGhostElement from './DragGhostElement';
@@ -110,7 +117,7 @@ import { setJwt } from '@craftercms/studio-ui/utils/auth';
 import { SHARED_WORKER_NAME } from '@craftercms/studio-ui/utils/constants';
 import useUnmount from '@craftercms/studio-ui/hooks/useUnmount';
 import { emitSystemEvent } from '@craftercms/studio-ui/state/actions/system';
-import StandardAction from '@craftercms/studio-ui/models/StandardAction';
+import { getParentModelId } from '../utils/ice';
 
 // TODO: add themeOptions and global styles customising
 interface BaseXBProps {
@@ -187,6 +194,16 @@ function ExperienceBuilderInternal(props: InternalGuestProps) {
           if (nullOrUndefined(record)) {
             console.error('[Guest] No record found for dispatcher element');
           } else {
+            if (
+              !isEditActionAvailable({
+                record,
+                models: getCachedModels(),
+                sandboxItemsByPath: getCachedSandboxItems(),
+                parentModelId: getParentModelId(record.modelId, getCachedModels(), modelHierarchyMap)
+              })
+            ) {
+              return false;
+            }
             if (refs.current.keysPressed.z && type === 'click') {
               return false;
             }
@@ -413,6 +430,7 @@ function ExperienceBuilderInternal(props: InternalGuestProps) {
           dispatch({ type });
           break;
         // region actions whitelisted
+        case fetchGuestModelComplete.type:
         case componentInstanceDragStarted.type:
         case clearHighlightedDropTargets.type:
         case desktopAssetUploadProgress.type:
@@ -494,20 +512,14 @@ function ExperienceBuilderInternal(props: InternalGuestProps) {
 
     refs.current.hasChanges = false;
 
-    fromTopic('FETCH_GUEST_MODEL_COMPLETE')
+    fromTopic(fetchGuestModelComplete.type)
       .pipe(
-        // Collect locked items to update locked lookup table on state...
-        tap(({ payload }: StandardAction<FetchGuestModelCompletePayload>) => {
-          const locked = payload.sandboxItems.filter((item) => item.stateMap.locked);
-          locked.length && dispatch(setLockedItems(locked));
-        }),
         filter(({ payload }) => payload.path === path),
-        pluck('payload', 'model'),
         withLatestFrom(contentTypes$),
         take(1)
       )
-      .subscribe(([model]) => {
-        iceId = iceRegistry.register({ modelId: model.craftercms.id });
+      .subscribe(([action]) => {
+        iceId = iceRegistry.register({ modelId: action.payload.model.craftercms.id });
         refs.current.contentReady = true;
         dispatch(contentReady());
       });
@@ -635,7 +647,7 @@ function ExperienceBuilderInternal(props: InternalGuestProps) {
               const hasValidations = Boolean(validations.length);
               const hasFailedRequired = validations.some(({ level }) => level === 'required');
               const elementRecord = elementRegistry.get(highlight.id);
-              const { isLocked, isExternallyModified } = checkIfLockedOrModified(state, elementRecord);
+              const { isLocked, isExternallyModified, path } = checkIfLockedOrModified(state, elementRecord);
               return (
                 <ZoneMarker
                   key={highlight.id}

--- a/ui/guest/src/store/epics/root.ts
+++ b/ui/guest/src/store/epics/root.ts
@@ -101,6 +101,7 @@ import { uploadDataUrl } from '@craftercms/studio-ui/services/content';
 import { getRequestForgeryToken } from '@craftercms/studio-ui/utils/auth';
 import { ensureSingleSlash } from '@craftercms/studio-ui/utils/string';
 import { getInheritanceParentIdsForField } from '@craftercms/studio-ui/utils/content';
+import { SearchItem } from '@craftercms/studio-ui/models';
 
 const createReader$ = (file: File) =>
   new Observable((subscriber: Subscriber<ProgressEvent<FileReader>>) => {
@@ -125,8 +126,7 @@ const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
     action$.pipe(
       ofType('mouseover', 'mouseleave'),
       withLatestFrom(state$),
-      filter((args) => args[1].status === EditingStatus.LISTENING),
-      tap(([action]) => action.payload.event.stopPropagation()),
+      tap(([action, state]) => state.status === EditingStatus.LISTENING && action.payload.event.stopPropagation()),
       ignoreElements()
     ),
   // endregion
@@ -260,7 +260,7 @@ const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
                         record.modelId,
                         record.fieldId,
                         record.index,
-                        dragContext.dragged.path
+                        (dragContext.dragged as SearchItem).path
                       );
                     }
                     break;
@@ -833,7 +833,7 @@ const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
       ofType(assetDragStarted.type),
       withLatestFrom(state$),
       switchMap(([, state]) => {
-        if (nullOrUndefined(state.dragContext.dragged.path)) {
+        if (nullOrUndefined((state.dragContext.dragged as SearchItem).path)) {
           console.error('No path found for this drag asset.');
         } else {
           return initializeDragSubjects(state$);

--- a/ui/guest/src/store/models/GuestStore.ts
+++ b/ui/guest/src/store/models/GuestStore.ts
@@ -24,6 +24,7 @@ import { ContentInstance } from '@craftercms/studio-ui/models/ContentInstance';
 import { EditingStatus } from '../../constants';
 import { RteConfig } from '../../models/Rte';
 import Person from '@craftercms/studio-ui/models/Person';
+import { SearchItem } from '@craftercms/studio-ui/models';
 
 interface T {
   [K: string]: any;
@@ -34,21 +35,21 @@ export interface GuestState {
   dragContext: {
     targetIndex: number;
     inZone: boolean;
-    invalidDrop: boolean;
-    dropZone: DropZone;
+    invalidDrop?: boolean;
+    dropZone?: DropZone;
     players: any[];
     siblings: any[];
     containers: any[];
-    over: any;
-    prev: any;
-    next: any;
-    coordinates: any;
+    over?: any;
+    prev?: any;
+    next?: any;
+    coordinates?: any;
     // TODO: Dragged seems to be an ICE record, but there's code looking for dragged.path
-    dragged: ICERecord & { path?: string };
+    dragged: ICERecord | DataTransferItem | SearchItem;
     dropZones: DropZone[];
-    scrolling: boolean;
-    contentType: ContentType;
-    instance: ContentInstance;
+    scrolling?: boolean;
+    contentType?: ContentType;
+    instance?: ContentInstance;
   };
   hostCheckedIn: boolean;
   status: EditingStatus;
@@ -60,7 +61,9 @@ export interface GuestState {
   draggable: T;
   highlighted: T;
   uploading: LookupTable;
-  models: LookupTable<ContentInstance>;
+  // TODO: Move items and instances to state and out of content controller.
+  // models: LookupTable<ContentInstance>;
+  // itemsByPath: LookupTable<SandboxItem>;
   lockedPaths: LookupTable<{ user: Person }>;
   externallyModifiedPaths: LookupTable<{ user: Person }>;
   contentTypes: LookupTable<ContentType>;

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -25,13 +25,24 @@ import {
   getSiblingRects
 } from '../../elementRegistry';
 import { checkIfLockedOrModified, dragOk } from '../util';
-import * as iceRegistry from '../../iceRegistry';
-import { findChildRecord, getById, getReferentialEntries } from '../../iceRegistry';
+import {
+  exists,
+  findChildRecord,
+  getById,
+  getContentTypeDropTargets,
+  getMediaDropTargets,
+  getMovableParentRecord,
+  getRecordDropTargets,
+  getReferentialEntries,
+  isMovable,
+  runDropTargetsValidations,
+  runValidation
+} from '../../iceRegistry';
 import { Reducer } from '@reduxjs/toolkit';
 import { GuestStandardAction } from '../models/GuestStandardAction';
 import { ElementRecord, ICERecord } from '../../models/InContextEditing';
 import { GuestState } from '../models/GuestStore';
-import { notNullOrUndefined, reversePluckProps } from '@craftercms/studio-ui/utils/object';
+import { notNullOrUndefined, nullOrUndefined, reversePluckProps } from '@craftercms/studio-ui/utils/object';
 import { updateDropZoneValidations } from '../../utils/dom';
 import { EditingStatus, HighlightMode } from '../../constants';
 import {
@@ -43,6 +54,7 @@ import {
   contentTreeFieldSelected,
   contentTreeSwitchFieldInstance,
   contentTypeDropTargetsRequest,
+  fetchGuestModelComplete,
   highlightModeChanged,
   hostCheckIn,
   setEditModePadding,
@@ -53,6 +65,10 @@ import {
   computedDragEnd,
   computedDragOver,
   desktopAssetDragStarted,
+  desktopAssetUploadComplete,
+  desktopAssetUploadFailed,
+  desktopAssetUploadProgress,
+  desktopAssetUploadStarted,
   dropzoneEnter,
   dropzoneLeave,
   editComponentInline,
@@ -63,16 +79,16 @@ import {
   setDropPosition,
   setEditingStatus,
   setEditMode,
-  startListening,
-  desktopAssetUploadComplete,
-  desktopAssetUploadProgress,
-  desktopAssetUploadStarted,
-  desktopAssetUploadFailed,
-  setLockedItems
+  setLockedItems,
+  startListening
 } from '../actions';
 import { ModelHierarchyMap } from '@craftercms/studio-ui/utils/content';
 import { contentEvent, lockContentEvent } from '@craftercms/studio-ui/state/actions/system';
 import { NotFunction, ReducerWithInitialState } from '@reduxjs/toolkit/src/createReducer';
+import StandardAction from '@craftercms/studio-ui/models/StandardAction';
+import { getParentModelId } from '../../utils/ice';
+import { getCachedModels, getCachedSandboxItems, modelHierarchyMap } from '../../contentController';
+import { isEditActionAvailable } from '../../utils/util';
 
 type CaseReducer<S = GuestState, A extends GuestStandardAction = GuestStandardAction> = Reducer<S, A>;
 
@@ -91,7 +107,8 @@ const initialState: GuestState = {
   highlightMode: HighlightMode.ALL,
   authoringBase: null,
   uploading: {},
-  models: {},
+  // models: {},
+  // itemsByPath: {},
   lockedPaths: {},
   externallyModifiedPaths: {},
   contentTypes: {},
@@ -122,6 +139,65 @@ const resetState: (state: GuestState) => GuestState = (state: GuestState) => ({
   dragContext: null
 });
 
+// Reducers for `desktopAssetDragStarted` & `assetDragStarted` are nearly identical. Refactored as one here.
+const reducerForAssetDragStarted: CaseReducer<
+  GuestState,
+  GuestStandardAction<
+    ReturnType<typeof desktopAssetDragStarted>['payload'] | ReturnType<typeof assetDragStarted>['payload']
+  >
+> = (state, action) => {
+  const { asset } = action.payload;
+  if (nullOrUndefined(asset)) {
+    return state;
+  }
+  let type: string;
+  const isFromDesktop = action.type === desktopAssetDragStarted.type;
+  const property: 'type' | 'mimeType' = isFromDesktop ? 'type' : 'mimeType';
+  if (asset[property].includes('image/')) {
+    type = 'image';
+  } else if (asset[property].includes('video/')) {
+    type = 'video-picker';
+  }
+  const dropTargets = getMediaDropTargets(type).filter((record) => {
+    if (
+      !isEditActionAvailable({
+        record,
+        models: getCachedModels(),
+        sandboxItemsByPath: getCachedSandboxItems(),
+        parentModelId: getParentModelId(record.modelId, getCachedModels(), modelHierarchyMap)
+      })
+    ) {
+      return false;
+    }
+    let { field: { validations = [] } = {} } = getReferentialEntries(record);
+    return Boolean(
+      isFromDesktop
+        ? validations['allowImageUpload'] || validations['allowVideoUpload']
+        : validations['allowImagesFromRepo'] || validations['allowVideosFromRepo']
+    );
+  });
+  const { players, containers, dropZones } = getDragContextFromDropTargets(dropTargets);
+  const highlighted = getHighlighted(dropZones);
+  return {
+    ...state,
+    highlighted,
+    status: isFromDesktop ? EditingStatus.UPLOAD_ASSET_FROM_DESKTOP : EditingStatus.PLACING_DETACHED_ASSET,
+    dragContext: {
+      players,
+      siblings: [],
+      dropZones,
+      containers,
+      inZone: false,
+      targetIndex: null,
+      dragged: asset
+    }
+  };
+};
+
+// TODO: Must figure out why these case reducers don't seem to have the Proxy object.
+//  Return statements and not mutating the state object is necessary.
+//  Is it because createReducer from redux-toolkit is not used?
+
 const reducer = createReducer(initialState, {
   // region dblclick
   dblclick: (state, { payload: { record } }) =>
@@ -142,7 +218,7 @@ const reducer = createReducer(initialState, {
     if (state.status === EditingStatus.LISTENING) {
       const { highlightMode } = state;
       const iceId = record.iceIds[0];
-      const movableRecordId = iceRegistry.getMovableParentRecord(iceId);
+      const movableRecordId = getMovableParentRecord(iceId);
       if (highlightMode === HighlightMode.ALL) {
         const highlight = getHoverData(record.id);
         if (notNullOrUndefined(movableRecordId)) {
@@ -192,8 +268,8 @@ const reducer = createReducer(initialState, {
     const { isLocked, isExternallyModified } = checkIfLockedOrModified(state, record);
     // Items that browser make draggable by default (images, etc) may not have an ice id
     if (!isLocked && !isExternallyModified && notNullOrUndefined(iceId)) {
-      const dropTargets = iceRegistry.getRecordDropTargets(iceId);
-      const validationsLookup = iceRegistry.runDropTargetsValidations(dropTargets);
+      const dropTargets = getRecordDropTargets(iceId);
+      const validationsLookup = runDropTargetsValidations(dropTargets);
       const { players, siblings, containers, dropZones } = getDragContextFromDropTargets(
         dropTargets,
         validationsLookup,
@@ -205,14 +281,13 @@ const reducer = createReducer(initialState, {
         highlighted,
         status: EditingStatus.SORTING_COMPONENT,
         dragContext: {
-          ...state.dragContext,
           players,
           siblings,
           dropZones,
           containers,
           inZone: false,
           targetIndex: null,
-          dragged: iceRegistry.getById(iceId)
+          dragged: getById(iceId)
         }
       };
     } else {
@@ -351,7 +426,7 @@ const reducer = createReducer(initialState, {
     }
 
     const maxCount = !currentDropZone.origin
-      ? iceRegistry.runValidation(currentDropZone.iceId as number, 'maxCount', [length])
+      ? runValidation(currentDropZone.iceId as number, 'maxCount', [length])
       : null;
 
     if (maxCount) {
@@ -391,7 +466,7 @@ const reducer = createReducer(initialState, {
       length = length - 1;
     }
 
-    const minCount = iceRegistry.runValidation(currentDropZone.iceId as number, 'minCount', [length]);
+    const minCount = runValidation(currentDropZone.iceId as number, 'minCount', [length]);
 
     if (minCount) {
       rest.minCount = minCount;
@@ -444,7 +519,7 @@ const reducer = createReducer(initialState, {
     const { contentTypeId } = action.payload;
     const highlighted = {};
 
-    iceRegistry.getContentTypeDropTargets(contentTypeId).forEach((item) => {
+    getContentTypeDropTargets(contentTypeId).forEach((item) => {
       let { elementRecordId } = compileDropZone(item.id);
       highlighted[elementRecordId] = getHoverData(elementRecordId);
     });
@@ -512,156 +587,93 @@ const reducer = createReducer(initialState, {
   // TODO: Not pure.
   [componentDragStarted.type]: (state, action) => {
     const { contentType } = action.payload;
-    if (notNullOrUndefined(contentType)) {
-      let dropTargets = iceRegistry.getContentTypeDropTargets(contentType, undefined, ['embedded', 'shared']);
-      const validationsLookup = iceRegistry.runDropTargetsValidations(dropTargets);
-      const { players, siblings, containers, dropZones } = getDragContextFromDropTargets(
-        dropTargets,
-        validationsLookup
-      );
-      const highlighted = getHighlighted(dropZones);
-      return {
-        ...state,
-        highlighted,
-        status: EditingStatus.PLACING_NEW_COMPONENT,
-        dragContext: {
-          ...state.dragContext,
-          players,
-          siblings,
-          dropZones,
-          containers,
-          contentType,
-          inZone: false,
-          targetIndex: null,
-          dragged: null
-        }
-      };
-    } else {
+    if (nullOrUndefined(contentType)) {
       return state;
     }
+    let dropTargets = getContentTypeDropTargets(contentType, undefined, ['embedded', 'shared']);
+    const validationsLookup = runDropTargetsValidations(dropTargets);
+    let { players, siblings, containers, dropZones } = getDragContextFromDropTargets(dropTargets, validationsLookup);
+    // TODO: Does filtering drop zones only enough? Verify siblings, containers, etc. don't need to be filtered as well.
+    dropZones = dropZones.filter((dz) => {
+      const iceRecord = getById(dz.iceId);
+      return isEditActionAvailable({
+        record: iceRecord,
+        models: getCachedModels(),
+        sandboxItemsByPath: getCachedSandboxItems(),
+        parentModelId: getParentModelId(iceRecord.modelId, getCachedModels(), modelHierarchyMap)
+      });
+    });
+    const highlighted = getHighlighted(dropZones);
+    return {
+      ...state,
+      highlighted,
+      status: EditingStatus.PLACING_NEW_COMPONENT,
+      dragContext: {
+        players,
+        siblings,
+        dropZones,
+        containers,
+        contentType,
+        inZone: false,
+        targetIndex: null,
+        dragged: null
+      }
+    };
   },
   // endregion
   // region componentInstanceDragStarted
   // TODO: Not pure.
   [componentInstanceDragStarted.type]: (state, action) => {
     const { instance, contentType } = action.payload;
-
-    if (notNullOrUndefined(instance)) {
-      const dropTargets = iceRegistry.getContentTypeDropTargets(
-        instance.craftercms.contentTypeId,
-        (record: ICERecord, hierarchyMap: ModelHierarchyMap) => {
-          const instanceId = instance.craftercms.id;
-          return hierarchyMap[record.modelId]?.children.includes(instanceId);
-        },
-        // This action type ensures we're working with existing 'shared' components
-        'sharedExisting'
-      );
-      const validationsLookup = iceRegistry.runDropTargetsValidations(dropTargets);
-      const { players, siblings, containers, dropZones } = getDragContextFromDropTargets(
-        dropTargets,
-        validationsLookup
-      );
-
-      const highlighted = getHighlighted(dropZones);
-
-      return {
-        ...state,
-        highlighted,
-        status: EditingStatus.PLACING_DETACHED_COMPONENT,
-        dragContext: {
-          ...state.dragContext,
-          players,
-          siblings,
-          dropZones,
-          containers,
-          instance,
-          contentType,
-          inZone: false,
-          targetIndex: null,
-          dragged: null
-        }
-      };
-    } else {
+    if (nullOrUndefined(instance)) {
       return state;
     }
+    const instanceId = instance.craftercms.id;
+    const dropTargets = getContentTypeDropTargets(
+      instance.craftercms.contentTypeId,
+      (record: ICERecord, hierarchyMap: ModelHierarchyMap) => {
+        return (
+          isEditActionAvailable({
+            record,
+            models: getCachedModels(),
+            sandboxItemsByPath: getCachedSandboxItems(),
+            parentModelId: getParentModelId(record.modelId, getCachedModels(), modelHierarchyMap)
+          }) && !hierarchyMap[record.modelId]?.children.includes(instanceId)
+        );
+      },
+      // This action type ensures we're working with existing 'shared' components
+      'sharedExisting'
+    );
+    const validationsLookup = runDropTargetsValidations(dropTargets);
+    const { players, siblings, containers, dropZones } = getDragContextFromDropTargets(dropTargets, validationsLookup);
+
+    const highlighted = getHighlighted(dropZones);
+
+    return {
+      ...state,
+      highlighted,
+      status: EditingStatus.PLACING_DETACHED_COMPONENT,
+      dragContext: {
+        players,
+        siblings,
+        dropZones,
+        containers,
+        instance,
+        contentType,
+        inZone: false,
+        targetIndex: null,
+        dragged: null
+      }
+    };
   },
   // endregion
   // region desktopAssetDragStarted
   // TODO: Not pure
-  [desktopAssetDragStarted.type]: (state, action) => {
-    const { asset } = action.payload;
-    if (notNullOrUndefined(asset)) {
-      let type;
-      if (asset.type.includes('image/')) {
-        type = 'image';
-      } else if (asset.type.includes('video/')) {
-        type = 'video-picker';
-      }
-
-      const dropTargets = iceRegistry.getMediaDropTargets(type).filter((record) => {
-        let { field: { validations = [] } = {} } = getReferentialEntries(record);
-        return Boolean(validations['allowImageUpload'] || validations['allowVideoUpload']);
-      });
-      const { players, containers, dropZones } = getDragContextFromDropTargets(dropTargets);
-      const highlighted = getHighlighted(dropZones);
-
-      return {
-        ...state,
-        highlighted,
-        status: EditingStatus.UPLOAD_ASSET_FROM_DESKTOP,
-        dragContext: {
-          ...state.dragContext,
-          players,
-          siblings: [],
-          dropZones,
-          containers,
-          inZone: false,
-          targetIndex: null,
-          dragged: asset
-        }
-      };
-    } else {
-      return state;
-    }
-  },
+  [desktopAssetDragStarted.type]: reducerForAssetDragStarted,
   // endregion
   // region assetDragStarted
   // TODO: Not pure
-  [assetDragStarted.type]: (state, action) => {
-    const { asset } = action.payload;
-    if (notNullOrUndefined(asset)) {
-      let type;
-      if (asset.mimeType.includes('image/')) {
-        type = 'image';
-      } else if (asset.mimeType.includes('video/')) {
-        type = 'video-picker';
-      }
-      const dropTargets = iceRegistry.getMediaDropTargets(type).filter((record) => {
-        let { field: { validations = [] } = {} } = getReferentialEntries(record);
-        return Boolean(validations['allowImagesFromRepo'] || validations['allowVideosFromRepo']);
-      });
-      const { players, containers, dropZones } = getDragContextFromDropTargets(dropTargets);
-      const highlighted = getHighlighted(dropZones);
-
-      return {
-        ...state,
-        highlighted,
-        status: EditingStatus.PLACING_DETACHED_ASSET,
-        dragContext: {
-          ...state.dragContext,
-          players,
-          siblings: [],
-          dropZones,
-          containers,
-          inZone: false,
-          targetIndex: null,
-          dragged: asset
-        }
-      };
-    } else {
-      return state;
-    }
-  },
+  [assetDragStarted.type]: reducerForAssetDragStarted,
   // endregion
   // region selectField
   [setEditingStatus.type]: (state, { payload }) => ({
@@ -673,7 +685,7 @@ const reducer = createReducer(initialState, {
   // TODO: Not pure
   [contentTreeFieldSelected.type]: (state, action) => {
     const { iceProps } = action.payload;
-    let iceId = iceRegistry.exists(iceProps);
+    let iceId = exists(iceProps);
     if (iceId === null) {
       return state;
     }
@@ -683,7 +695,7 @@ const reducer = createReducer(initialState, {
     if (iceRecord.recordType === 'component') {
       if (state.highlightMode === HighlightMode.MOVE_TARGETS) {
         // If in move mode, dynamically switch components to their movable item record so users can manipulate.
-        const movableRecordId = iceRegistry.getMovableParentRecord(iceId);
+        const movableRecordId = getMovableParentRecord(iceId);
         iceId = notNullOrUndefined(movableRecordId) ? movableRecordId : iceId;
       }
     } else if (iceRecord.recordType === 'repeat-item' || iceRecord.recordType === 'node-selector-item') {
@@ -704,7 +716,7 @@ const reducer = createReducer(initialState, {
     return {
       ...state,
       status: EditingStatus.FIELD_SELECTED,
-      draggable: iceRegistry.isMovable(iceId) ? { [registryEntries[0].id]: iceId } : {},
+      draggable: isMovable(iceId) ? { [registryEntries[0].id]: iceId } : {},
       highlighted: { [registryEntries[0].id]: highlight },
       fieldSwitcher:
         registryEntries.length > 1
@@ -726,7 +738,7 @@ const reducer = createReducer(initialState, {
     const highlight = getHoverData(state.fieldSwitcher.registryEntryIds[nextElem]);
     return {
       ...state,
-      draggable: iceRegistry.isMovable(state.fieldSwitcher.iceId) ? { [id]: state.fieldSwitcher.iceId } : {},
+      draggable: isMovable(state.fieldSwitcher.iceId) ? { [id]: state.fieldSwitcher.iceId } : {},
       highlighted: { [id]: highlight },
       fieldSwitcher: {
         ...state.fieldSwitcher,
@@ -769,28 +781,52 @@ const reducer = createReducer(initialState, {
     editModePadding: action.payload.editModePadding
   }),
   // endregion
-  // TODO: The below return statements shouldn't be necessary, but TypeScript is demanding them.
   // region contentEvent
   [contentEvent.type]: (state, { payload }) => {
     if (state.username !== payload.user.username) {
-      state.externallyModifiedPaths[payload.targetPath] = { user: payload.user };
+      return {
+        ...state,
+        externallyModifiedPaths: { ...state.externallyModifiedPaths, [payload.targetPath]: { user: payload.user } }
+      };
+    } else {
       return state;
     }
   },
   // endregion
   // region lockContentEvent
   [lockContentEvent.type]: (state, { payload }) => {
-    if (payload.locked) state.lockedPaths[payload.targetPath] = { user: payload.user };
-    else delete state.lockedPaths[payload.targetPath];
+    const nextState = { ...state, lockedPaths: { ...state.lockedPaths } };
+    if (payload.locked) {
+      nextState.lockedPaths[payload.targetPath] = { user: payload.user };
+    } else {
+      delete nextState.lockedPaths[payload.targetPath];
+    }
     return state;
   },
   // endregion
   // region setLockedItems
   [setLockedItems.type]: (state, { payload }) => {
+    const lockedPaths = { ...state.lockedPaths };
     payload.forEach((item) => {
-      state.lockedPaths[item.path] = { user: item.lockOwner };
+      lockedPaths[item.path] = { user: item.lockOwner };
     });
-    return state;
+    return { ...state, lockedPaths };
+  },
+  // endregion
+  // region fetchGuestModelComplete
+  [fetchGuestModelComplete.type]: (
+    state,
+    { payload }: StandardAction<ReturnType<typeof fetchGuestModelComplete>['payload']>
+  ) => {
+    const lockedPaths = { ...state.lockedPaths };
+    // const itemsByPath = { ...state.itemsByPath };
+    payload.sandboxItems.forEach((item) => {
+      if (item.stateMap.locked) {
+        lockedPaths[item.path] = { user: item.lockOwner };
+      }
+      // itemsByPath[item.path] = item;
+    });
+    return { ...state, lockedPaths /* , itemsByPath */ };
   }
   // endregion
 });

--- a/ui/guest/src/store/store.ts
+++ b/ui/guest/src/store/store.ts
@@ -51,15 +51,3 @@ export function createGuestStore(): GuestStore {
 }
 
 export default createGuestStore;
-
-export const state$ = new Observable((subscriber) => {
-  const store = createGuestStore();
-  return store.subscribe(() => {
-    const state = store.getState();
-    subscriber.next(state.models);
-  });
-}).pipe(share());
-
-export const models$ = state$.pipe(pluck('content'), distinctUntilChanged());
-
-export const contentTypes$ = state$.pipe(pluck('contentTypes'), distinctUntilChanged());

--- a/ui/guest/src/store/util.ts
+++ b/ui/guest/src/store/util.ts
@@ -31,6 +31,8 @@ import { GuestState } from './models/GuestStore';
 import { ElementRecord } from '../models/InContextEditing';
 import { getCachedModel, getCachedModels, modelHierarchyMap } from '../contentController';
 import { getParentModelId } from '../utils/ice';
+import { getReferentialEntries } from '../iceRegistry';
+import { extractCollectionItem } from '@craftercms/studio-ui/utils/model';
 
 export function dragOk(status): boolean {
   return [
@@ -101,8 +103,17 @@ export function beforeWrite$<T extends any = 'continue', S extends any = never>(
  * it uses to compute the result, so they can be used by consumer if needed.
  */
 export const checkIfLockedOrModified = (state: GuestState, record: ElementRecord) => {
-  const { modelId } = record;
-  const model = getCachedModel(modelId);
+  let { modelId, fieldId } = record;
+  // If the present record refers to a node selector item, we need to switch the model to that item of the collection.
+  // Otherwise, is just the model from the present record.
+  let model = getCachedModel(modelId);
+  if (fieldId.length > 0) {
+    const entries = getReferentialEntries(record.iceIds[0]);
+    if (entries.recordType === 'node-selector-item') {
+      model = getCachedModel(extractCollectionItem(model, fieldId[0], record.index));
+      modelId = model.craftercms.id;
+    }
+  }
   const parentModelId = model.craftercms.path ? null : getParentModelId(modelId, getCachedModels(), modelHierarchyMap);
   const parentModel = parentModelId ? getCachedModel(parentModelId) : null;
   const path = model.craftercms.path ?? parentModel.craftercms.path;

--- a/ui/guest/src/utils/util.ts
+++ b/ui/guest/src/utils/util.ts
@@ -14,8 +14,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ICERecord } from '../models/InContextEditing';
+import { ElementRecord, ICERecord } from '../models/InContextEditing';
 import { pluckProps } from '@craftercms/studio-ui/utils/object';
+import LookupTable from '@craftercms/studio-ui/src/models/LookupTable';
+import { ContentInstance, SandboxItem } from '@craftercms/studio-ui/models';
 
 export const foo = (...args: any[]) => void null;
 export const //
@@ -49,4 +51,22 @@ export function createLocationArgument() {
     'protocol',
     'search'
   );
+}
+
+export function isEditActionAvailable(args: {
+  record: ElementRecord | ICERecord;
+  models: LookupTable<ContentInstance>;
+  sandboxItemsByPath: LookupTable<SandboxItem>;
+  parentModelId: string | null;
+}): boolean {
+  const { record, models, sandboxItemsByPath, parentModelId } = args;
+  const model = models[record.modelId];
+  let path = model.craftercms.path;
+  if (!path) {
+    path = models[parentModelId].craftercms.path;
+  }
+  if (!path) {
+    console.error('* * * * *\nNo path found. Check.\n* * * * *', record, models);
+  }
+  return sandboxItemsByPath[path].availableActionsMap.edit;
 }

--- a/ui/guest/src/utils/util.ts
+++ b/ui/guest/src/utils/util.ts
@@ -65,8 +65,5 @@ export function isEditActionAvailable(args: {
   if (!path) {
     path = models[parentModelId].craftercms.path;
   }
-  if (!path) {
-    console.error('* * * * *\nNo path found. Check.\n* * * * *', record, models);
-  }
-  return sandboxItemsByPath[path].availableActionsMap.edit;
+  return sandboxItemsByPath[path]?.availableActionsMap.edit;
 }

--- a/ui/legacy/src/components/cstudio-forms/data-sources/components.js
+++ b/ui/legacy/src/components/cstudio-forms/data-sources/components.js
@@ -255,17 +255,19 @@
     },
 
     _editShared(key, control, datasource, index, callback) {
-      const readonly = control.readonly;
-      const action = readonly ? CStudioAuthoring.Operations.viewContent : CStudioAuthoring.Operations.editContent;
-
-      CStudioAuthoring.Service.lookupContentItem(CStudioAuthoringContext.site, key, {
-        success: function (contentTO) {
+      craftercms.services.content.fetchSandboxItem(CStudioAuthoringContext.site, key).subscribe({
+        next(sandboxItem) {
+          const readonly = control.readonly;
+          const action =
+            readonly || !sandboxItem.availableActionsMap.edit
+              ? CStudioAuthoring.Operations.viewContent
+              : CStudioAuthoring.Operations.editContent;
           action(
-            contentTO.item.contentType,
+            sandboxItem.contentTypeId,
             CStudioAuthoringContext.siteId,
-            contentTO.item.mimeType,
-            contentTO.item.nodeRef,
-            contentTO.item.uri,
+            sandboxItem.mimeType,
+            null,
+            sandboxItem.path,
             false,
             {
               success: function (contentTO, editorId, name, value, draft, action) {
@@ -286,7 +288,7 @@
             }
           );
         },
-        failure: function () {}
+        error() {}
       });
     },
 


### PR DESCRIPTION
craftersoftware/craftercms#911

- Fix issue where XB edit mode is blocked for pages that are readonly to the user, but contain items that the usere does have write access to.
- Fix issue where the item selector items to which the user doesn't have edit permissions, display the edit button. Clicking the edit button and trying to save an edit crashes the form leaving it in an unusable.
- Adding a tree navigator with the path of the folder of a page shows an item which clicking it doesn't take the user to preview as expected and clicking to open the item menu shows a skeletonised item menu that never resolves.
- Fix issue where the TreeNavigator UI doesn't handle error in the service response and displays a spinner that doesn't go away.
