### PR TITLE
[8052] Item selectors should allow navigating to the item when the form is in view mode

### DIFF
--- a/static-assets/components/cstudio-forms/controls/node-selector.js
+++ b/static-assets/components/cstudio-forms/controls/node-selector.js
@@ -408,7 +408,9 @@ YAHOO.extend(CStudioForms.Controls.NodeSelector, CStudioForms.CStudioFormField, 
 					// isEditable: studio-ui has mechanisms to edit the item (e.g. a component or a text file)
 					// allowEdit: the datasource has edit capabilities (datasource.edit exists).
 					const isEditable = this.allowEdit && (isComponent || craftercms.utils.content.isEditableAsset(item.key));
-					if (isEditable && hasEditAction) {
+					// At this point, we only need to check if the item is editable (see definition above). If the user doesn't
+					// have write permission, the datasource.edit method will open the item in view mode.
+					if (isEditable) {
 						$actionsContainer.append(editBtn);
 						editBtn.on('click', function () {
 							const elIndex = $(this).data('index');


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for displaying the edit button in the node selector, making it visible for all editable items regardless of user permissions.

- **Documentation**
  - Updated comments to clarify that items without write permission will open in view mode when the edit button is clicked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->