### PR TITLE
[7688] Fix Project Tools not rendering when opening from the Launcher

### DIFF
--- a/ui/app/src/components/PreviewSimulatorPanel/PreviewSimulatorPanel.tsx
+++ b/ui/app/src/components/PreviewSimulatorPanel/PreviewSimulatorPanel.tsx
@@ -262,7 +262,7 @@ export function PreviewSimulatorPanel(props: any) {
               key={device.value}
               value={device.value}
               control={<Radio />}
-              label={formatMessage(getTranslation(device.title, translations))}
+              label={getTranslation(device.title, translations, formatMessage)}
             />
           ))}
         </RadioGroup>

--- a/ui/app/src/components/SiteConfigurationManagement/SiteConfigurationManagement.tsx
+++ b/ui/app/src/components/SiteConfigurationManagement/SiteConfigurationManagement.tsx
@@ -84,12 +84,11 @@ interface SiteConfigurationManagementProps {
   embedded?: boolean;
   showAppsButton?: boolean;
   isSubmitting?: boolean;
-  mountMode?: 'page' | 'dialog';
   onSubmittingAndOrPendingChange?(value: onSubmittingAndOrPendingChangeProps): void;
 }
 
 export function SiteConfigurationManagement(props: SiteConfigurationManagementProps) {
-  const { embedded, showAppsButton, onSubmittingAndOrPendingChange, isSubmitting, mountMode } = props;
+  const { embedded, showAppsButton, onSubmittingAndOrPendingChange, isSubmitting } = props;
   const site = useActiveSiteId();
   const { username } = useActiveUser();
   const sessionStorageKey = `craftercms.${username}.projectToolsConfigurationData.${site}`;

--- a/ui/app/src/components/SiteConfigurationManagement/SiteConfigurationManagement.tsx
+++ b/ui/app/src/components/SiteConfigurationManagement/SiteConfigurationManagement.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { fetchActiveEnvironment } from '../../services/environment';
 import { fetchConfigurationXML, fetchSiteConfigurationFiles, writeConfiguration } from '../../services/configuration';
 import { SiteConfigurationFileWithId } from '../../models/SiteConfigurationFile';
@@ -76,9 +76,9 @@ import { MaxLengthCircularProgress } from '../MaxLengthCircularProgress';
 import useUnmount from '../../hooks/useUnmount';
 import useActiveUser from '../../hooks/useActiveUser';
 import { createCustomDocumentEventListener } from '../../utils/dom';
-import { useNavigate } from 'react-router';
 import { ProjectToolsRoutes } from '../../env/routes';
 import ListItemButton from '@mui/material/ListItemButton';
+import { SiteToolsContext } from '../SiteTools/siteToolsContext';
 
 interface SiteConfigurationManagementProps {
   embedded?: boolean;
@@ -101,6 +101,7 @@ export function SiteConfigurationManagement(props: SiteConfigurationManagementPr
   const [selectedConfigFile, setSelectedConfigFile] = useState<SiteConfigurationFileWithId>(
     () => JSON.parse(sessionStorage.getItem(sessionStorageKey))?.selectedConfigFile ?? null
   );
+  const [changesRecoveredOnMount] = useState<boolean>(() => selectedConfigFile !== null);
   const ignoreEnv = selectedConfigFile?.path === 'site-policy-config.xml';
   const [selectedConfigFileXml, setSelectedConfigFileXml] = useState(null);
   const [configError, setConfigError] = useState(null);
@@ -117,9 +118,11 @@ export function SiteConfigurationManagement(props: SiteConfigurationManagementPr
   const [confirmDialogProps, setConfirmDialogProps] = useState<ConfirmDialogProps>(null);
   const [keyword, setKeyword] = useState('');
   const dispatch = useDispatch();
+  const setTool = useContext(SiteToolsContext)?.setTool;
   const refs = useUpdateRefs({
     disabledSaveButton,
-    selectedConfigFile
+    selectedConfigFile,
+    setTool
   });
   const functionRefs = useUpdateRefs({
     onSubmittingAndOrPendingChange
@@ -128,9 +131,16 @@ export function SiteConfigurationManagement(props: SiteConfigurationManagementPr
     container: null
   });
   const [contentSize, setContentSize] = useState(0);
-  const navigate = useNavigate();
 
   useMount(() => {
+    if (changesRecoveredOnMount) {
+      dispatch(
+        showSystemNotification({
+          message: formatMessage({ defaultMessage: 'Unsaved changes were restored on to the editor.' }),
+          options: { variant: 'info' }
+        })
+      );
+    }
     fetchActiveEnvironment().subscribe({
       next(env) {
         setEnvironment(env);
@@ -142,7 +152,7 @@ export function SiteConfigurationManagement(props: SiteConfigurationManagementPr
   });
 
   useUnmount(() => {
-    if (!refs.current.disabledSaveButton && mountMode === 'page') {
+    if (!refs.current.disabledSaveButton) {
       sessionStorage.setItem(
         sessionStorageKey,
         JSON.stringify({
@@ -151,22 +161,37 @@ export function SiteConfigurationManagement(props: SiteConfigurationManagementPr
         })
       );
       const eventId = 'unsavedConfigurationChangesConfirmation';
-      dispatch(
-        showConfirmDialog({
-          body: <FormattedMessage defaultMessage="You left unsaved changes. Go back and continue editing?" />,
-          onCancel: batchActions([closeConfirmDialog(), dispatchDOMEvent({ id: eventId, button: 'cancel' })]),
-          onOk: batchActions([closeConfirmDialog(), dispatchDOMEvent({ id: eventId, button: 'ok' })]),
-          okButtonText: <FormattedMessage defaultMessage="Continue editing" />,
-          cancelButtonText: <FormattedMessage defaultMessage="Discard changes" />
-        })
-      );
-      createCustomDocumentEventListener<{ button: 'ok' | 'cancel' }>(eventId, ({ button }) => {
-        if (button === 'ok') {
-          navigate(ProjectToolsRoutes.Configuration);
-        } else {
-          sessionStorage.removeItem(sessionStorageKey);
-        }
-      });
+      const title = getTranslation(refs.current.selectedConfigFile.title, translations, formatMessage);
+      if (refs.current.setTool) {
+        dispatch(
+          showConfirmDialog({
+            body: formatMessage({ defaultMessage: 'You left unsaved changes on "{title}"' }, { title }),
+            onCancel: batchActions([closeConfirmDialog(), dispatchDOMEvent({ id: eventId, button: 'cancel' })]),
+            onOk: batchActions([closeConfirmDialog(), dispatchDOMEvent({ id: eventId, button: 'ok' })]),
+            okButtonText: <FormattedMessage defaultMessage="Go back and recover changes" />,
+            cancelButtonText: <FormattedMessage defaultMessage="Discard changes" />
+          })
+        );
+        createCustomDocumentEventListener<{ button: 'ok' | 'cancel' }>(eventId, ({ button }) => {
+          if (button === 'ok') {
+            refs.current.setTool(ProjectToolsRoutes.Configuration);
+          } else {
+            sessionStorage.removeItem(sessionStorageKey);
+          }
+        });
+      } else {
+        dispatch(
+          showConfirmDialog({
+            body: formatMessage(
+              {
+                defaultMessage:
+                  'You left unsaved changes on "{title}". You may go back to configuration now if you wish to recover or ignore to discard changes.'
+              },
+              { title }
+            )
+          })
+        );
+      }
     }
   });
 
@@ -186,34 +211,35 @@ export function SiteConfigurationManagement(props: SiteConfigurationManagementPr
   useEffect(() => {
     if (selectedConfigFile && environment) {
       setConfigError(null);
-      fetchConfigurationXML(
-        site,
-        selectedConfigFile.path,
-        selectedConfigFile.module,
-        ignoreEnv ? null : environment
-      ).subscribe({
-        next(xml) {
-          const sessionData = JSON.parse(sessionStorage.getItem(sessionStorageKey));
-          if (sessionData?.content) {
-            setSelectedConfigFileXml(sessionData.content);
-            setContentSize(sessionData.content.length);
-            setDisabledSaveButton(false);
-            sessionStorage.removeItem(sessionStorageKey);
-          } else {
+      const sessionData = JSON.parse(sessionStorage.getItem(sessionStorageKey));
+      if (sessionData?.content) {
+        setSelectedConfigFileXml(sessionData.content);
+        setContentSize(sessionData.content.length);
+        setDisabledSaveButton(false);
+        sessionStorage.removeItem(sessionStorageKey);
+        setLoadingXml(false);
+      } else {
+        fetchConfigurationXML(
+          site,
+          selectedConfigFile.path,
+          selectedConfigFile.module,
+          ignoreEnv ? null : environment
+        ).subscribe({
+          next(xml) {
             setSelectedConfigFileXml(xml ?? '');
             setContentSize(xml?.length ?? 0);
+            setLoadingXml(false);
+          },
+          error({ response }) {
+            if (response.response.code === 7000) {
+              setSelectedConfigFileXml('');
+            } else {
+              setConfigError(response.response);
+            }
+            setLoadingXml(false);
           }
-          setLoadingXml(false);
-        },
-        error({ response }) {
-          if (response.response.code === 7000) {
-            setSelectedConfigFileXml('');
-          } else {
-            setConfigError(response.response);
-          }
-          setLoadingXml(false);
-        }
-      });
+        });
+      }
     }
   }, [selectedConfigFile, environment, site, ignoreEnv, refs, sessionStorageKey]);
 

--- a/ui/app/src/components/SiteTools/EmbeddedSiteTools/EmbeddedSiteTools.tsx
+++ b/ui/app/src/components/SiteTools/EmbeddedSiteTools/EmbeddedSiteTools.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { GlobalAppContextProvider, useGlobalAppState } from '../../GlobalApp';
 import useReference from '../../../hooks/useReference';
 import { useActiveSiteId } from '../../../hooks/useActiveSiteId';
@@ -23,6 +23,7 @@ import { embeddedStyles } from '../styles';
 import { onSubmittingAndOrPendingChangeProps } from '../../../hooks/useEnhancedDialogState';
 import { useDispatch } from 'react-redux';
 import { updateWidgetDialog } from '../../../state/actions/dialogs';
+import { SiteToolsContext, SiteToolsContextProps } from '../siteToolsContext';
 
 interface EmbeddedSiteToolsProps {
   onMinimize?: () => void;
@@ -38,6 +39,10 @@ export const EmbeddedSiteToolsContainer = (props: EmbeddedSiteToolsProps) => {
   const site = useActiveSiteId();
   const { classes } = embeddedStyles();
   const dispatch = useDispatch();
+  const contextValue = useMemo<SiteToolsContextProps>(
+    () => ({ setTool: (id) => setActiveToolId(id.replace(/^\//, '')), activeToolId }),
+    [activeToolId]
+  );
 
   const onNavItemClick = (id: string) => {
     setActiveToolId(id);
@@ -50,31 +55,33 @@ export const EmbeddedSiteToolsContainer = (props: EmbeddedSiteToolsProps) => {
     });
 
   return (
-    <SiteTools
-      site={site}
-      sidebarWidth={width}
-      onWidthChange={setWidth}
-      onNavItemClick={onNavItemClick}
-      sidebarBelowToolbar
-      hideSidebarLogo
-      showAppsButton={false}
-      hideSidebarSiteSwitcher
-      activeToolId={activeToolId}
-      openSidebar={openSidebar || !activeToolId}
-      tools={tools}
-      classes={{
-        root: classes.root
-      }}
-      onSubmittingAndOrPendingChange={onSubmittingAndOrPendingChange}
-      onMinimize={() => {
-        if (props.onMinimize) {
-          props.onMinimize();
-        } else {
-          dispatch(updateWidgetDialog({ isMinimized: true }));
-        }
-      }}
-      mountMode="dialog"
-    />
+    <SiteToolsContext.Provider value={contextValue}>
+      <SiteTools
+        site={site}
+        sidebarWidth={width}
+        onWidthChange={setWidth}
+        onNavItemClick={onNavItemClick}
+        sidebarBelowToolbar
+        hideSidebarLogo
+        showAppsButton={false}
+        hideSidebarSiteSwitcher
+        activeToolId={activeToolId}
+        openSidebar={openSidebar || !activeToolId}
+        tools={tools}
+        classes={{
+          root: classes.root
+        }}
+        onSubmittingAndOrPendingChange={onSubmittingAndOrPendingChange}
+        onMinimize={() => {
+          if (props.onMinimize) {
+            props.onMinimize();
+          } else {
+            dispatch(updateWidgetDialog({ isMinimized: true }));
+          }
+        }}
+        mountMode="dialog"
+      />
+    </SiteToolsContext.Provider>
   );
 };
 

--- a/ui/app/src/components/SiteTools/UrlDrivenSiteTools/UrlDrivenSiteTools.tsx
+++ b/ui/app/src/components/SiteTools/UrlDrivenSiteTools/UrlDrivenSiteTools.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useGlobalAppState } from '../../GlobalApp';
 import useReference from '../../../hooks/useReference';
 import useActiveSiteId from '../../../hooks/useActiveSiteId';
@@ -22,6 +22,7 @@ import useEnv from '../../../hooks/useEnv';
 import SiteTools, { Tool } from '../SiteTools';
 import { getSystemLink } from '../../../utils/system';
 import { useLocation, useNavigate } from 'react-router';
+import { SiteToolsContext, SiteToolsContextProps } from '../siteToolsContext';
 
 interface UrlDrivenSiteToolsProps {
   footerHtml: string;
@@ -36,14 +37,18 @@ export function UrlDrivenSiteTools(props: UrlDrivenSiteToolsProps) {
   const tools: Tool[] = useReference('craftercms.siteTools')?.tools;
   const site = useActiveSiteId();
   const { authoringBase } = useEnv();
-  const push = useNavigate();
+  const navigate = useNavigate();
+  const contextValue = useMemo<SiteToolsContextProps>(
+    () => ({ setTool: (id) => navigate(id), activeToolId }),
+    [navigate, activeToolId]
+  );
 
   useEffect(() => {
     setActiveToolId(location.pathname.replace('/', ''));
   }, [location]);
 
   const onNavItemClick = (id: string) => {
-    push(id);
+    navigate(id);
   };
 
   const onBackClick = () => {
@@ -55,18 +60,20 @@ export function UrlDrivenSiteTools(props: UrlDrivenSiteToolsProps) {
   };
 
   return (
-    <SiteTools
-      site={site}
-      sidebarWidth={width}
-      onWidthChange={setWidth}
-      onNavItemClick={onNavItemClick}
-      onBackClick={onBackClick}
-      activeToolId={activeToolId}
-      footerHtml={footerHtml}
-      openSidebar={openSidebar || !activeToolId}
-      tools={tools}
-      mountMode="page"
-    />
+    <SiteToolsContext.Provider value={contextValue}>
+      <SiteTools
+        site={site}
+        sidebarWidth={width}
+        onWidthChange={setWidth}
+        onNavItemClick={onNavItemClick}
+        onBackClick={onBackClick}
+        activeToolId={activeToolId}
+        footerHtml={footerHtml}
+        openSidebar={openSidebar || !activeToolId}
+        tools={tools}
+        mountMode="page"
+      />
+    </SiteToolsContext.Provider>
   );
 }
 

--- a/ui/app/src/components/SiteTools/siteToolsContext.ts
+++ b/ui/app/src/components/SiteTools/siteToolsContext.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createContext } from 'react';
+
+export interface SiteToolsContextProps {
+  setTool(toolId: string): void;
+  activeToolId: string;
+}
+
+export const SiteToolsContext = createContext<SiteToolsContextProps>(undefined);

--- a/ui/app/src/utils/i18n.ts
+++ b/ui/app/src/utils/i18n.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { createIntl, createIntlCache, IntlShape } from 'react-intl';
+import { createIntl, createIntlCache, IntlShape, MessageDescriptor } from 'react-intl';
 import { Subject } from 'rxjs';
 import TranslationOrText from '../models/TranslationOrText';
 import { nou } from './object';
@@ -101,7 +101,11 @@ export function augmentTranslations(translations: { [localeCode: string]: object
   }
 }
 
-export function getTranslation(key: string, table: any, formatMessage = (descriptor) => descriptor) {
+export function getTranslation(
+  key: string,
+  table: Record<string, MessageDescriptor>,
+  formatMessage: IntlShape['formatMessage']
+): string {
   return formatMessage(
     table[key] || {
       id: 'translationNotAvailable',


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7688

Refactor site tools to use context for tool management

Introduced a SiteToolsContext to simplify tool management and navigation logic. Replaced direct navigation calls with context-based operations, ensuring more consistent state across embedded and URL-driven site tools. Adjusted translation utils and configuration recovery logic for better error handling and user notifications.