### PR TITLE
[7418] FE2 - Validators update to handle MessageDescriptors

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/utils.ts
+++ b/ui/app/src/components/ContentTypeManagement/utils.ts
@@ -732,29 +732,29 @@ export function applyTranslations(
 ): PartialContentType {
 	const translatedSections = descriptor.sections.map((section) => ({
 		...section,
-		title: translateIfMessageDescriptor(section['title'], formatMessage) as string,
-		description: translateIfMessageDescriptor(section['description'], formatMessage) as string
+		title: translateIfMessageDescriptor(section['title'], formatMessage),
+		description: translateIfMessageDescriptor(section['description'], formatMessage)
 	}));
 
 	const translatedFieldsArray = Object.values(descriptor.fields).map((field) => {
 		return {
 			...field,
-			name: translateIfMessageDescriptor(field['name'], formatMessage) as string,
-			description: translateIfMessageDescriptor(field['description'], formatMessage) as string
+			name: translateIfMessageDescriptor(field['name'], formatMessage),
+			description: translateIfMessageDescriptor(field['description'], formatMessage)
 		};
 	});
 	const translatedFieldsLookup = createLookupTable(translatedFieldsArray, 'id');
 
 	return {
 		...descriptor,
-		name: translateIfMessageDescriptor(descriptor['name'], formatMessage) as string,
-		description: translateIfMessageDescriptor(descriptor['description'], formatMessage) as string,
+		name: translateIfMessageDescriptor(descriptor['name'], formatMessage),
+		description: translateIfMessageDescriptor(descriptor['description'], formatMessage),
 		sections: translatedSections,
 		fields: translatedFieldsLookup as unknown as LookupTable<ContentTypeField>
 	};
 }
 
