### PR TITLE
[7176] Fix beforeunload event listener not removed correctly

### DIFF
--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -245,7 +245,7 @@ export function initTinyMCE(
           record.element.classList.add(emptyFieldClass);
         }
 
-        window.removeEventListener('beforeunload', beforeUnloadFn);
+        window.removeEventListener('beforeunload', beforeUnloadFn, { capture: true });
 
         // The timeout prevents clicking the edit menu to be shown when clicking out of an RTE
         // with the intention to exit editing.


### PR DESCRIPTION
craftercms/craftercms#7176

Safe for 4.2