### PR TITLE
[7826] Video upload to S3 end up multiples upload

### DIFF
--- a/static-assets/components/cstudio-dialogs/uploadS3-dialog.js
+++ b/static-assets/components/cstudio-dialogs/uploadS3-dialog.js
@@ -171,7 +171,6 @@ CStudioAuthoring.Dialogs.UploadS3Dialog = CStudioAuthoring.Dialogs.UploadS3Dialo
 		});
 
 		var url = CStudioAuthoring.Service.createServiceUri(serviceUri);
-		url += '&' + CStudioAuthoringContext.xsrfParameterName + '=' + CrafterCMSNext.util.auth.getRequestForgeryToken();
 
 		CrafterCMSNext.render(document.getElementById('uploadContainer'), 'SingleFileUpload', {
 			formTarget: '#asset_upload_form',

--- a/ui/app/src/components/SingleFileUpload/SingleFileUpload.tsx
+++ b/ui/app/src/components/SingleFileUpload/SingleFileUpload.tsx
@@ -272,7 +272,9 @@ export function SingleFileUpload(props: SingleFileUploadProps) {
 						setConfirm({ body: message });
 						setSuggestedName(modifiedName);
 					} else {
-						uppy.upload();
+						// When uploading large files to aws/s3, something causes requests to fail and get retried n times before finally stating it failed; despite the file seemingly actually getting uploaded.
+						// This setTimeout avoids that issue. The mechanism of failure or why this avoids it is unknown.
+						setTimeout(() => uppy.upload(), 50);
 						setDescription(`${formatMessage(messages.uploadingFile)}:`);
 						onUploadStart?.();
 					}
@@ -293,7 +295,7 @@ export function SingleFileUpload(props: SingleFileUploadProps) {
 	}, [onUploadStart, formatMessage, path, site, uppy]);
 
 	const onConfirm = () => {
-		uppy.upload().then(() => {});
+		uppy.upload();
 		setSuggestedName(null);
 		setDescription(`${formatMessage(messages.uploadingFile)}:`);
 		onUploadStart?.();


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of large file uploads to AWS/S3 by introducing a short delay before starting the upload, addressing intermittent upload failures.

- **Chores**
  - Removed the XSRF token parameter from the file upload dialog service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->