### PR TITLE
[7463] Fix reading async language bundles correctly according vite's bundling the JSON files as modules

### DIFF
--- a/ui/app/src/utils/i18n.ts
+++ b/ui/app/src/utils/i18n.ts
@@ -61,7 +61,7 @@ async function fetchLocale(locale: string): Promise<LookupTable<string>> {
       translations = Promise.resolve({});
       break;
   }
-  return translations;
+  return translations.default ?? translations;
 }
 
 async function createIntlInstance(localeCode: string): Promise<IntlShape> {


### PR DESCRIPTION
craftercms/craftercms#7463