### PR TITLE
[4.x][8027] Opening a template editor form the content type or an item's options menu forces lowercase template names

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/ContentTypeManagement.tsx
+++ b/ui/app/src/components/ContentTypeManagement/ContentTypeManagement.tsx
@@ -31,6 +31,7 @@ import {
   emitSystemEvent
 } from '../../state/actions/system';
 import { ProjectToolsRoutes } from '../../env/routes';
+import { fetchContentTypes } from '../../state/actions/preview';
 
 export interface ContentTypeManagementProps {
   embedded?: boolean;
@@ -61,6 +62,7 @@ export function ContentTypeManagement(props: ContentTypeManagementProps) {
       .subscribe((e: any) => {
         switch (e.data.type) {
           case 'CONTENT_TYPES_ON_SAVED': {
+            dispatch(fetchContentTypes());
             switch (e.data.saveType) {
               case 'saveAndClose':
                 onClose?.();


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8027