### PR TITLE
[7504] Improve indication of workflow states for disabled items

### DIFF
--- a/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
+++ b/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
@@ -66,6 +66,7 @@ export function DisabledItemIcon(props: DisabledItemIconProps) {
 				<DisabledTypeIcon
 					{...itemTypeIconProps}
 					className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
+					aria-label={getItemTypeText(item, formatMessage)}
 					sx={{
 						fontSize: '1.1rem',
 						position: 'absolute',
@@ -77,6 +78,7 @@ export function DisabledItemIcon(props: DisabledItemIconProps) {
 				/>
 				<BlockRoundedIcon
 					className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
+					aria-label={formatMessage({ defaultMessage: 'Disabled' })}
 					sx={{
 						fontSize: '1.1rem',
 						color: (theme) => theme.palette.error.main,

--- a/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
+++ b/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ItemDisplayProps } from '../ItemDisplay';
+import ItemTypeIcon, { getItemTypeText } from '../ItemTypeIcon';
+import Tooltip from '@mui/material/Tooltip';
+import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
+import * as React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import ComponentIconSolid from '@mui/icons-material/Extension';
+import PageIconSolid from '@mui/icons-material/InsertDriveFile';
+import TaxonomyIconSolid from '@mui/icons-material/LocalOffer';
+import LevelDescriptorIcon from '../../icons/LevelDescriptor';
+import UnknownStateIcon from '@mui/icons-material/HelpOutlineRounded';
+import Box from '@mui/material/Box';
+
+export interface DisabledItemIconProps {
+	item: ItemDisplayProps['item'];
+	itemTypeIconProps: ItemDisplayProps['itemTypeIconProps'];
+	sxs?: ItemDisplayProps['sxs'];
+	classes?: ItemDisplayProps['classes'];
+}
+
+export function DisabledItemIcon(props: DisabledItemIconProps) {
+	const { item, itemTypeIconProps, sxs, classes } = props;
+	const { formatMessage } = useIntl();
+	const isDisabledItem = item.stateMap.disabled;
+
+	let DisabledTypeIcon = UnknownStateIcon;
+	switch (item.systemType) {
+		case 'component':
+			DisabledTypeIcon = ComponentIconSolid;
+			break;
+		case 'page':
+			DisabledTypeIcon = PageIconSolid;
+			break;
+		case 'taxonomy':
+			DisabledTypeIcon = TaxonomyIconSolid;
+			break;
+		case 'levelDescriptor':
+			DisabledTypeIcon = LevelDescriptorIcon;
+			break;
+	}
+
+	return isDisabledItem ? (
+		<Tooltip
+			title={
+				<>
+					<FormattedMessage defaultMessage="Disabled" /> {getItemTypeText(item, formatMessage)}
+				</>
+			}
+		>
+			<Box component="span" sx={{ display: 'flex', position: 'relative' }}>
+				<DisabledTypeIcon
+					{...itemTypeIconProps}
+					className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
+					sx={{
+						fontSize: '1.1rem',
+						position: 'absolute',
+						top: '-5px',
+						left: '-3px',
+						padding: '3px',
+						...sxs?.icon
+					}}
+				/>
+				<BlockRoundedIcon
+					className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
+					sx={{
+						fontSize: '1.1rem',
+						color: (theme) => theme.palette.error.main,
+						...sxs?.icon
+					}}
+				/>
+			</Box>
+		</Tooltip>
+	) : (
+		<ItemTypeIcon
+			{...itemTypeIconProps}
+			item={item}
+			className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
+			sx={{
+				fontSize: '1.1rem',
+				...(item.stateMap.disabled
+					? {
+							position: 'absolute',
+							top: '-5px',
+							left: '-3px',
+							padding: '3px'
+						}
+					: {}),
+				...sxs?.icon
+			}}
+		/>
+	);
+}
+
+export default DisabledItemIcon;

--- a/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
+++ b/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
@@ -37,7 +37,6 @@ export interface DisabledItemIconProps {
 export function DisabledItemIcon(props: DisabledItemIconProps) {
 	const { item, itemTypeIconProps, sxs, classes } = props;
 	const { formatMessage } = useIntl();
-	const isDisabledItem = item.stateMap.disabled;
 
 	let DisabledTypeIcon = UnknownStateIcon;
 	switch (item.systemType) {
@@ -55,7 +54,7 @@ export function DisabledItemIcon(props: DisabledItemIconProps) {
 			break;
 	}
 
-	return isDisabledItem ? (
+	return (
 		<Tooltip
 			title={
 				<>
@@ -86,16 +85,6 @@ export function DisabledItemIcon(props: DisabledItemIconProps) {
 				/>
 			</Box>
 		</Tooltip>
-	) : (
-		<ItemTypeIcon
-			{...itemTypeIconProps}
-			item={item}
-			className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
-			sx={{
-				fontSize: '1.1rem',
-				...sxs?.icon
-			}}
-		/>
 	);
 }
 

--- a/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
+++ b/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
@@ -15,7 +15,7 @@
  */
 
 import { ItemDisplayProps } from '../ItemDisplay';
-import ItemTypeIcon, { getItemTypeText } from '../ItemTypeIcon';
+import { getItemTypeText } from '../ItemTypeIcon';
 import Tooltip from '@mui/material/Tooltip';
 import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
 import * as React from 'react';

--- a/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
+++ b/ui/app/src/components/DisabledItemIcon/DisabledItemIcon.tsx
@@ -93,14 +93,6 @@ export function DisabledItemIcon(props: DisabledItemIconProps) {
 			className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
 			sx={{
 				fontSize: '1.1rem',
-				...(item.stateMap.disabled
-					? {
-							position: 'absolute',
-							top: '-5px',
-							left: '-3px',
-							padding: '3px'
-						}
-					: {}),
 				...sxs?.icon
 			}}
 		/>

--- a/ui/app/src/components/DisabledItemIcon/index.ts
+++ b/ui/app/src/components/DisabledItemIcon/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { default } from './DisabledItemIcon';
+
+export * from './DisabledItemIcon';

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -21,13 +21,16 @@ import palette from '../../styles/palette';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import { isPreviewable } from '../PathNavigator/utils';
 import ItemStateIcon, { ItemStateIconProps } from '../ItemStateIcon';
-import ItemTypeIcon, { ItemTypeIconProps } from '../ItemTypeIcon';
+import ItemTypeIcon, { getItemTypeText, ItemTypeIconProps } from '../ItemTypeIcon';
 import ItemPublishingTargetIcon, { ItemPublishingTargetIconProps } from '../ItemPublishingTargetIcon';
 import { isInWorkflow } from './utils';
 import Box from '@mui/material/Box';
 import { PartialSxRecord } from '../../models';
 import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material/styles';
+import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
+import { useIntl } from 'react-intl';
+import Tooltip from '@mui/material/Tooltip';
 
 export type ItemDisplayClassKey = 'root' | 'label' | 'labelPreviewable' | 'icon' | 'typeIcon';
 
@@ -75,6 +78,7 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 		sxs,
 		...rest
 	} = props;
+	const { formatMessage } = useIntl();
 	// endregion
 	if (!item) {
 		// Prevents crashing if the item is nullish
@@ -123,14 +127,42 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 							}}
 						/>
 					)}
-			{showItemType && (
-				<ItemTypeIcon
-					{...itemTypeIconProps}
-					item={item}
-					className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
-					sx={{ fontSize: '1.1rem', ...sxs?.icon }}
-				/>
-			)}
+			<Box component="span" sx={{ display: 'flex', position: 'relative' }}>
+				{showItemType && (
+					<>
+						<ItemTypeIcon
+							{...itemTypeIconProps}
+							item={item}
+							className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
+							disabled={item.stateMap.disabled}
+							sx={{
+								fontSize: '1.1rem',
+								...(item.stateMap.disabled
+									? {
+											position: 'absolute',
+											top: '-5px',
+											left: '-3px',
+											padding: '3px'
+										}
+									: {}),
+								...sxs?.icon
+							}}
+						/>
+						{item.stateMap.disabled && (
+							<Tooltip title={getItemTypeText(item, formatMessage, item.stateMap.disabled)}>
+								<BlockRoundedIcon
+									className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
+									sx={{
+										fontSize: '1.1rem',
+										color: (theme) => theme.palette.error.main,
+										...sxs?.icon
+									}}
+								/>
+							</Tooltip>
+						)}
+					</>
+				)}
+			</Box>
 			<Typography
 				noWrap
 				component={labelComponent}

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -21,7 +21,7 @@ import palette from '../../styles/palette';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import { isPreviewable } from '../PathNavigator/utils';
 import ItemStateIcon, { ItemStateIconProps } from '../ItemStateIcon';
-import { ItemTypeIcon, ItemTypeIconProps } from '../ItemTypeIcon';
+import ItemTypeIcon, { ItemTypeIconProps } from '../ItemTypeIcon';
 import ItemPublishingTargetIcon, { ItemPublishingTargetIconProps } from '../ItemPublishingTargetIcon';
 import { isInWorkflow } from './utils';
 import Box from '@mui/material/Box';

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -21,7 +21,7 @@ import palette from '../../styles/palette';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import { isPreviewable } from '../PathNavigator/utils';
 import ItemStateIcon, { ItemStateIconProps } from '../ItemStateIcon';
-import { ItemTypeIconProps } from '../ItemTypeIcon';
+import { ItemTypeIcon, ItemTypeIconProps } from '../ItemTypeIcon';
 import ItemPublishingTargetIcon, { ItemPublishingTargetIconProps } from '../ItemPublishingTargetIcon';
 import { isInWorkflow } from './utils';
 import Box from '@mui/material/Box';
@@ -81,6 +81,7 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 		// Prevents crashing if the item is nullish
 		return null;
 	}
+	const isDisabledItem = item.stateMap.disabled;
 	const inWorkflow = isInWorkflow(item.stateMap) || item.systemType === 'folder';
 	return (
 		<Box
@@ -124,9 +125,20 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 							}}
 						/>
 					)}
-			{showItemType && (
-				<DisabledItemIcon item={item} itemTypeIconProps={itemTypeIconProps} sxs={sxs} classes={classes} />
-			)}
+			{showItemType &&
+				(isDisabledItem ? (
+					<DisabledItemIcon item={item} itemTypeIconProps={itemTypeIconProps} sxs={sxs} classes={classes} />
+				) : (
+					<ItemTypeIcon
+						{...itemTypeIconProps}
+						item={item}
+						className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
+						sx={{
+							fontSize: '1.1rem',
+							...sxs?.icon
+						}}
+					/>
+				))}
 			<Typography
 				noWrap
 				component={labelComponent}

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -21,16 +21,14 @@ import palette from '../../styles/palette';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import { isPreviewable } from '../PathNavigator/utils';
 import ItemStateIcon, { ItemStateIconProps } from '../ItemStateIcon';
-import ItemTypeIcon, { getItemTypeText, ItemTypeIconProps } from '../ItemTypeIcon';
+import { ItemTypeIconProps } from '../ItemTypeIcon';
 import ItemPublishingTargetIcon, { ItemPublishingTargetIconProps } from '../ItemPublishingTargetIcon';
 import { isInWorkflow } from './utils';
 import Box from '@mui/material/Box';
 import { PartialSxRecord } from '../../models';
 import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material/styles';
-import BlockRoundedIcon from '@mui/icons-material/BlockRounded';
-import { useIntl } from 'react-intl';
-import Tooltip from '@mui/material/Tooltip';
+import { DisabledItemIcon } from '../DisabledItemIcon';
 
 export type ItemDisplayClassKey = 'root' | 'label' | 'labelPreviewable' | 'icon' | 'typeIcon';
 
@@ -78,7 +76,6 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 		sxs,
 		...rest
 	} = props;
-	const { formatMessage } = useIntl();
 	// endregion
 	if (!item) {
 		// Prevents crashing if the item is nullish
@@ -127,42 +124,9 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 							}}
 						/>
 					)}