-function translateIfMessageDescriptor(
+export function translateIfMessageDescriptor(
 	titleOrDescriptor: TranslationOrText,
 	formatMessage: IntlShape['formatMessage']
 ): string {

--- a/ui/app/src/components/ContentTypeManagement/utils.ts
+++ b/ui/app/src/components/ContentTypeManagement/utils.ts
@@ -759,6 +759,7 @@ export function translateIfMessageDescriptor(
 	formatMessage: IntlShape['formatMessage']
 ): string {
 	const value = getPossibleTranslation(titleOrDescriptor, formatMessage);
+	// TODO: Ignoring non string values. Must adjust to not ignore and actually handle either here or at the consumer level.
 	return typeof value === 'string' ? value : '';
 }
 

--- a/ui/app/src/components/ContentTypeManagement/utils.ts
+++ b/ui/app/src/components/ContentTypeManagement/utils.ts
@@ -54,6 +54,7 @@ import type { BuiltInControlType } from '../FormsEngine/lib/controlMap';
 import { asArray } from '../../utils/array';
 import { componentsDataSourceContentTypesPropertyNames, systemValidationsKeysMap } from '../../utils/contentType';
 import { XmlKeys } from '../FormsEngine/lib/formConsts';
+import { getPossibleTranslation } from '../../utils/i18n';
 
 // TODO: assess which of the utils here should go to utils/contentType.ts, or other places (serializers, etc.)
 
@@ -731,52 +732,33 @@ export function applyTranslations(
 ): PartialContentType {
 	const translatedSections = descriptor.sections.map((section) => ({
 		...section,
-		title: translateIfMessageDescriptor(formatMessage, section, 'title'),
-		description: translateIfMessageDescriptor(formatMessage, section, 'description')
+		title: translateIfMessageDescriptor(section['title'], formatMessage) as string,
+		description: translateIfMessageDescriptor(section['description'], formatMessage) as string
 	}));
 
 	const translatedFieldsArray = Object.values(descriptor.fields).map((field) => {
 		return {
 			...field,
-			name: translateIfMessageDescriptor(formatMessage, field, 'name'),
-			description: translateIfMessageDescriptor(formatMessage, field, 'description')
+			name: translateIfMessageDescriptor(field['name'], formatMessage) as string,
+			description: translateIfMessageDescriptor(field['description'], formatMessage) as string
 		};
 	});
 	const translatedFieldsLookup = createLookupTable(translatedFieldsArray, 'id');
 
 	return {
 		...descriptor,
-		name: translateIfMessageDescriptor(formatMessage, descriptor, 'name'),
-		description: translateIfMessageDescriptor(formatMessage, descriptor, 'description'),
+		name: translateIfMessageDescriptor(descriptor['name'], formatMessage) as string,
+		description: translateIfMessageDescriptor(descriptor['description'], formatMessage) as string,
 		sections: translatedSections,
 		fields: translatedFieldsLookup as unknown as LookupTable<ContentTypeField>
 	};
 }
 
 function translateIfMessageDescriptor(
-	formatMessage: IntlShape['formatMessage'],
-	target: DescriptorContentType,
-	property: 'name' | 'description'
-): string;
-function translateIfMessageDescriptor(
-	formatMessage: IntlShape['formatMessage'],
-	target: DescriptorSection,
-	property: 'title' | 'description'
-): string;
-function translateIfMessageDescriptor(
-	formatMessage: IntlShape['formatMessage'],
-	target: DescriptorField,
-	property: 'name' | 'description' | 'helpText'
-): string;
-function translateIfMessageDescriptor<K>(
-	formatMessage: IntlShape['formatMessage'],
-	target: K,
-	property: keyof K
+	titleOrDescriptor: TranslationOrText,
+	formatMessage: IntlShape['formatMessage']
 ): string {
-	const value = target[property];
-	if (nnou(value) && typeof value === 'object') {
-		return formatMessage(value as MessageDescriptor);
-	}
+	const value = getPossibleTranslation(titleOrDescriptor, formatMessage);
 	return typeof value === 'string' ? value : '';
 }
 

--- a/ui/app/src/components/FormsEngine/components/FormsEngineField.tsx
+++ b/ui/app/src/components/FormsEngine/components/FormsEngineField.tsx
@@ -273,7 +273,7 @@ export const FormsEngineField = forwardRef<HTMLDivElement, FormsEngineFieldProps
 			{children}
 			{hasDescription && <FormHelperText>{field.description}</FormHelperText>}
 			{!isValid &&
-				validityData?.messages?.length &&
+				!!validityData?.messages?.length &&
 				validityData.messages.map((message, key) => (
 					<FormHelperText key={key}>{translateIfMessageDescriptor(message, formatMessage)}</FormHelperText>
 				))}

--- a/ui/app/src/components/FormsEngine/components/FormsEngineField.tsx
+++ b/ui/app/src/components/FormsEngine/components/FormsEngineField.tsx
@@ -43,6 +43,7 @@ import {
 	useStableGlobalApiContext
 } from '../lib/formsEngineContext';
 import { useAtomValue } from 'jotai';
+import { translateIfMessageDescriptor } from '../lib/formUtils';
 
 function createLengthBlock({ length, max, min }: { length: number; max: number; min: number }) {
 	const pieces = [];
@@ -273,7 +274,9 @@ export const FormsEngineField = forwardRef<HTMLDivElement, FormsEngineFieldProps
 			{hasDescription && <FormHelperText>{field.description}</FormHelperText>}
 			{!isValid &&
 				validityData?.messages?.length &&
-				validityData.messages.map((message, key) => <FormHelperText key={key}>{message}</FormHelperText>)}
+				validityData.messages.map((message, key) => (
+					<FormHelperText key={key}>{translateIfMessageDescriptor(message, formatMessage)}</FormHelperText>
+				))}
 		</FormControl>
 	);
 });

--- a/ui/app/src/components/FormsEngine/components/FormsEngineField.tsx
+++ b/ui/app/src/components/FormsEngine/components/FormsEngineField.tsx
@@ -43,7 +43,7 @@ import {
 	useStableGlobalApiContext
 } from '../lib/formsEngineContext';
 import { useAtomValue } from 'jotai';
-import { getPossibleTranslation } from '../../../utils/i18n';
+import { translateIfMessageDescriptor } from '../../ContentTypeManagement/utils';
 
 function createLengthBlock({ length, max, min }: { length: number; max: number; min: number }) {
 	const pieces = [];
@@ -275,7 +275,7 @@ export const FormsEngineField = forwardRef<HTMLDivElement, FormsEngineFieldProps
 			{!isValid &&
 				!!validityData?.messages?.length &&
 				validityData.messages.map((message, key) => (
-					<FormHelperText key={key}>{getPossibleTranslation(message, formatMessage)}</FormHelperText>
+					<FormHelperText key={key}>{translateIfMessageDescriptor(message, formatMessage)}</FormHelperText>
 				))}
 		</FormControl>
 	);

