### PR TITLE
[7558] Select All is missing in the multi-select Item-Selector Browse dialog

### DIFF
--- a/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -77,9 +77,9 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 	const [selectedLookup, setSelectedLookup] = useSpreadState<LookupTable<MediaItem>>({});
 	const selectedArray = Object.keys(selectedLookup).filter((key) => selectedLookup[key]);
 	const selectedInCurrentPage = items?.filter((item) => selectedArray.includes(item.path));
-	const allSelectedInCurrentPage = (items && selectedInCurrentPage.length === items.length) ?? false;
+	const allSelectedInCurrentPage = items?.length > 0 && selectedInCurrentPage.length === items.length;
 	const someSelectedInCurrentPage =
-		(items && selectedInCurrentPage.length > 0 && selectedInCurrentPage.length < items?.length) ?? false;
+		(items?.length > 0 && selectedInCurrentPage.length > 0 && selectedInCurrentPage.length < items?.length) ?? false;
 	const browsePath = path.replace(/\/+$/, '');
 	const [currentPath, setCurrentPath] = useState(browsePath);
 	const [fetchingBrowsePathExists, setFetchingBrowsePathExists] = useState(false);
@@ -108,20 +108,22 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 
 	useEffect(() => {
 		const query = preselectedPaths?.map((path) => `localId:"${path}"`).join(' ');
-		setFetchingPreselectedItems(true);
-		search(site, { query }).subscribe({
-			next: ({ items }) => {
-				if (multiSelect) {
-					setSelectedLookup(createLookupTable(items, 'path'));
-				} else if (items.length) {
-					setSelectedCard(items[0]);
+		if (query) {
+			setFetchingPreselectedItems(true);
+			search(site, { query }).subscribe({
+				next: ({ items }) => {
+					if (multiSelect) {
+						setSelectedLookup(createLookupTable(items, 'path'));
+					} else if (items.length) {
+						setSelectedCard(items[0]);
+					}
+					setFetchingPreselectedItems(false);
+				},
+				error: () => {
+					setFetchingPreselectedItems(false);
 				}
-				setFetchingPreselectedItems(false);
-			},
-			error: () => {
-				setFetchingPreselectedItems(false);
-			}
-		});
+			});
+		}
 	}, [site, preselectedPaths, multiSelect, setSelectedLookup]);
 
 	useEffect(() => {

--- a/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -76,6 +76,10 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 	const [total, setTotal] = useState<number>();
 	const [selectedLookup, setSelectedLookup] = useSpreadState<LookupTable<MediaItem>>({});
 	const selectedArray = Object.keys(selectedLookup).filter((key) => selectedLookup[key]);
+	const selectedInCurrentPage = items?.filter((item) => selectedArray.includes(item.path));
+	const allSelectedInCurrentPage = (items && selectedInCurrentPage.length === items.length) ?? false;
+	const someSelectedInCurrentPage =
+		(items && selectedInCurrentPage.length > 0 && selectedInCurrentPage.length < items?.length) ?? false;
 	const browsePath = path.replace(/\/+$/, '');
 	const [currentPath, setCurrentPath] = useState(browsePath);
 	const [fetchingBrowsePathExists, setFetchingBrowsePathExists] = useState(false);
@@ -145,6 +149,16 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 			setSelectedLookup({ [item.path]: selectedLookup[item.path] ? null : item });
 		} else {
 			setSelectedCard(selectedCard?.path === item.path ? null : item);
+		}
+	};
+
+	const onSelectAll = () => {
+		if (multiSelect) {
+			const newSelectedLookup = { ...selectedLookup };
+			items.forEach((item) => {
+				newSelectedLookup[item.path] = allSelectedInCurrentPage ? null : item;
+			});
+			setSelectedLookup(newSelectedLookup);
 		}
 	};
 
@@ -254,6 +268,9 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 			preselectedLookup={preselectedLookup}
 			disableChangePreselected={disableChangePreselected}
 			disableSubmission={disableSubmission}
+			onSelectAll={onSelectAll}
+			allSelected={allSelectedInCurrentPage}
+			someSelected={someSelectedInCurrentPage}
 		/>
 	) : (
 		<EmptyState

--- a/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -50,6 +50,7 @@ import ListViewIcon from '@mui/icons-material/ViewStreamRounded';
 import GridViewIcon from '@mui/icons-material/GridOnRounded';
 import ReorderRoundedIcon from '@mui/icons-material/ReorderRounded';
 import { SORT_AUTO } from '../Search/utils';
+import Checkbox from '@mui/material/Checkbox';
 
 export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 	// region const { ... } = props;
@@ -85,7 +86,10 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 		onToggleViewMode,
 		preselectedLookup = {},
 		disableChangePreselected = true,
-		disableSubmission
+		disableSubmission,
+		allSelected,
+		someSelected,
+		onSelectAll
 	} = props;
 	// endregion
 	const { formatMessage } = useIntl();
@@ -120,6 +124,14 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 						>
 							<Toolbar disableGutters variant="dense">
 								<Box sx={{ flexGrow: 1, display: 'flex' }}>
+									{multiSelect && (
+										<>
+											<Tooltip title={<FormattedMessage defaultMessage="Select All on this page" />}>
+												<Checkbox checked={allSelected} indeterminate={someSelected} onChange={onSelectAll} />
+											</Tooltip>
+											<Divider orientation="vertical" flexItem sx={{ marginTop: '-3px', marginBottom: '-3px' }} />
+										</>
+									)}
 									<Tooltip title={<FormattedMessage id="word.refresh" defaultMessage="Refresh" />}>
 										<IconButton onClick={onRefresh}>
 											<RefreshIcon />

--- a/ui/app/src/components/BrowseFilesDialog/utils.ts
+++ b/ui/app/src/components/BrowseFilesDialog/utils.ts
@@ -70,6 +70,8 @@ export interface BrowseFilesDialogUIProps {
 	preselectedLookup?: LookupTable<boolean>;
 	disableChangePreselected?: BrowseFilesDialogBaseProps['disableChangePreselected'];
 	disableSubmission?: boolean;
+	allSelected: boolean;
+	someSelected: boolean;
 	onCardSelected(item: MediaItem): void;
 	onPreviewImage?(item: MediaItem): void;
 	onCheckboxChecked(path: string, selected: boolean): void;
@@ -82,6 +84,7 @@ export interface BrowseFilesDialogUIProps {
 	onRefresh(): void;
 	onUpload(): void;
 	onToggleViewMode?(): void;
+	onSelectAll(): void;
 }
 
 export const initialParameters: ElasticParams = {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced multi-selection in the file browsing dialog with a bulk select checkbox and helpful tooltip, allowing users to quickly select or deselect all items on the current page.

- **Bug Fixes**
  - Refined the selection state logic to accurately reflect full or partial selection even with no items present.
  - Streamlined error handling when fetching preselected items, resulting in more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->