-			<Box component="span" sx={{ display: 'flex', position: 'relative' }}>
-				{showItemType && (
-					<>
-						<ItemTypeIcon
-							{...itemTypeIconProps}
-							item={item}
-							className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
-							disabled={item.stateMap.disabled}
-							sx={{
-								fontSize: '1.1rem',
-								...(item.stateMap.disabled
-									? {
-											position: 'absolute',
-											top: '-5px',
-											left: '-3px',
-											padding: '3px'
-										}
-									: {}),
-								...sxs?.icon
-							}}
-						/>
-						{item.stateMap.disabled && (
-							<Tooltip title={getItemTypeText(item, formatMessage, item.stateMap.disabled)}>
-								<BlockRoundedIcon
-									className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
-									sx={{
-										fontSize: '1.1rem',
-										color: (theme) => theme.palette.error.main,
-										...sxs?.icon
-									}}
-								/>
-							</Tooltip>
-						)}
-					</>
-				)}
-			</Box>
+			{showItemType && (
+				<DisabledItemIcon item={item} itemTypeIconProps={itemTypeIconProps} sxs={sxs} classes={classes} />
+			)}
 			<Typography
 				noWrap
 				component={labelComponent}

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -133,10 +133,7 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 						{...itemTypeIconProps}
 						item={item}
 						className={[classes?.icon, itemTypeIconProps?.className].filter(Boolean).join(' ')}