--- a/ui/app/src/components/FormsEngine/components/FormsEngineField.tsx
+++ b/ui/app/src/components/FormsEngine/components/FormsEngineField.tsx
@@ -43,7 +43,7 @@ import {
 	useStableGlobalApiContext
 } from '../lib/formsEngineContext';
 import { useAtomValue } from 'jotai';
-import { translateIfMessageDescriptor } from '../lib/formUtils';
+import { getPossibleTranslation } from '../../../utils/i18n';
 
 function createLengthBlock({ length, max, min }: { length: number; max: number; min: number }) {
 	const pieces = [];
@@ -275,7 +275,7 @@ export const FormsEngineField = forwardRef<HTMLDivElement, FormsEngineFieldProps
 			{!isValid &&
 				!!validityData?.messages?.length &&
 				validityData.messages.map((message, key) => (
-					<FormHelperText key={key}>{translateIfMessageDescriptor(message, formatMessage)}</FormHelperText>
+					<FormHelperText key={key}>{getPossibleTranslation(message, formatMessage)}</FormHelperText>
 				))}
 		</FormControl>
 	);

--- a/ui/app/src/components/FormsEngine/lib/formUtils.tsx
+++ b/ui/app/src/components/FormsEngine/lib/formUtils.tsx
@@ -721,10 +721,3 @@ export function prepareEmbeddedItemForm(props: {
 		}
 	};
 }
-
-export function translateIfMessageDescriptor(
-	message: string | MessageDescriptor,
-	formatMessage: IntlShape['formatMessage']
-): string {
-	return typeof message === 'string' ? message : formatMessage(message);
-}

--- a/ui/app/src/components/FormsEngine/lib/formUtils.tsx
+++ b/ui/app/src/components/FormsEngine/lib/formUtils.tsx
@@ -44,7 +44,7 @@ import { nanoid } from 'nanoid';
 import { popDialog, pushDialog } from '../../../state/actions/dialogStack';
 import alertDialogUrl from '../../../assets/warning.svg';
 import PrimaryButton from '../../PrimaryButton';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, type MessageDescriptor } from 'react-intl';
 import { AlertDialogProps } from '../../AlertDialog';
 import { Theme } from '@mui/material/styles';
 import { AtomWithStorage, JotaiStore } from '../types';
@@ -720,4 +720,11 @@ export function prepareEmbeddedItemForm(props: {
 			contentObject
 		}
 	};
+}
+
+export function translateIfMessageDescriptor(
+	message: string | MessageDescriptor,
+	formatMessage: IntlShape['formatMessage']
+): string {
+	return typeof message === 'string' ? message : formatMessage(message);
 }

--- a/ui/app/src/components/FormsEngine/lib/formUtils.tsx
+++ b/ui/app/src/components/FormsEngine/lib/formUtils.tsx
@@ -44,7 +44,7 @@ import { nanoid } from 'nanoid';
 import { popDialog, pushDialog } from '../../../state/actions/dialogStack';
 import alertDialogUrl from '../../../assets/warning.svg';
 import PrimaryButton from '../../PrimaryButton';
-import { FormattedMessage, type MessageDescriptor } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { AlertDialogProps } from '../../AlertDialog';
 import { Theme } from '@mui/material/styles';
 import { AtomWithStorage, JotaiStore } from '../types';

