### PR TITLE
[8323] Cancel button not visible in content type editor help text modal when in dark mode

### DIFF
--- a/ui/scss/src/forms-engine.scss
+++ b/ui/scss/src/forms-engine.scss
@@ -191,8 +191,9 @@ hr.MuiDivider-root {
 	overflow-y: auto;
 }
 
-// Dark mode styles should not apply on the .contentTypePopupBtn buttons
-.contentTypePopupBtn {
+// Dark mode styles should not apply on the .contentTypePopupBtn and #richTextDialog buttons
+.contentTypePopupBtn,
+#richTextDialog {
 	.btn {
 		border-color: rgba(0, 0, 0, 0) !important;
 	}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dark mode styling in the Rich Text dialog so buttons and controls display with proper colors and contrast.
  * Extended dark mode handling to additional dialog components for a more consistent appearance across the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->