### PR TITLE
[8073] Allowed types not showing on Preview Panels

### DIFF
--- a/ui/app/src/components/PreviewBrowseComponentsPanel/PreviewBrowseComponentsPanel.tsx
+++ b/ui/app/src/components/PreviewBrowseComponentsPanel/PreviewBrowseComponentsPanel.tsx
@@ -74,7 +74,7 @@ export function PreviewBrowseComponentsPanel() {
 		if (!contentTypes || !allowedTypesData) return result;
 		contentTypes.forEach((contentType) => {
 			// When selecting 'Allow any component' in the content type editor, there will be a key '*' in the allowedTypesData
-			if (allowedTypesData[contentType.id]?.shared || allowedTypesData['*']?.shared) {
+			if (allowedTypesData[contentType.id]?.sharedExisting || allowedTypesData['*']?.sharedExisting) {
 				allowedTypes.push(contentType);
 			} else {
 				otherTypes.push(contentType);

--- a/ui/app/src/components/PreviewBrowseComponentsPanel/PreviewBrowseComponentsPanel.tsx
+++ b/ui/app/src/components/PreviewBrowseComponentsPanel/PreviewBrowseComponentsPanel.tsx
@@ -73,7 +73,8 @@ export function PreviewBrowseComponentsPanel() {
 		const result = { allowedTypes, otherTypes };
 		if (!contentTypes || !allowedTypesData) return result;
 		contentTypes.forEach((contentType) => {
-			if (allowedTypesData[contentType.id]?.shared) {
+			// When selecting 'Allow any component' in the content type editor, there will be a key '*' in the allowedTypesData
+			if (allowedTypesData[contentType.id]?.shared || allowedTypesData['*']?.shared) {
 				allowedTypes.push(contentType);
 			} else {
 				otherTypes.push(contentType);

--- a/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
+++ b/ui/app/src/components/PreviewComponentsPanel/PreviewComponentsPanel.tsx
@@ -115,7 +115,13 @@ export function PreviewComponentsPanel() {
 				continue;
 			}
 			// if contentType.type === 'component' ...
-			if (allowedTypesData[id]?.embedded || allowedTypesData[id]?.shared) {
+			// When selecting 'Allow any component' in the content type editor, there will be a key '*' in the allowedTypesData
+			if (
+				allowedTypesData[id]?.embedded ||
+				allowedTypesData[id]?.shared ||
+				allowedTypesData['*']?.embedded ||
+				allowedTypesData['*']?.shared
+			) {
 				allowedTypes.push(contentType);
 			} else {
 				otherTypes.push(contentType);

--- a/ui/app/src/services/contentTypes.ts
+++ b/ui/app/src/services/contentTypes.ts
@@ -408,6 +408,7 @@ function parseLegacyFormDefinition(definition: LegacyFormDefinition): ContentTyp
 	const fields: LookupTable<ContentTypeField> = {};
 	const sections: Array<ContentTypeSection> = [];
 	const dataSources: LookupTable<DataSource> = {};
+	// TODO: update type to be LookupTable<DataSource>. https://github.com/craftercms/craftercms/issues/8216
 	const dropTargetsLookup: LookupTable<LegacyDataSource> = {};
 
 	const legacyDataSourceArray = asArray(definition.datasources?.datasource);

--- a/ui/app/src/services/contentTypes.ts
+++ b/ui/app/src/services/contentTypes.ts
@@ -431,6 +431,8 @@ function parseLegacyFormDefinition(definition: LegacyFormDefinition): ContentTyp
 				//   break;
 			}
 			dataSources[datasource.id].properties[property.name] = value;
+			// datasource also needs to be directly edited since it's set to dropTargetsLookup when datasource type is 'components'
+			datasource.properties[property.name] = value;
 		});
 		if (datasource.type === 'components') {
 			dropTargetsLookup[datasource.id] = datasource;

--- a/ui/app/src/services/contentTypes.ts
+++ b/ui/app/src/services/contentTypes.ts
@@ -416,6 +416,7 @@ function parseLegacyFormDefinition(definition: LegacyFormDefinition): ContentTyp
 	legacyDataSourceArray.forEach((datasource: LegacyDataSource) => {
 		// TODO: Delete datasource.properties after props have been added to the root object? Must update code usages of datasource.properties.
 		dataSources[datasource.id] = { ...datasource, properties: {} };
+		const legacyDatasource = { ...datasource };
 		asArray(datasource.properties?.property).forEach((property) => {
 			let value: unknown = property.value;
 			switch (property.type) {
@@ -431,11 +432,11 @@ function parseLegacyFormDefinition(definition: LegacyFormDefinition): ContentTyp
 				//   break;
 			}
 			dataSources[datasource.id].properties[property.name] = value;
-			// datasource also needs to be directly edited since it's set to dropTargetsLookup when datasource type is 'components'
-			datasource.properties[property.name] = value;
+			// Also update legacyDatasource, since dropTargetsLookup references it for 'components' type datasources.
+			legacyDatasource.properties[property.name] = value;
 		});
-		if (datasource.type === 'components') {
-			dropTargetsLookup[datasource.id] = datasource;
+		if (legacyDatasource.type === 'components') {
+			dropTargetsLookup[datasource.id] = legacyDatasource;
 		}
 	});
 

--- a/ui/app/src/state/epics/contentTypes.ts
+++ b/ui/app/src/state/epics/contentTypes.ts
@@ -65,9 +65,15 @@ export default [
 			ofType(fetchComponentsByContentType.type, setContentTypeFilter.type),
 			withLatestFrom(state$),
 			switchMap(([, state]) => {
-				const allowedContentTypes = Object.entries(state.preview.guest?.allowedContentTypes ?? {}).flatMap(
+				let allowedContentTypes = Object.entries(state.preview.guest?.allowedContentTypes ?? {}).flatMap(
 					([key, type]) => (type.shared ? [key] : [])
 				);
+				// If '*' is included in allowedContentTypes, it means that all content types are allowed.
+				if (allowedContentTypes.includes('*')) {
+					allowedContentTypes = Object.values(state.contentTypes.byId)
+						.filter((contentType) => contentType.type === 'component' && !contentType.id.includes('/level-descriptor'))
+						.map((contentType) => contentType.id);
+				}
 				return fetchItemsByContentType(
 					state.sites.active,
 					state.preview.components.contentTypeFilter === 'compatible'

--- a/ui/app/src/state/epics/contentTypes.ts
+++ b/ui/app/src/state/epics/contentTypes.ts
@@ -65,11 +65,14 @@ export default [
 			ofType(fetchComponentsByContentType.type, setContentTypeFilter.type),
 			withLatestFrom(state$),
 			switchMap(([, state]) => {
+				// allowedContentTypes is an array of content type IDs that are 'compatible' with preview.
+				// For a content type to be compatible, the type should have the 'shareExisting' property set to true.
+				// *Note that this is different from the 'shared' property, which means that new content of the type can be created.
 				let allowedContentTypes = Object.entries(state.preview.guest?.allowedContentTypes ?? {}).flatMap(
-					([key, type]) => (type.shared ? [key] : [])
+					([key, type]) => (type.sharedExisting ? [key] : [])
 				);
 				// If '*' is included in allowedContentTypes, it means that all content types are allowed.
-				if (allowedContentTypes.includes('*')) {
+				if (allowedContentTypes.includes('*') && state.preview.guest.allowedContentTypes['*'].sharedExisting) {
 					allowedContentTypes = Object.values(state.contentTypes.byId)
 						.filter((contentType) => contentType.type === 'component' && !contentType.id.includes('/level-descriptor'))
 						.map((contentType) => contentType.id);

--- a/ui/guest/src/react/ZoneMarker.tsx
+++ b/ui/guest/src/react/ZoneMarker.tsx
@@ -179,7 +179,9 @@ export function ZoneMarker(props: ZoneMarkerProps) {
 									onClick={(e) => e.stopPropagation()}
 								>
 									{Object.entries(allowedTypesMeta).map(([id, modes]) => {
-										const type = contentTypes[id];
+										// 'id' can be '*' (meaning all content types), so we need to handle that scenario
+										// TODO: i18n
+										const type = id === '*' ? { id: 'all', name: 'all types' } : contentTypes[id];
 										const { backgroundColor, textColor } = getAvatarWithIconColors(
 											type?.id ?? type?.name,
 											theme,

--- a/ui/guest/src/react/ZoneMarker.tsx
+++ b/ui/guest/src/react/ZoneMarker.tsx
@@ -181,7 +181,7 @@ export function ZoneMarker(props: ZoneMarkerProps) {
 									{Object.entries(allowedTypesMeta).map(([id, modes]) => {
 										// 'id' can be '*' (meaning all content types), so we need to handle that scenario
 										// TODO: i18n
-										const type = id === '*' ? { id: 'all', name: 'all types' } : contentTypes[id];
+										const type = id === '*' ? { id: 'all', name: 'All types' } : contentTypes[id];
 										const { backgroundColor, textColor } = getAvatarWithIconColors(
 											type?.id ?? type?.name,
 											theme,


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured datasource properties are consistently updated and reflect parsed values when referenced directly.  
- **New Features**
  - Expanded content type permissions to include a global wildcard, allowing broader access to components.  
  - Improved handling of wildcard content types for better classification and fetching of allowed components.  
  - Added support for a global wildcard representation in content type displays for clearer identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->