### PR TITLE
[7079] Avoid decoding entities on the ace code editor RTE plugin to avoid undesired Tiny markup transformations when cleansing markup

### DIFF
--- a/static-assets/js/tinymce-plugins/ace/plugin.js
+++ b/static-assets/js/tinymce-plugins/ace/plugin.js
@@ -82,7 +82,7 @@
       if (!isActive) {
         // Code mode
         editor.mode.set('readonly');
-        editorTextareaEl.value = editor.dom.decode(getContent(editor));
+        editorTextareaEl.value = getContent(editor);
         editorTextareaEl.style.height = editor.getDoc().documentElement.scrollHeight;
 
         if (typeof ace !== 'undefined') {
@@ -128,8 +128,9 @@
             maxLines: Math.round(300 / 17)
           });
           aceEditor.on('change', function () {
-            editorTextareaEl.value = aceEditor.getValue();
-            editor.setContent(aceEditor.getValue());
+            let value = aceEditor.getValue();
+            editorTextareaEl.value = value;
+            editor.setContent(value);
           });
 
           editor.container.classList.add('hidden');
@@ -192,8 +193,9 @@
 
       const editorTextareaEl = document.querySelector(`#${CSS.escape(editor.id)}`);
       aceEditor.on('change', function () {
-        editorTextareaEl.value = aceEditor.getValue();
-        editor.setContent(aceEditor.getValue());
+        let value = aceEditor.getValue();
+        editorTextareaEl.value = value;
+        editor.setContent(value);
 
         if (inlineMode) {
           aceModes.inline.getSession().setValue(aceEditor.getValue());

--- a/ui/app/src/CHANGELOG.md
+++ b/ui/app/src/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Remove legacy `browseCMIS` dialog and `openCMISBrowse` function from common-api.
 * Remove `CMIS-repo`, `CMIS-upload`, `img-cmis-repo`, `img-CMIS-upload`, `video-cmis-repo` and `video-CMIS-upload` datasources. 
 * `ICEConfig` TypeScript `interface` changed to be `type`. It now accepts either the (model) or (modelId & path).
+* The `acecode` TinyMCE plugin (for code-highlighted Rich Text Editor code editing), renders the code exactly as Tiny provides without decoding entities.
 
 ## 4.1.5
 * [common-api.js]


### PR DESCRIPTION
craftercms/craftercms#7079