### PR TITLE
[7418] Fix complementValuesWithSystemProps to avoid overriding already existing values

### DIFF
--- a/ui/app/src/components/FormsEngine/lib/useSaveForm.tsx
+++ b/ui/app/src/components/FormsEngine/lib/useSaveForm.tsx
@@ -149,18 +149,22 @@ function complementValuesWithSystemProps(
 	contentType: ContentType,
 	saveAsDraft: boolean
 ): void {
-	Object.assign(
-		values,
-		createObjectWithSystemProps(contentType, {
-			[XmlKeys.modelId]: id,
-			[XmlKeys.internalName]: values[XmlKeys.internalName] as string,
-			[XmlKeys.fileName]: (values[XmlKeys.fileName] ?? contentObject[XmlKeys.fileName]) as string,
-			[XmlKeys.folderName]: (values[XmlKeys.folderName] ?? contentObject[XmlKeys.folderName]) as string,
-			[XmlKeys.dateCreated]: contentObject[XmlKeys.dateCreated] as string,
-			[XmlKeys.dateCreatedDt]: contentObject[XmlKeys.dateCreatedDt] as string,
-			[XmlKeys.savedAsDraft]: saveAsDraft
-		})
-	);
+	const systemProps = createObjectWithSystemProps(contentType, {
+		[XmlKeys.modelId]: id,
+		[XmlKeys.internalName]: values[XmlKeys.internalName] as string,
+		[XmlKeys.fileName]: (values[XmlKeys.fileName] ?? contentObject[XmlKeys.fileName]) as string,
+		[XmlKeys.folderName]: (values[XmlKeys.folderName] ?? contentObject[XmlKeys.folderName]) as string,
+		[XmlKeys.dateCreated]: contentObject[XmlKeys.dateCreated] as string,
+		[XmlKeys.dateCreatedDt]: contentObject[XmlKeys.dateCreatedDt] as string,
+		[XmlKeys.savedAsDraft]: saveAsDraft
+	});
+
+	// Do not overwrite any existing value.
+	for (const key in systemProps) {
+		if (!(key in values)) {
+			values[key] = systemProps[key];
+		}
+	}
 }
 
 export default useSaveForm;


### PR DESCRIPTION
- Fix complementValuesWithSystemProps to avoid overwriting systemProps like 'disabled' when saving form.

https://github.com/craftercms/craftercms/issues/7418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where form data could be inadvertently overwritten during save operations, ensuring user-provided values are properly preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->