### PR TITLE
[8055] /site/components/{parentPath[0]} doesn't work after two layers of "embedded" components

### DIFF
--- a/static-assets/components/cstudio-forms/data-sources/embedded-content.js
+++ b/static-assets/components/cstudio-forms/data-sources/embedded-content.js
@@ -56,7 +56,11 @@ YAHOO.extend(CStudioForms.Datasources.EmbeddedContent, CStudioForms.CStudioFormD
 				(contentType) => contentType.type === 'component' && contentType.name !== '/component/level-descriptor'
 			);
 		} else {
-			let parentPath = _self.form.path;
+			const urlParams = new URLSearchParams(window.location.search);
+			// If `self.form.path` is undefined, but the URL has a `parentPath` parameter, it means that the form is embedded.
+			// In that case, we use the `parentPath` parameter as the parent path (meaning that the parent path is the immediate
+			// shared parent).
+			let parentPath = Boolean(_self.form.path) ? _self.form.path : urlParams.get('parentPath');
 			CStudioAuthoring.Operations.openContentWebForm(
 				_self.contentType,
 				null,

--- a/ui/app/src/utils/path.ts
+++ b/ui/app/src/utils/path.ts
@@ -298,7 +298,10 @@ export function getControllerPath(type: SystemType): string {
 	return `/scripts/${type === 'page' ? 'pages' : 'components'}`;
 }
 
+// For nested embedded components, parentPath will be the last non-embedded (shared) path, meaning that the parent
+// path will always be a 'physical' path.
 const availableMacrosRegex = /{(objectId|objectGroupId|objectGroupId2|year|month|yyyy|mm|dd|parentPath(\[[0-9]+])?)}/;
+
 export function processPathMacros(dependencies: {
 	path: string;
 	objectId: string;

--- a/ui/legacy/components/cstudio-forms/data-sources/components.js
+++ b/ui/legacy/components/cstudio-forms/data-sources/components.js
@@ -393,7 +393,11 @@
 				? this._processPathsForMacros(this.baseRepoPath)
 				: craftercms.utils.content.generateComponentBasePath(contentType);
 
-			let parentPath = self.form.path;
+			const urlParams = new URLSearchParams(window.location.search);
+			// If `self.form.path` is undefined, but the URL has a `parentPath` parameter, it means that the form is embedded.
+			// In that case, we use the `parentPath` parameter as the parent path (meaning that the parent path is the immediate
+			// shared parent).
+			let parentPath = Boolean(self.form.path) ? self.form.path : urlParams.get('parentPath');
 			CStudioAuthoring.Operations.openContentWebForm(
 				contentType,
 				null,


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of embedded forms by correctly determining the parent path from the URL if it is not set, ensuring forms function as expected in more scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->