### PR TITLE
[7619] React "key" prop missing on ZoneMarker allowedTypesMeta listing

### DIFF
--- a/ui/guest/src/react/ZoneMarker.tsx
+++ b/ui/guest/src/react/ZoneMarker.tsx
@@ -187,6 +187,7 @@ export function ZoneMarker(props: ZoneMarkerProps) {
                     );
                     return (
                       <UltraStyledTooltip
+                        key={id}
                         arrow
                         // TODO: i18n
                         title={`Drop target compatible with "${type?.name}" as ${Object.keys(modes)


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7619