### PR TITLE
[7985] Image cropper dialog does not have a scrollbar

### DIFF
--- a/static-assets/themes/cstudioTheme/css/contextNav.css
+++ b/static-assets/themes/cstudioTheme/css/contextNav.css
@@ -1080,8 +1080,8 @@ body.yui-skin-cstudioTheme .mask {
 
 #crop-popup-inner .rightControls {
 	width: 30%;
-	height: 268px;
 	float: left;
+	overflow-y: auto;
 }
 
 #crop-popup-inner .rightControls .img-preview > img {

--- a/static-assets/themes/cstudioTheme/css/contextNav.css
+++ b/static-assets/themes/cstudioTheme/css/contextNav.css
@@ -1082,6 +1082,7 @@ body.yui-skin-cstudioTheme .mask {
 	width: 30%;
 	float: left;
 	overflow-y: auto;
+	max-height: 80vh;
 }
 
 #crop-popup-inner .rightControls .img-preview > img {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the layout of the crop popup's right controls by allowing vertical scrolling when content exceeds available space, ensuring better usability without a fixed height constraint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->