### PR TITLE
[8319] Publish Approval dialog should default to the NOW option when approving a request that was subitted with NOW as the preferred publish time

### DIFF
--- a/ui/app/src/components/PublishPackageReviewDialog/PublishingPackageReviewDialogContainer.tsx
+++ b/ui/app/src/components/PublishPackageReviewDialog/PublishingPackageReviewDialogContainer.tsx
@@ -193,7 +193,7 @@ export function PublishingPackageReviewDialogContainer(props: PublishingPackageR
 		if (state.action === 'approve') {
 			const data: PublishingPackageApproveParams = {
 				comment: state.approverComment,
-				schedule: state.scheduling === 'custom' ? state.schedule.toISOString() : null,
+				schedule: state.scheduling === 'custom' || state.scheduling === 'keep' ? state.schedule.toISOString() : null,
 				updateSchedule: true
 			};
 

--- a/ui/app/src/components/PublishPackageReviewDialog/PublishingPackageReviewDialogContainer.tsx
+++ b/ui/app/src/components/PublishPackageReviewDialog/PublishingPackageReviewDialogContainer.tsx
@@ -290,7 +290,7 @@ export function PublishingPackageReviewDialogContainer(props: PublishingPackageR
 										<Typography variant="body2" color="textSecondary" sx={{ mb: 1 }}>
 											<FormattedMessage defaultMessage="Scheduling" />
 										</Typography>
-										<RadioGroup sx={{ mb: 1 }} onChange={onArgumentChange} name="scheduling">
+										<RadioGroup sx={{ mb: 1 }} onChange={onArgumentChange} name="scheduling" value={state.scheduling}>
 											{publishingPackage?.schedule && (
 												<FormControlLabel
 													value="keep"

--- a/ui/app/src/components/PublishPackageReviewDialog/PublishingPackageReviewDialogContainer.tsx
+++ b/ui/app/src/components/PublishPackageReviewDialog/PublishingPackageReviewDialogContainer.tsx
@@ -128,7 +128,7 @@ export function PublishingPackageReviewDialogContainer(props: PublishingPackageR
 	useEffect(() => {
 		setState({
 			scheduling: publishingPackage?.schedule ? 'keep' : 'now',
-			schedule: new Date(publishingPackage?.schedule) ?? createAtLeastHalfHourInFutureDate()
+			schedule: publishingPackage?.schedule ? new Date(publishingPackage.schedule) : createAtLeastHalfHourInFutureDate()
 		});
 	}, [publishingPackage, setState]);
 

--- a/ui/app/src/components/PublishPackageReviewDialog/PublishingPackageReviewDialogContainer.tsx
+++ b/ui/app/src/components/PublishPackageReviewDialog/PublishingPackageReviewDialogContainer.tsx
@@ -193,7 +193,12 @@ export function PublishingPackageReviewDialogContainer(props: PublishingPackageR
 		if (state.action === 'approve') {
 			const data: PublishingPackageApproveParams = {
 				comment: state.approverComment,
-				schedule: state.scheduling === 'custom' || state.scheduling === 'keep' ? state.schedule.toISOString() : null,
+				schedule:
+					state.scheduling === 'custom'
+						? state.schedule.toISOString()
+						: state.scheduling === 'keep'
+							? new Date(publishingPackage.schedule).toISOString()
+							: null,
 				updateSchedule: true
 			};
 

--- a/ui/app/src/utils/itemActions.ts
+++ b/ui/app/src/utils/itemActions.ts
@@ -924,7 +924,7 @@ export const itemActionDispatcher = ({
 		case 'schedulePublish':
 		case 'requestPublish': {
 			const schedulingMap = {
-				approvePublish: null,
+				approvePublish: undefined,
 				schedulePublish: 'custom',
 				requestPublish: 'now',
 				publish: 'now'


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approving a publish now preserves any previously scheduled time instead of clearing it, preventing invalid/empty schedule values.
  * Scheduling options (Keep/Now/Later) reliably reflect your current selection in the dialog.
  * Improved consistency between the Keep/Now/Later controls and the date-time picker so saved schedules match what you selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->