### PR TITLE
[8335] Typo on review dialog of project duplication

### DIFF
--- a/ui/app/src/components/DuplicateSiteDialog/DuplicateSiteDialogContainer.tsx
+++ b/ui/app/src/components/DuplicateSiteDialog/DuplicateSiteDialogContainer.tsx
@@ -374,7 +374,7 @@ export function DuplicateSiteDialogContainer(props: DuplicateSiteDialogContainer
 								</Grid>
 								<Grid size={12}>
 									<Typography variant="h6" gutterBottom>
-										<FormattedMessage defaultMessage="Project info" />
+										<FormattedMessage defaultMessage="Project Info" />
 										<IconButton
 											onClick={handleBack}
 											size="large"


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized header capitalization to “Project Info” in the Duplicate Site dialog for improved consistency and readability.
  * Applies to the project details step during site duplication, aligning with title case used across dialogs and wizards.
  * No functional changes or workflow impact; all other text, interactions, and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->