### PR TITLE
[8115] Path Navigator Tree stays in loading state when content doesn't exist

### DIFF
--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -214,7 +214,8 @@ export function PathNavigatorTree(props: PathNavigatorTreeProps) {
 		};
 	}, [dispatch, id, onSearch$, rootPath]);
 
-	if (!rootItem || !state) {
+	// If there is no state yet, or if the root item is nullish and the rootPath is not missing, show loading skeleton.
+	if (!state || (!rootItem && !state.isRootPathMissing)) {
 		const storedState = getStoredPathNavigatorTree(uuid, user.username, id);
 		return <PathNavigatorSkeleton renderBody={storedState ? !storedState.collapsed : !initialCollapsed} />;
 	}

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeUI.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeUI.tsx
@@ -130,7 +130,7 @@ export function PathNavigatorTreeUI(props: PathNavigatorTreeUIProps) {
 			/>
 			{isRootPathMissing ? (
 				<ErrorState
-					sxs={{ image: { display: 'none' } }}
+					sxs={{ root: { textAlign: 'center' }, image: { display: 'none' } }}
 					title={
 						<FormattedMessage
 							id="pathNavigatorTree.missingRootPath"


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading skeleton behavior to avoid displaying it when the root path is missing.
  - Enhanced error state appearance by centering the text when the root path is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->