### PR TITLE
[7598] Studio does not update its cache of content types when types are updated

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/ContentTypeManagement.tsx
+++ b/ui/app/src/components/ContentTypeManagement/ContentTypeManagement.tsx
@@ -34,6 +34,7 @@ import Button from '@mui/material/Button';
 import Fade from '@mui/material/Fade';
 import { FeedbackOutlined } from '@mui/icons-material';
 import useContentTypeList from '../../hooks/useContentTypeList';
+import { fetchContentTypes } from '../../state/actions/preview';
 
 export interface ContentTypeManagementProps {
 	embedded?: boolean;
@@ -153,6 +154,7 @@ function LegacyTypeManagement(props: ContentTypeManagementProps) {
 			.subscribe((e) => {
 				switch (e.data.type) {
 					case 'CONTENT_TYPES_ON_SAVED': {
+						dispatch(fetchContentTypes());
 						switch (e.data.saveType) {
 							case 'saveAndClose':
 								onClose?.();


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7598

also applies for https://github.com/craftercms/craftercms/issues/7738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved content type management by automatically updating content types when changes are saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->