### PR TITLE
[7418] FE2 - Fix table of contents scroll

### DIFF
--- a/ui/app/src/components/FormsEngine/components/SectionAccordion.tsx
+++ b/ui/app/src/components/FormsEngine/components/SectionAccordion.tsx
@@ -51,7 +51,6 @@ export function SectionAccordion({
 	const [isExpanded, setExpanded] = useAtom(useContext(StableFormContext).atoms.expandedStateBySectionId[section.id]);
 	return (
 		<Accordion
-			data-section-id={section.id}
 			elevation={isDarkMode ? 2 : undefined}
 			{...accordionProps}
 			expanded={isExpanded}
@@ -71,7 +70,7 @@ export function SectionAccordion({
 				accordionProps.sx
 			)}
 		>
-			<AccordionSummary {...slotProps?.accordionSummary} data-section-id={section.title}>
+			<AccordionSummary {...slotProps?.accordionSummary} data-section-id={section.id}>
 				<Typography>{section.title}</Typography>
 				{slotProps?.accordionSummary?.children}
 			</AccordionSummary>

--- a/ui/app/src/components/FormsEngine/components/SectionAccordion.tsx
+++ b/ui/app/src/components/FormsEngine/components/SectionAccordion.tsx
@@ -51,6 +51,7 @@ export function SectionAccordion({
 	const [isExpanded, setExpanded] = useAtom(useContext(StableFormContext).atoms.expandedStateBySectionId[section.id]);
 	return (
 		<Accordion
+			data-section-id={section.id}
 			elevation={isDarkMode ? 2 : undefined}
 			{...accordionProps}
 			expanded={isExpanded}

--- a/ui/app/src/components/FormsEngine/components/TableOfContents.tsx
+++ b/ui/app/src/components/FormsEngine/components/TableOfContents.tsx
@@ -59,17 +59,18 @@ export function TableOfContents({ containerRef, fieldsToRender }: TableOfContent
 	};
 	const handleSectionClick = (event: SyntheticEvent) => {
 		setOpenDrawerSidebar(false);
-		const sectionId = event.currentTarget.parentElement.getAttribute('data-section-id');
+		const sectionId = event.currentTarget.getAttribute('data-section-id');
 		if (!store.get(expandedStateAtoms[sectionId])) {
 			store.set(expandedStateAtoms[sectionId], true);
 		}
 		scrollToTarget(containerRef.current.querySelector(`[data-area-id="formBody"] [data-section-id="${sectionId}"]`));
 	};
 	const handleFieldClick = (event: SyntheticEvent) => {
+		event.stopPropagation();
 		// TODO: When filtering and clicked, the section may be collapsed. Through DOM, we can't
 		//  get the section id since sections aren't rendered when filtering. How do we get to the section to expand it?
 		setOpenDrawerSidebar(false);
-		const fieldId = event.currentTarget.parentElement.getAttribute('data-field-id');
+		const fieldId = event.currentTarget.getAttribute('data-field-id');
 		scrollToTarget(containerRef.current.querySelector(`[data-area-id="formBody"] [data-field-id="${fieldId}"]`));
 	};
 	const handleSectionExpansionToggleClick = (event: SyntheticEvent, itemId: string, expanded: boolean) => {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of navigation from the Table of Contents—clicks consistently take you to the intended section or field.
  - Prevented accidental section toggling when selecting a field item, reducing unintended interactions.
  - Enhanced linking between TOC items and form sections for more accurate scrolling and focus behavior.
  - Overall, refined click handling provides a smoother, more predictable experience when navigating complex forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->