### PR TITLE
Attempt to address underscore not displayed on Linux by bumping font size

### DIFF
--- a/ui/app/src/components/AceEditor/AceEditor.tsx
+++ b/ui/app/src/components/AceEditor/AceEditor.tsx
@@ -254,7 +254,7 @@ function AceEditorComp(props: AceEditorProps, ref: MutableRef<AceAjax.Editor>) {
             // @ts-ignore - Ace types are incorrect; they don't implement the constructor that receives options.
             aceEditor = ace.edit(pre, refs.current.options);
             aceEditor.setOptions({
-              fontSize: '14px',
+              fontSize: '15px',
               fontFamily: "'Monaco', 'Menlo', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace"
             });
             autoFocus && aceEditor.focus();


### PR DESCRIPTION
craftercms/craftercms#7210 - Previously bumped from default (12) to 14. 14 creates the issue. 
craftercms/craftercms#7401 - Both 13 and 15 seem to fix via dev tools update; testing 15 (greater size preferred per 7210).
