### PR TITLE
[7859] Replace LoadingButton usages to Button with loading prop

### DIFF
--- a/ui/app/src/components/LoadingIconButton/LoadingIconButton.tsx
+++ b/ui/app/src/components/LoadingIconButton/LoadingIconButton.tsx
@@ -15,13 +15,13 @@
  */
 
 import React from 'react';
-import LoadingButton, { LoadingButtonProps } from '@mui/lab/LoadingButton';
+import Button, { ButtonProps } from '@mui/material/Button';
 
-export function LoadingIconButton(props: LoadingButtonProps) {
+export function LoadingIconButton(props: ButtonProps) {
 	const { sx, ...rest } = props;
 
 	return (
-		<LoadingButton
+		<Button
 			{...rest}
 			sx={{
 				borderRadius: '50%',
@@ -36,7 +36,7 @@ export function LoadingIconButton(props: LoadingButtonProps) {
 			}}
 		>
 			{props.children}
-		</LoadingButton>
+		</Button>
 	);
 }
 

--- a/ui/app/src/components/PrimaryButton/PrimaryButton.tsx
+++ b/ui/app/src/components/PrimaryButton/PrimaryButton.tsx
@@ -15,12 +15,12 @@
  */
 
 import * as React from 'react';
-import LoadingButton, { LoadingButtonProps } from '@mui/lab/LoadingButton';
+import Button, { ButtonProps } from '@mui/material/Button';
 
-export interface PrimaryButtonProps extends LoadingButtonProps {}
+export interface PrimaryButtonProps extends ButtonProps {}
 
 const PrimaryButton = React.forwardRef<HTMLButtonElement, PrimaryButtonProps>((props, ref) => {
-	return <LoadingButton ref={ref} {...props} variant="contained" color="primary" />;
+	return <Button ref={ref} {...props} variant="contained" color="primary" />;
 });
 
 export default PrimaryButton;

--- a/ui/app/src/components/SecondaryButton/SecondaryButton.tsx
+++ b/ui/app/src/components/SecondaryButton/SecondaryButton.tsx
@@ -15,12 +15,12 @@
  */
 
 import * as React from 'react';
-import LoadingButton, { LoadingButtonProps } from '@mui/lab/LoadingButton';
+import Button, { ButtonProps } from '@mui/material/Button';
 
-export interface SecondaryButtonProps extends LoadingButtonProps {}
+export interface SecondaryButtonProps extends ButtonProps {}
 
 const SecondaryButton = React.forwardRef<HTMLButtonElement, SecondaryButtonProps>((props, ref) => {
-	return <LoadingButton ref={ref} {...props} variant="outlined" />;
+	return <Button ref={ref} {...props} variant="outlined" />;
 });
 
 export default SecondaryButton;

--- a/ui/app/src/components/SplitButton/SplitButtonUI.tsx
+++ b/ui/app/src/components/SplitButton/SplitButtonUI.tsx
@@ -25,7 +25,6 @@ import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
 import Popper from '@mui/material/Popper';
 import { SplitButtonUIProps } from './utils';
-import LoadingButton from '@mui/lab/LoadingButton';
 
 export function SplitButtonUI(props: SplitButtonUIProps) {
 	const {
@@ -45,9 +44,9 @@ export function SplitButtonUI(props: SplitButtonUIProps) {
 	return (
 		<>
 			<ButtonGroup disabled={disabled} variant="contained" color="primary" ref={anchorRef} aria-label="split button">
-				<LoadingButton color="primary" variant="contained" loading={loading} onClick={handleClick}>
+				<Button color="primary" variant="contained" loading={loading} onClick={handleClick}>
 					{options[selectedIndex].label}
-				</LoadingButton>
+				</Button>
 				{options.length > 1 && (
 					<Button
 						disabled={loading}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated various button components for a unified, consistent experience.
  - Standardized clickable components to maintain similar styling and interactivity.
  - Adjusted loading indicators in components like the loading icon and split buttons, which may alter the previous loading state feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->