### PR TITLE
[7406] Pages search ahead not showing the results in Preview address bar

### DIFF
--- a/ui/app/src/components/PagesSearchAhead/PagesSearchAhead.tsx
+++ b/ui/app/src/components/PagesSearchAhead/PagesSearchAhead.tsx
@@ -70,7 +70,8 @@ const useStyles = makeStyles()((theme: Theme) => ({
     width: 400,
     position: 'absolute',
     right: '-52px',
-    top: '50px'
+    top: '50px',
+    zIndex: theme.zIndex.drawer + 2
   },
   listBox: {
     overflow: 'auto',


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7406