-						sx={{
-							fontSize: '1.1rem',
-							...sxs?.icon
-						}}
+						sx={{ fontSize: '1.1rem', ...sxs?.icon }}
 					/>
 				))}
 			<Typography

--- a/ui/app/src/components/ItemDisplay/utils.tsx
+++ b/ui/app/src/components/ItemDisplay/utils.tsx
@@ -78,8 +78,6 @@ export function getItemStateId(stateMap: ItemStateMap): ItemStates {
 			return 'systemProcessing';
 		case stateMap.locked:
 			return 'locked';
-		case stateMap.disabled:
-			return 'disabled';
 		case stateMap.submittedToLive:
 			return 'submittedToLive';
 		case stateMap.submittedToStaging:

--- a/ui/app/src/components/ItemDisplay/utils.tsx
+++ b/ui/app/src/components/ItemDisplay/utils.tsx
@@ -70,6 +70,8 @@ export function getItemStateText(stateMap: ItemStateMap, values?: Record<string,
 	);
 }
 
+// Disable case was removed from the switch statement to allow for rendering both workflow state and disabled status.
+// (by using DisabledItemIcon)
 export function getItemStateId(stateMap: ItemStateMap): ItemStates {
 	switch (true) {
 		case stateMap.deleted:

--- a/ui/app/src/components/ItemTypeIcon/ItemTypeIcon.tsx
+++ b/ui/app/src/components/ItemTypeIcon/ItemTypeIcon.tsx
@@ -22,7 +22,9 @@ import Freemarker from '../../icons/Freemarker';
 import Html from '../../icons/Html';
 import Css from '../../icons/Css';
 import ComponentIcon from '../../icons/Component';
+import ComponentIconSolid from '@mui/icons-material/Extension';
 import PageIcon from '../../icons/Page';
+import PageIconSolid from '@mui/icons-material/InsertDriveFile';
 import LevelDescriptorIcon from '../../icons/LevelDescriptor';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 import * as React from 'react';
@@ -35,9 +37,10 @@ import FontIcon from '@mui/icons-material/FontDownloadOutlined';
 import TextIcon from '@mui/icons-material/SubjectRounded';
 import FolderIcon from '@mui/icons-material/FolderOpenRounded';
 import TaxonomyIcon from '@mui/icons-material/LocalOfferOutlined';
+import TaxonomyIconSolid from '@mui/icons-material/LocalOffer';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import { ContentItem } from '../../models/Item';
-import { IntlFormatters, useIntl } from 'react-intl';
+import { defineMessage, IntlFormatters, useIntl } from 'react-intl';
 import { messages } from './translations';
 import { SvgIconProps } from '@mui/material/SvgIcon';
 import { BoxProps } from '@mui/material/Box';
@@ -45,6 +48,7 @@ import { BoxProps } from '@mui/material/Box';
 export interface ItemTypeIconProps extends SvgIconProps {
 	item: Pick<ContentItem, 'systemType' | 'mimeType'>;
 	tooltipProps?: Partial<TooltipProps>;
+	disabled?: boolean;
 	sxs?: Partial<{
 		icon: BoxProps['sx'];
 	}>;
@@ -52,17 +56,22 @@ export interface ItemTypeIconProps extends SvgIconProps {
 
 export function getItemTypeText(
 	item: Pick<ContentItem, 'systemType' | 'mimeType'>,
-	formatMessage: IntlFormatters['formatMessage']
+	formatMessage: IntlFormatters['formatMessage'],
+	disabled: boolean = false
 ) {
-	return messages[item.systemType]
+	let itemTypeText = messages[item.systemType]
 		? formatMessage(messages[item.systemType])
 		: item.mimeType
 			? item.mimeType
 			: formatMessage(messages.unknown);
+	itemTypeText = disabled
+		? `${formatMessage(defineMessage({ defaultMessage: 'Disabled' }))} ${itemTypeText}`
+		: itemTypeText;
+	return itemTypeText;
 }
 
 export function ItemTypeIcon(props: ItemTypeIconProps) {
-	const { item, tooltipProps, sxs, ...rest } = props;
+	const { item, tooltipProps, disabled = false, sxs, ...rest } = props;
 	const { formatMessage } = useIntl();
 	let TheIcon = UnknownStateIcon;
 	switch (item.systemType) {
@@ -124,10 +133,10 @@ export function ItemTypeIcon(props: ItemTypeIconProps) {
 			}
 			break;
 		case 'component':
-			TheIcon = ComponentIcon;
+			TheIcon = disabled ? ComponentIconSolid : ComponentIcon;
 			break;
 		case 'page':
-			TheIcon = PageIcon;
+			TheIcon = disabled ? PageIconSolid : PageIcon;
 			break;
 		case 'folder':
 			TheIcon = FolderIcon;
@@ -142,14 +151,14 @@ export function ItemTypeIcon(props: ItemTypeIconProps) {
 			TheIcon = Groovy;
 			break;
 		case 'taxonomy':
-			TheIcon = TaxonomyIcon;
+			TheIcon = disabled ? TaxonomyIconSolid : TaxonomyIcon;
 			break;
 		case 'configuration':
 			TheIcon = SettingsOutlinedIcon;
 			break;
 	}
 	return (
-		<Tooltip {...tooltipProps} title={getItemTypeText(item, formatMessage)}>
+		<Tooltip {...tooltipProps} title={getItemTypeText(item, formatMessage, disabled)}>
 			<TheIcon sx={sxs?.icon} {...rest} />
 		</Tooltip>
 	);

--- a/ui/app/src/components/ItemTypeIcon/ItemTypeIcon.tsx
+++ b/ui/app/src/components/ItemTypeIcon/ItemTypeIcon.tsx
@@ -22,9 +22,7 @@ import Freemarker from '../../icons/Freemarker';
 import Html from '../../icons/Html';
 import Css from '../../icons/Css';
 import ComponentIcon from '../../icons/Component';
-import ComponentIconSolid from '@mui/icons-material/Extension';
 import PageIcon from '../../icons/Page';
-import PageIconSolid from '@mui/icons-material/InsertDriveFile';
 import LevelDescriptorIcon from '../../icons/LevelDescriptor';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 import * as React from 'react';
@@ -37,10 +35,9 @@ import FontIcon from '@mui/icons-material/FontDownloadOutlined';
 import TextIcon from '@mui/icons-material/SubjectRounded';
 import FolderIcon from '@mui/icons-material/FolderOpenRounded';
 import TaxonomyIcon from '@mui/icons-material/LocalOfferOutlined';
-import TaxonomyIconSolid from '@mui/icons-material/LocalOffer';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import { ContentItem } from '../../models/Item';
-import { defineMessage, IntlFormatters, useIntl } from 'react-intl';
+import { IntlFormatters, useIntl } from 'react-intl';
 import { messages } from './translations';
 import { SvgIconProps } from '@mui/material/SvgIcon';
 import { BoxProps } from '@mui/material/Box';
@@ -48,7 +45,6 @@ import { BoxProps } from '@mui/material/Box';
 export interface ItemTypeIconProps extends SvgIconProps {
 	item: Pick<ContentItem, 'systemType' | 'mimeType'>;
 	tooltipProps?: Partial<TooltipProps>;
-	disabled?: boolean;
 	sxs?: Partial<{
 		icon: BoxProps['sx'];
 	}>;
@@ -56,22 +52,17 @@ export interface ItemTypeIconProps extends SvgIconProps {
 
 export function getItemTypeText(
 	item: Pick<ContentItem, 'systemType' | 'mimeType'>,
-	formatMessage: IntlFormatters['formatMessage'],
-	disabled: boolean = false
+	formatMessage: IntlFormatters['formatMessage']
 ) {
-	let itemTypeText = messages[item.systemType]
+	return messages[item.systemType]
 		? formatMessage(messages[item.systemType])
 		: item.mimeType
 			? item.mimeType
 			: formatMessage(messages.unknown);
-	itemTypeText = disabled
-		? `${formatMessage(defineMessage({ defaultMessage: 'Disabled' }))} ${itemTypeText}`
-		: itemTypeText;
-	return itemTypeText;
 }
 
 export function ItemTypeIcon(props: ItemTypeIconProps) {
-	const { item, tooltipProps, disabled = false, sxs, ...rest } = props;
+	const { item, tooltipProps, sxs, ...rest } = props;
 	const { formatMessage } = useIntl();
 	let TheIcon = UnknownStateIcon;
 	switch (item.systemType) {
@@ -133,10 +124,10 @@ export function ItemTypeIcon(props: ItemTypeIconProps) {
 			}
 			break;
 		case 'component':
-			TheIcon = disabled ? ComponentIconSolid : ComponentIcon;
+			TheIcon = ComponentIcon;
 			break;
 		case 'page':
-			TheIcon = disabled ? PageIconSolid : PageIcon;
+			TheIcon = PageIcon;
 			break;
 		case 'folder':
 			TheIcon = FolderIcon;
@@ -151,14 +142,14 @@ export function ItemTypeIcon(props: ItemTypeIconProps) {
 			TheIcon = Groovy;
 			break;
 		case 'taxonomy':
-			TheIcon = disabled ? TaxonomyIconSolid : TaxonomyIcon;
+			TheIcon = TaxonomyIcon;
 			break;
 		case 'configuration':
 			TheIcon = SettingsOutlinedIcon;
 			break;
 	}
 	return (
-		<Tooltip {...tooltipProps} title={getItemTypeText(item, formatMessage, disabled)}>
+		<Tooltip {...tooltipProps} title={getItemTypeText(item, formatMessage)}>
 			<TheIcon sx={sxs?.icon} {...rest} />
 		</Tooltip>
 	);


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new visual indicator for disabled items, displaying a specialized icon and tooltip when an item is disabled.

- **Refactor**
  - Updated item display logic to use the new disabled item icon component, improving clarity and consistency in representing disabled states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->