### PR TITLE
[7870] Modifying Page URL does not reload page URL on Save & Close

### DIFF
--- a/static-assets/components/cstudio-forms/forms-engine.js
+++ b/static-assets/components/cstudio-forms/forms-engine.js
@@ -1553,6 +1553,7 @@ const initializeCStudioForms = () => {
 											var getContentItemCb = {
 												success: function (contentTO) {
 													var previewUrl = CStudioAuthoringContext.previewAppBaseUri + contentTO.item.browserUri;
+													const initialPath = path;
 													path = entityId;
 													var formId = CStudioAuthoring.Utils.getQueryVariable(location.search.substring(1), 'wid');
 													var editorId = CStudioAuthoring.Utils.getQueryVariable(location.search, 'editorId');
@@ -1573,6 +1574,8 @@ const initializeCStudioForms = () => {
 
 														contentTO.initialModel = CStudioForms.initialModel;
 														contentTO.updatedModel = CStudioForms.updatedModel;
+														contentTO.initialModelPath = initialPath;
+														contentTO.updatedModelPath = entityId;
 
 														iceWindowCallback.success(contentTO, editorId, name, value, draft, action);
 

--- a/ui/app/src/components/LegacyFormDialog/EmbeddedLegacyContainer.tsx
+++ b/ui/app/src/components/LegacyFormDialog/EmbeddedLegacyContainer.tsx
@@ -16,7 +16,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LegacyFormDialogContainerProps } from './utils';
-import { getEditFormSrc } from '../../utils/path';
+import { getEditFormSrc, getPreviewURLFromPath } from '../../utils/path';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import { ApiResponse } from '../../models/ApiResponse';
@@ -51,6 +51,8 @@ import { hasEditAction } from '../../utils/content';
 import { nnou } from '../../utils/object';
 import { useFetchItem } from '../../hooks/useFetchItem';
 import Box from '@mui/material/Box';
+import usePreviewNavigation from '../../hooks/usePreviewNavigation';
+import { getSystemLink } from '../../utils/system';
 
 // FE2 TODO: for removal after FE1 removal
 export const EmbeddedLegacyContainer = React.forwardRef(function EmbeddedLegacyEditor(
@@ -87,6 +89,7 @@ export const EmbeddedLegacyContainer = React.forwardRef(function EmbeddedLegacyE
 	// non-existing item (old filename path), so we will only re-fetch when the actual path prop of the component
 	// changes.
 	const item = useFetchItem(path);
+	const { currentUrlPath } = usePreviewNavigation();
 	const availableActions = item?.availableActions;
 	let fieldsIndexes;
 	if (selectedFields && index) {
@@ -150,8 +153,24 @@ export const EmbeddedLegacyContainer = React.forwardRef(function EmbeddedLegacyE
 		const messagesSubscription = messages.subscribe((e: any) => {
 			switch (e.data.type) {
 				case EMBEDDED_LEGACY_FORM_SUCCESS: {
+					// Determine if current previewed page is the same as the one that was saved (before possible url update)
+					const initialModelPath = e.data.initialModelPath;
+					const updatedModelPath = e.data.updatedModelPath;
+
 					onSave(e.data);
-					getHostToGuestBus().next({ type: reloadRequest.type });
+					// If 'currentUrlPath' is the same as the initial path of the page being edited, and there has been an url update,
+					// preview the new one. Otherwise, reload the current previewed page.
+					if (currentUrlPath === getPreviewURLFromPath(initialModelPath)) {
+						window.location.href = getSystemLink({
+							page: getPreviewURLFromPath(updatedModelPath),
+							systemLinkId: 'preview',
+							site,
+							authoringBase
+						});
+					} else {
+						getHostToGuestBus().next({ type: reloadRequest.type });
+					}
+
 					dispatch(updateEditDialogConfig({ pendingChanges: false }));
 					switch (e.data.action) {
 						case 'save': {

--- a/ui/app/src/components/LegacyFormDialog/EmbeddedLegacyContainer.tsx
+++ b/ui/app/src/components/LegacyFormDialog/EmbeddedLegacyContainer.tsx
@@ -168,7 +168,7 @@ export const EmbeddedLegacyContainer = React.forwardRef(function EmbeddedLegacyE
 							authoringBase
 						});
 					} else {
-						getHostToGuestBus().next({ type: reloadRequest.type });
+						getHostToGuestBus().next(reloadRequest());
 					}
 
 					dispatch(updateEditDialogConfig({ pendingChanges: false }));


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- After saving changes in embedded legacy forms, the preview now automatically navigates to the updated page if you were previewing the original page, ensuring you see your latest edits immediately.

- **Bug Fixes**
	- Improved handling of page preview updates to avoid unnecessary reloads when editing different pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->