### PR TITLE
[4207] Fix RTE toolbar/YUI dialog z-index issue

### DIFF
--- a/static-assets/themes/cstudioTheme/css/forms-default.css
+++ b/static-assets/themes/cstudioTheme/css/forms-default.css
@@ -1388,6 +1388,10 @@ body.yui-skin-cstudioTheme.masked {
   overflow: hidden;
 }
 
+.masked .tox .tox-editor-header {
+  z-index: inherit;
+}
+
 /* Long File Name in Image Picker */
 .image-picker-control .cstudio-form-field-title {
   float: none;


### PR DESCRIPTION
Temporarily drop RTE toolbar z-index while a YUI dialog is shown via `.masked` class

https://github.com/craftercms/craftercms/issues/7447