### PR TITLE
[8217] Site switcher dropdown focus is not visible

### DIFF
--- a/ui/app/src/components/SiteSwitcherSelect/SiteSwitcherSelect.tsx
+++ b/ui/app/src/components/SiteSwitcherSelect/SiteSwitcherSelect.tsx
@@ -31,6 +31,7 @@ import SiteStatusIndicator from '../SiteStatusIndicator/SiteStatusIndicator';
 import { previewSwitch } from '../../services/security';
 import { BaseSelectProps } from '@mui/material/Select/Select';
 import { PartialSxRecord } from '../../models';
+import { outlinedInputClasses } from '@mui/material';
 
 export interface SiteSwitcherSelectProps extends BaseSelectProps {
 	site: string;
@@ -71,13 +72,7 @@ function SiteSwitcherSelect(props: SiteSwitcherSelectProps) {
 			sx={{
 				maxWidth: 150,
 				background: 'transparent',
-				'.MuiOutlinedInput-notchedOutline': { border: 0 },
-				'&.MuiInput-underline::before': {
-					display: 'none'
-				},
-				'&.MuiInput-underline::after': {
-					display: 'none'
-				},
+				[`.${outlinedInputClasses.notchedOutline}`]: { border: 0 },
 				...sxs?.menuRoot,
 				[`& .${selectClasses.select}`]: {
 					border: 'none',

--- a/ui/app/src/components/SiteSwitcherSelect/SiteSwitcherSelect.tsx
+++ b/ui/app/src/components/SiteSwitcherSelect/SiteSwitcherSelect.tsx
@@ -65,12 +65,13 @@ function SiteSwitcherSelect(props: SiteSwitcherSelectProps) {
 	return (
 		<Select
 			displayEmpty
-			variant="standard"
+			variant="outlined"
 			{...rest}
 			className={props.className}
 			sx={{
 				maxWidth: 150,
 				background: 'transparent',
+				'.MuiOutlinedInput-notchedOutline': { border: 0 },
 				'&.MuiInput-underline::before': {
 					display: 'none'
 				},

--- a/ui/app/src/components/SiteSwitcherSelect/SiteSwitcherSelect.tsx
+++ b/ui/app/src/components/SiteSwitcherSelect/SiteSwitcherSelect.tsx
@@ -31,7 +31,7 @@ import SiteStatusIndicator from '../SiteStatusIndicator/SiteStatusIndicator';
 import { previewSwitch } from '../../services/security';
 import { BaseSelectProps } from '@mui/material/Select/Select';
 import { PartialSxRecord } from '../../models';
-import { outlinedInputClasses } from '@mui/material';
+import { outlinedInputClasses } from '@mui/material/OutlinedInput';
 
 export interface SiteSwitcherSelectProps extends BaseSelectProps {
 	site: string;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of the site switcher dropdown to use an outlined style, improving visual consistency with other components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->