### PR TITLE
[6888] processPathMacros function crashes when supplied with a null path

### DIFF
--- a/ui/app/src/utils/path.ts
+++ b/ui/app/src/utils/path.ts
@@ -300,6 +300,8 @@ export function processPathMacros(dependencies: {
   fullParentPath?: string;
 }): string {
   let { path, objectId, objectGroupId, useUUID, fullParentPath } = dependencies;
+  if (!path) return path;
+
   let processedPath = path;
 
   // Remove unrecognized macros.


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6888