### PR TITLE
[8339] TB2 - Fix s3 and webdav descriptors ids to match legacy ids

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgS3Repo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgS3Repo.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const imgS3RepoDataSourceDescriptor: DescriptorContentType = {
-	id: 'img-s3-repo',
+	id: 'img-S3-repo',
 	name: defineMessage({ defaultMessage: 'Image From S3 Repository' }),
 	description: '',
 	type: 'image',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgS3Upload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgS3Upload.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const imgS3UploadDataSourceDescriptor: DescriptorContentType = {
-	id: 'img-s3-upload',
+	id: 'img-S3-upload',
 	name: defineMessage({ defaultMessage: 'Image Uploaded to S3 Repository' }),
 	description: '',
 	type: 'image',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgWebDavRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgWebDavRepo.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const imgWebDavRepoDataSourceDescriptor: DescriptorContentType = {
-	id: 'img-webdav-repo',
+	id: 'img-WebDAV-repo',
 	name: defineMessage({ defaultMessage: 'Image From WebDav Repository' }),
 	description: '',
 	type: 'image',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgWebDavUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgWebDavUpload.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const imgWebDavUploadDataSourceDescriptor: DescriptorContentType = {
-	id: 'img-webdav-upload',
+	id: 'img-WebDAV-upload',
 	name: defineMessage({ defaultMessage: 'Image Uploaded to WebDav Repository' }),
 	description: '',
 	type: 'image',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/index.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/index.ts
@@ -78,24 +78,24 @@ export type BuiltInDataSourceType =
 	| 'flash-desktop-upload'
 	| 'img-desktop-upload'
 	| 'img-repository-upload'
-	| 'img-s3-repo'
-	| 'img-s3-upload'
-	| 'img-webdav-repo'
-	| 'img-webdav-upload'
+	| 'img-S3-repo'
+	| 'img-S3-upload'
+	| 'img-WebDAV-repo'
+	| 'img-WebDAV-upload'
 	| 'key-value-list'
-	| 's3-repo'
-	| 's3-upload'
+	| 'S3-repo'
+	| 'S3-upload'
 	| 'shared-content'
 	| 'simpleTaxonomy'
 	| 'video-browse-repo'
 	| 'video-desktop-upload'
-	| 'video-s3-repo'
-	| 'video-s3-transcoding'
-	| 'video-s3-upload'
-	| 'video-webdav-repo'
-	| 'video-webdav-upload'
-	| 'webdav-repo'
-	| 'webdav-upload';
+	| 'video-S3-repo'
+	| 'video-S3-transcoding'
+	| 'video-S3-upload'
+	| 'video-WebDAV-repo'
+	| 'video-WebDAV-upload'
+	| 'WebDAV-repo'
+	| 'WebDAV-upload';
 
 export const dataSourceDescriptors: Record<BuiltInDataSourceType, DescriptorContentType> = {
 	components: componentsDescriptor,
@@ -108,24 +108,24 @@ export const dataSourceDescriptors: Record<BuiltInDataSourceType, DescriptorCont
 	'flash-desktop-upload': flashDesktopUploadDescriptor,
 	'img-desktop-upload': imgDesktopUploadDescriptor,
 	'img-repository-upload': imgRepositoryUploadDescriptor,
-	'img-s3-repo': imgS3RepoDescriptor,
-	'img-s3-upload': imgS3UploadDescriptor,
-	'img-webdav-repo': imgWebDavRepoDescriptor,
-	'img-webdav-upload': imgWebdavUploadDescriptor,
+	'img-S3-repo': imgS3RepoDescriptor,
+	'img-S3-upload': imgS3UploadDescriptor,
+	'img-WebDAV-repo': imgWebDavRepoDescriptor,
+	'img-WebDAV-upload': imgWebdavUploadDescriptor,
 	'key-value-list': keyValueListDescriptor,
-	's3-repo': s3RepoDescriptor,
-	's3-upload': s3UploadDescriptor,
+	'S3-repo': s3RepoDescriptor,
+	'S3-upload': s3UploadDescriptor,
 	'shared-content': sharedContentDescriptor,
 	simpleTaxonomy: simpleTaxonomyDescriptor,
 	'video-browse-repo': videoBrowseRepoDescriptor,
 	'video-desktop-upload': videoDesktopUploadDescriptor,
-	'video-s3-repo': videoS3RepoDescriptor,
-	'video-s3-transcoding': videoS3TranscodingDescriptor,
-	'video-s3-upload': videoS3UploadDescriptor,
-	'video-webdav-repo': videoWebDavRepoDescriptor,
-	'video-webdav-upload': videoWebDavUploadDescriptor,
-	'webdav-repo': webDavRepoDescriptor,
-	'webdav-upload': webDavUploadDescriptor
+	'video-S3-repo': videoS3RepoDescriptor,
+	'video-S3-transcoding': videoS3TranscodingDescriptor,
+	'video-S3-upload': videoS3UploadDescriptor,
+	'video-WebDAV-repo': videoWebDavRepoDescriptor,
+	'video-WebDAV-upload': videoWebDavUploadDescriptor,
+	'WebDAV-repo': webDavRepoDescriptor,
+	'WebDAV-upload': webDavUploadDescriptor
 };
 
 export default dataSourceDescriptors;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/s3Repo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/s3Repo.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const s3RepoDataSourceDescriptor: DescriptorContentType = {
-	id: 's3-repo',
+	id: 'S3-repo',
 	name: defineMessage({ defaultMessage: 'File From S3 Repository' }),
 	description: '',
 	type: 'item',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/s3Upload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/s3Upload.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const s3UploadDataSourceDescriptor: DescriptorContentType = {
-	id: 's3-upload',
+	id: 'S3-upload',
 	name: defineMessage({ defaultMessage: 'File Uploaded to S3 Repository' }),
 	description: '',
 	type: 'item',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Repo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Repo.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const videoS3RepoDataSourceDescriptor: DescriptorContentType = {
-	id: 'video-s3-repo',
+	id: 'video-S3-repo',
 	name: defineMessage({ defaultMessage: 'Video From S3 Repository' }),
 	description: '',
 	type: 'video',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Transcoding.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Transcoding.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const videoS3TranscodingDataSourceDescriptor: DescriptorContentType = {
-	id: 'video-s3-transcoding',
+	id: 'video-S3-transcoding',
 	name: defineMessage({ defaultMessage: 'Video Transcoding From S3 Repository' }),
 	description: '',
 	type: 'transcoded-video',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Upload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Upload.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const videoS3UploadDataSourceDescriptor: DescriptorContentType = {
-	id: 'video-s3-upload',
+	id: 'video-S3-upload',
 	name: defineMessage({ defaultMessage: 'Video Uploaded to S3 Repository' }),
 	description: '',
 	type: 'video',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoWebDavRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoWebDavRepo.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const videoWebDavRepoDataSourceDescriptor: DescriptorContentType = {
-	id: 'video-webdav-repo',
+	id: 'video-WebDAV-repo',
 	name: defineMessage({ defaultMessage: 'Video From WebDav Repository' }),
 	description: '',
 	type: 'video',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoWebDavUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoWebDavUpload.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const videoWebDavUploadDataSourceDescriptor: DescriptorContentType = {
-	id: 'video-webdav-upload',
+	id: 'video-WebDAV-upload',
 	name: defineMessage({ defaultMessage: 'Video Uploaded to WebDav Repository' }),
 	description: '',
 	type: 'video',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/webDavRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/webDavRepo.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const webDavRepoDataSourceDescriptor: DescriptorContentType = {
-	id: 'webdav-repo',
+	id: 'WebDAV-repo',
 	name: defineMessage({ defaultMessage: 'File From WebDav Repository' }),
 	description: '',
 	type: 'item',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/webDavUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/webDavUpload.ts
@@ -19,7 +19,7 @@ import { createVirtualSection, DescriptorContentType } from '../../utils';
 import { defineMessage } from 'react-intl';
 
 export const webDavUploadDataSourceDescriptor: DescriptorContentType = {
-	id: 'webdav-upload',
+	id: 'WebDAV-upload',
 	name: defineMessage({ defaultMessage: 'File Uploaded to WebDav Repository' }),
 	description: '',
 	type: 'item',


### PR DESCRIPTION
Update the s3 and webdav descriptors ids and descriptorMap to match the legacy datasources ids

https://github.com/craftercms/craftercms/issues/8339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized casing for all data source identifiers to use proper S3/WebDAV capitalization across image and video variants (repo, upload, transcoding).
  - Aligned all corresponding options and mappings to the new identifier format.

- Style
  - Improved readability and consistency of identifier labels shown in selection lists and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->