### PR TITLE
[7437] XB - Paste action in textarea fields in XB replaces current content 

### DIFF
--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -348,7 +348,8 @@ export function initTinyMCE(
           // Doing this immediately (without the timeout) causes the content to be duplicated.
           // TinyMCE seems to be doing something internally that causes this.
           setTimeout(() => {
-            replaceLineBreaksIfApplicable(text);
+            const newContent = editor.getContent({ format: 'html' });
+            replaceLineBreaksIfApplicable(newContent);
             editor.selection.select(editor.getBody(), true);
             editor.selection.collapse(false);
           }, 10);

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -348,7 +348,7 @@ export function initTinyMCE(
           // Doing this immediately (without the timeout) causes the content to be duplicated.
           // TinyMCE seems to be doing something internally that causes this.
           setTimeout(() => {
-            const newContent = editor.getContent({ format: 'html' });
+            const newContent = getContent();
             replaceLineBreaksIfApplicable(newContent);
             editor.selection.select(editor.getBody(), true);
             editor.selection.collapse(false);

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -349,9 +349,11 @@ export function initTinyMCE(
           // TinyMCE seems to be doing something internally that causes this.
           setTimeout(() => {
             const newContent = getContent();
-            replaceLineBreaksIfApplicable(newContent);
-            editor.selection.select(editor.getBody(), true);
-            editor.selection.collapse(false);
+            if (newContent.includes('\n')) {
+              replaceLineBreaksIfApplicable(newContent);
+              editor.selection.select(editor.getBody(), true);
+              editor.selection.collapse(false);
+            }
           }, 10);
         }
         // TODO: It'd be great to be able to select the piece of the pasted content that falls out of the max-length.


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7437