### PR TITLE
[4.1.x][6705] Update pathMacros regex to handle anything between {} as macros 

### DIFF
--- a/ui/app/src/utils/path.ts
+++ b/ui/app/src/utils/path.ts
@@ -313,7 +313,7 @@ export function processPathMacros(dependencies: {
   let processedPath = path;
 
   // Remove unrecognized macros.
-  const pathMacros = processedPath.match(/\{([^{}]+)}/g) ?? [];
+  const pathMacros = processedPath.match(/\{(.+)}}/g) ?? [];
   pathMacros.forEach((macro) => {
     if (!availableMacrosRegex.test(macro)) {
       processedPath = processedPath.replace(macro, '');


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6705