--- a/ui/app/src/components/FormsEngine/lib/validators.ts
+++ b/ui/app/src/components/FormsEngine/lib/validators.ts
@@ -27,33 +27,33 @@ type ValidatorFunctionDef = (
 	messages: FieldValidityState['messages']
 ) => boolean;
 export const validatorsMap: Partial<Record<BuiltInControlType, ValidatorFunctionDef>> = {
-	repeat: null,
-	'auto-filename': null,
-	'aws-file-upload': null,
-	'checkbox-group': null,
-	checkbox: null,
-	'date-time': null,
-	disabled: null,
-	dropdown: null,
-	'file-name': null,
-	forcehttps: null,
-	'image-picker': null,
-	input: null,
-	'internal-name': null,
-	label: null,
-	'link-input': null,
-	'link-textarea': null,
-	'linked-dropdown': null,
-	'locale-selector': null,
-	'node-selector': null,
-	'numeric-input': null,
-	'page-nav-order': null,
-	rte: null,
-	textarea: null,
-	time: null,
-	'transcoded-video-picker': null,
-	uuid: null,
-	'video-picker': null,
+	repeat: undefined,
+	'auto-filename': undefined,
+	'aws-file-upload': undefined,
+	'checkbox-group': undefined,
+	checkbox: undefined,
+	'date-time': undefined,
+	disabled: undefined,
+	dropdown: undefined,
+	'file-name': undefined,
+	forcehttps: undefined,
+	'image-picker': undefined,
+	input: undefined,
+	'internal-name': undefined,
+	label: undefined,
+	'link-input': undefined,
+	'link-textarea': undefined,
+	'linked-dropdown': undefined,
+	'locale-selector': undefined,
+	'node-selector': undefined,
+	'numeric-input': undefined,
+	'page-nav-order': undefined,
+	rte: undefined,
+	textarea: undefined,
+	time: undefined,
+	'transcoded-video-picker': undefined,
+	uuid: undefined,
+	'video-picker': undefined,
 	colorPicker: undefined
 };
 
@@ -74,7 +74,7 @@ export function validateFieldValue(field: ContentTypeField, currentValue: unknow
 	}
 	const validator = validatorsMap[field.type as BuiltInControlType];
 	// If there's a validator, run it. If not, it's valid.
-	const isValid = validator ? validator(field, currentValue, messages) : true;
+	const isValid = typeof validator === 'function' ? validator(field, currentValue, messages) : true;
 	return { isValid, messages };
 }
 

--- a/ui/app/src/components/FormsEngine/lib/validators.ts
+++ b/ui/app/src/components/FormsEngine/lib/validators.ts
@@ -19,8 +19,14 @@ import type { ContentTypeField } from '../../../models/ContentType';
 import type { BuiltInControlType } from './controlMap';
 import LookupTable from '../../../models/LookupTable';
 import { XmlKeys } from './formConsts';
+import { defineMessage, type MessageDescriptor } from 'react-intl';
 
-export const validatorsMap: Record<BuiltInControlType, ElementType> = {
+type ValidatorFunctionDef = (
+	field: ContentTypeField,
+	currentValue: unknown,
+	messages: FieldValidityState['messages']
+) => boolean;
+export const validatorsMap: Partial<Record<BuiltInControlType, ValidatorFunctionDef>> = {
 	repeat: null,
 	'auto-filename': null,
 	'aws-file-upload': null,
@@ -53,24 +59,23 @@ export const validatorsMap: Record<BuiltInControlType, ElementType> = {
 
 export interface FieldValidityState {
 	isValid: boolean;
-	messages: string[];
+	messages: (string | MessageDescriptor)[];
 }
 
 export function validateFieldValue(field: ContentTypeField, currentValue: unknown): FieldValidityState {
-	let isValid = false;
+	const messages: FieldValidityState['messages'] = [];
 	const isRequired = isFieldRequired(field);
 	const isEmpty = isEmptyValue(field, currentValue);
-	if (!isRequired && isEmpty) {
-		// If not required and its empty, then it's valid.
-		isValid = true;
-	} else if (!isEmpty) {
-		// FE2 TODO: Add other validation types (max length, etc)...
-		isValid = true;
+
+	// If it's required, and the value is empty, then it's invalid.
+	if (isRequired && isEmpty) {
+		messages.push(defineMessage({ defaultMessage: 'This field is required.' }));
+		return { isValid: false, messages };
 	}
-	return {
-		isValid,
-		messages: isValid ? null : ['This field is required.']
-	};
+	const validator = validatorsMap[field.type as BuiltInControlType];
+	// If there's a validator, run it. If not, it's valid.
+	const isValid = validator ? validator(field, currentValue, messages) : true;
+	return { isValid, messages };
 }
 
 export function isEmptyValue(field: ContentTypeField, currentValue: unknown): boolean {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation error messages are now fully localized, including a clearer “This field is required.” message.
  * Improved translation support for content type titles, names, and descriptions for more consistent display across the app.

* **Bug Fixes**
  * Prevented empty or falsy validation messages from appearing in forms.
  * Standardized validation behavior across fields to ensure accurate, consistent error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->