### PR TITLE
[7505] Improve the error message displayed when creating access tokens with an expiry time that is already past

### DIFF
--- a/ui/app/src/components/ApiResponseErrorState/ApiResponseErrorState.tsx
+++ b/ui/app/src/components/ApiResponseErrorState/ApiResponseErrorState.tsx
@@ -20,6 +20,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import React from 'react';
 import { useIntl } from 'react-intl';
 import ErrorState, { ErrorStateProps } from '../ErrorState/ErrorState';
+import { capitalize } from '../../utils/string';
 
 export type ApiResponseErrorStateProps = Omit<ErrorStateProps, 'title' | 'message'> & {
 	error: ApiResponse;
@@ -59,7 +60,9 @@ export function createErrorStatePropsFromApiResponse(
 			(remedialAction && message ? (remedialAction.endsWith('.') ? '' : '.') : ''),
 		children: (
 			<>
-				{validationErrors?.map(({ field, message }, index) => <div key={`${field}_${index}`}>{message}</div>)}
+				{validationErrors?.map(({ field, message }, index) => (
+					<div key={`${field}_${index}`}>{capitalize(message)}</div>
+				))}
 				{documentationUrl && (
 					<Button href={documentationUrl} target="_blank" rel="noreferrer" variant="text">
 						{formatMessage({

--- a/ui/app/src/components/CreateTokenDialog/CreateTokenDialogContainer.tsx
+++ b/ui/app/src/components/CreateTokenDialog/CreateTokenDialogContainer.tsx
@@ -86,7 +86,12 @@ export function CreateTokenDialogContainer(props: CreateTokenContainerProps) {
 				functionRefs.current.onSubmittingAndOrPendingChange({
 					isSubmitting: false
 				});
-				dispatch(showErrorDialog({ error: response.response }));
+				dispatch(
+					showErrorDialog({
+						error: response.response,
+						validationErrors: response.validationErrors
+					})
+				);
 			}
 		);
 	};

--- a/ui/app/src/components/CreateTokenDialog/CreateTokenDialogContainer.tsx
+++ b/ui/app/src/components/CreateTokenDialog/CreateTokenDialogContainer.tsx
@@ -82,11 +82,11 @@ export function CreateTokenDialogContainer(props: CreateTokenContainerProps) {
 				});
 				onCreated?.(token);
 			},
-			(response) => {
+			({ response }) => {
 				functionRefs.current.onSubmittingAndOrPendingChange({
 					isSubmitting: false
 				});
-				dispatch(showErrorDialog({ error: response }));
+				dispatch(showErrorDialog({ error: response.response }));
 			}
 		);
 	};

--- a/ui/app/src/components/ErrorDialog/ErrorDialog.tsx
+++ b/ui/app/src/components/ErrorDialog/ErrorDialog.tsx
@@ -20,7 +20,7 @@ import CloseIcon from '@mui/icons-material/CloseRounded';
 import Dialog from '@mui/material/Dialog';
 import StandardAction from '../../models/StandardAction';
 import { ApiResponse } from '../../models/ApiResponse';
-import ApiResponseErrorState, { ApiResponseErrorStateProps } from '../ApiResponseErrorState';
+import ApiResponseErrorState, { type ApiResponseErrorStateProps } from '../ApiResponseErrorState';
 import { useUnmount } from '../../hooks/useUnmount';
 import Box from '@mui/material/Box';
 

--- a/ui/app/src/components/ErrorDialog/ErrorDialog.tsx
+++ b/ui/app/src/components/ErrorDialog/ErrorDialog.tsx
@@ -20,13 +20,14 @@ import CloseIcon from '@mui/icons-material/CloseRounded';
 import Dialog from '@mui/material/Dialog';
 import StandardAction from '../../models/StandardAction';
 import { ApiResponse } from '../../models/ApiResponse';
-import ApiResponseErrorState from '../ApiResponseErrorState';
+import ApiResponseErrorState, { ApiResponseErrorStateProps } from '../ApiResponseErrorState';
 import { useUnmount } from '../../hooks/useUnmount';
 import Box from '@mui/material/Box';
 
 interface ErrorDialogBaseProps {
 	open: boolean;
 	error: ApiResponse;
+	validationErrors?: ApiResponseErrorStateProps['validationErrors'];
 }
 
 export type ErrorDialogProps = PropsWithChildren<
@@ -44,7 +45,7 @@ export interface ErrorDialogStateProps extends ErrorDialogBaseProps {
 }
 
 function ErrorDialogBody(props: ErrorDialogProps) {
-	const { onDismiss, error } = props;
+	const { onDismiss, error, validationErrors } = props;
 	useUnmount(props.onClosed);
 	return (
 		<Box sx={{ padding: (theme) => theme.spacing(2) }}>
@@ -60,7 +61,7 @@ function ErrorDialogBody(props: ErrorDialogProps) {
 			>
 				<CloseIcon />
 			</IconButton>
-			{error && <ApiResponseErrorState error={error} />}
+			{error && <ApiResponseErrorState error={error} validationErrors={validationErrors} />}
 		</Box>
 	);
 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the token creation dialog to display more accurate and capitalized validation error messages.
  - Enhanced error dialogs to show detailed validation error information for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->