### PR TITLE
[7418] Use XML values on fields types in control descriptors

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/awsFileUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/awsFileUpload.ts
@@ -37,7 +37,7 @@ export const awsFileUploadDescriptor: DescriptorContentType = {
 	fields: {
 		profile_id: {
 			id: 'profile_id',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: 's3-default',
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/awsFileUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/awsFileUpload.ts
@@ -44,7 +44,7 @@ export const awsFileUploadDescriptor: DescriptorContentType = {
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkbox.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkbox.ts
@@ -37,14 +37,14 @@ export const checkboxDescriptor: DescriptorContentType = {
 	fields: {
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: false,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkboxGroup.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkboxGroup.ts
@@ -78,7 +78,7 @@ export const checkboxGroupDescriptor: DescriptorContentType = {
 		},
 		minSize: {
 			id: 'minSize',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Minimum Selected' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkboxGroup.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkboxGroup.ts
@@ -46,7 +46,7 @@ export const checkboxGroupDescriptor: DescriptorContentType = {
 		},
 		selectAll: {
 			id: 'selectAll',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Show select all' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
@@ -71,7 +71,7 @@ export const checkboxGroupDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/dateTime.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/dateTime.ts
@@ -90,7 +90,7 @@ export const dateTimeDescriptor: DescriptorContentType = {
 		},
 		populateDateExp: {
 			id: 'populateDateExp',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Populate Expression' }),
 			defaultValue: 'now',
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/dateTime.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/dateTime.ts
@@ -48,42 +48,42 @@ export const dateTimeDescriptor: DescriptorContentType = {
 	fields: {
 		showDate: {
 			id: 'showDate',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Show Date' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
 		},
 		showTime: {
 			id: 'showTime',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Show Time' }),
 			defaultValue: false,
 			validations: immutableEmptyObject
 		},
 		showClear: {
 			id: 'showClear',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Show Clear' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		showNowLink: {
 			id: 'showNowLink',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Show Now Link' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		populate: {
 			id: 'populate',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Populated' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
 		},
 		allowPastDate: {
 			id: 'allowPastDate',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow Past Date' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
@@ -97,28 +97,28 @@ export const dateTimeDescriptor: DescriptorContentType = {
 		},
 		useCustomTimezone: {
 			id: 'useCustomTimezone',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Use Custom Timezone' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		readonlyEdit: {
 			id: 'readonlyEdit',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only on Edit' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/disabled.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/disabled.ts
@@ -33,7 +33,7 @@ export const disabledDescriptor: DescriptorContentType = {
 	fields: {
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'readonly' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/dropdown.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/dropdown.ts
@@ -46,21 +46,21 @@ export const dropdownDescriptor: DescriptorContentType = {
 		},
 		emptyvalue: {
 			id: 'emptyvalue',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow Empty Value' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/fileName.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/fileName.ts
@@ -32,7 +32,7 @@ export const fileNameDescriptor: DescriptorContentType = {
 	fields: {
 		maxlength: {
 			id: 'maxlength',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Max Length' }),
 			defaultValue: 50,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/fileName.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/fileName.ts
@@ -39,14 +39,14 @@ export const fileNameDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		allowEditWithoutWarning: {
 			id: 'allowEditWithoutWarning',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow Edit Without Warning' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/forceHttps.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/forceHttps.ts
@@ -32,7 +32,7 @@ export const forceHttpsDescriptor: DescriptorContentType = {
 	fields: {
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/imagePicker.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/imagePicker.ts
@@ -74,14 +74,14 @@ export const imagePickerDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/imagePicker.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/imagePicker.ts
@@ -51,14 +51,14 @@ export const imagePickerDescriptor: DescriptorContentType = {
 		},
 		thumbnailWidth: {
 			id: 'thumbnailWidth',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Thumbnail Width' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		thumbnailHeight: {
 			id: 'thumbnailHeight',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Thumbnail Height' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/index.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/index.ts
@@ -104,7 +104,7 @@ export const defaultDataSourcesSection = createVirtualSection({
 export const commonControlFieldsDescriptors: LookupTable<DescriptorField> = {
 	title: {
 		id: 'title',
-		type: 'input',
+		type: 'string',
 		name: defineMessage({ defaultMessage: 'Title' }),
 		defaultValue: undefined,
 		validations: {
@@ -215,7 +215,7 @@ export const typeBasicDetailsDescriptor: DescriptorContentType = {
 		},
 		name: {
 			id: 'name',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Name' }),
 			description: '',
 			helpText: '',
@@ -344,7 +344,7 @@ export const sectionDescriptor: DescriptorContentType = {
 	fields: {
 		title: {
 			id: 'title',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Title' }),
 			description: '',
 			helpText: '',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/index.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/index.ts
@@ -81,7 +81,7 @@ export const systemFieldsDescriptors: LookupTable<ContentTypeField> = {
 	},
 	[XmlKeys.disabled]: {
 		id: XmlKeys.disabled,
-		type: 'checkbox',
+		type: 'boolean',
 		name: 'Disabled',
 		defaultValue: undefined,
 		validations: immutableEmptyObject
@@ -242,7 +242,7 @@ export const typeBasicDetailsDescriptor: DescriptorContentType = {
 		},
 		quickCreate: {
 			id: 'quickCreate',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Enable Quick Create' }),
 			description: '',
 			helpText: '',
@@ -296,7 +296,7 @@ export const typeBasicDetailsDescriptor: DescriptorContentType = {
 		},
 		isHeadless: {
 			id: 'isHeadless',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Is Headless Type' }),
 			description: defineMessage({
 				defaultMessage:
@@ -386,7 +386,7 @@ export const sectionDescriptor: DescriptorContentType = {
 		},
 		expandByDefault: {
 			id: 'expandByDefault',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Expand by default' }),
 			description: defineMessage({
 				defaultMessage: 'Check this to show the section expanded when the content type is displayed in the content form'

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/input.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/input.ts
@@ -37,7 +37,7 @@ export const inputDescriptor: DescriptorContentType = {
 	fields: {
 		maxlength: {
 			id: 'maxlength',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Max Length' }),
 			defaultValue: 50,
 			validations: immutableEmptyObject
@@ -72,7 +72,7 @@ export const inputDescriptor: DescriptorContentType = {
 		},
 		pattern: {
 			id: 'pattern',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Match Pattern' }),
 			defaultValue: '',
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/input.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/input.ts
@@ -44,28 +44,28 @@ export const inputDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		tokenized: {
 			id: 'tokenized',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Tokenize for Indexing' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		escapeContent: {
 			id: 'escapeContent',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Escape Content' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: false,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/internalName.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/internalName.ts
@@ -51,28 +51,28 @@ export const internalNameDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		tokenized: {
 			id: 'tokenized',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Tokenize for Indexing' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		escapeContent: {
 			id: 'escapeContent',
-			type: 'checkbox',
+			type: 'boolean',
 			name: 'escapeContent',
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/internalName.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/internalName.ts
@@ -44,7 +44,7 @@ export const internalNameDescriptor: DescriptorContentType = {
 	fields: {
 		maxlength: {
 			id: 'maxlength',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Max Length' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
@@ -79,7 +79,7 @@ export const internalNameDescriptor: DescriptorContentType = {
 		},
 		pattern: {
 			id: 'pattern',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Match Pattern' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/label.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/label.ts
@@ -39,7 +39,7 @@ export const labelDescriptor: DescriptorContentType = {
 		},
 		renderAsHTML: {
 			id: 'renderAsHTML',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Render as HTML' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/label.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/label.ts
@@ -32,7 +32,7 @@ export const labelDescriptor: DescriptorContentType = {
 	fields: {
 		text: {
 			id: 'text',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Text' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkInput.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkInput.ts
@@ -44,21 +44,21 @@ export const linkInputDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'readonly' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		tokenized: {
 			id: 'tokenized',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Tokenize for Indexing' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkInput.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkInput.ts
@@ -37,7 +37,7 @@ export const linkInputDescriptor: DescriptorContentType = {
 	fields: {
 		maxlength: {
 			id: 'maxlength',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'maxLength' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
@@ -65,7 +65,7 @@ export const linkInputDescriptor: DescriptorContentType = {
 		},
 		pattern: {
 			id: 'pattern',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Match Pattern' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkTextarea.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkTextarea.ts
@@ -51,21 +51,21 @@ export const linkTextareaDescriptor: DescriptorContentType = {
 		},
 		allowResize: {
 			id: 'allowResize',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow Resize' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkTextarea.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkTextarea.ts
@@ -37,14 +37,14 @@ export const linkTextareaDescriptor: DescriptorContentType = {
 	fields: {
 		rows: {
 			id: 'rows',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Rows' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		maxlength: {
 			id: 'maxlength',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Maximum Length' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkedDropdown.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkedDropdown.ts
@@ -46,14 +46,14 @@ export const linkedDropdownDescriptor: DescriptorContentType = {
 		},
 		emptyvalue: {
 			id: 'emptyvalue',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow Empty Value' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
@@ -67,7 +67,7 @@ export const linkedDropdownDescriptor: DescriptorContentType = {
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkedDropdown.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/linkedDropdown.ts
@@ -60,7 +60,7 @@ export const linkedDropdownDescriptor: DescriptorContentType = {
 		},
 		dependsOn: {
 			id: 'dependsOn',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Depends On' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/localeSelector.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/localeSelector.ts
@@ -37,14 +37,14 @@ export const localeSelectorDescriptor: DescriptorContentType = {
 	fields: {
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/nodeSelector.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/nodeSelector.ts
@@ -37,14 +37,14 @@ export const nodeSelectorDescriptor: DescriptorContentType = {
 	fields: {
 		minSize: {
 			id: 'minSize',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Minimum Size' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		maxSize: {
 			id: 'maxSize',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Maximum Size' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/nodeSelector.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/nodeSelector.ts
@@ -60,35 +60,35 @@ export const nodeSelectorDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		disableFlattening: {
 			id: 'disableFlattening',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Disable Flattening for Search' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		useSingleValueFilename: {
 			id: 'useSingleValueFilename',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Use single value filename (backward compat)' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		useMVS: {
 			id: 'useMVS',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Use _mvs postfix (backward compat)' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		allowDuplicates: {
 			id: 'allowDuplicates',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow Duplicates' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/numericInput.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/numericInput.ts
@@ -51,21 +51,21 @@ export const numericInputDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		tokenized: {
 			id: 'tokenized',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Tokenize for Indexing' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/numericInput.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/numericInput.ts
@@ -37,14 +37,14 @@ export const numericInputDescriptor: DescriptorContentType = {
 	fields: {
 		maxValue: {
 			id: 'maxValue',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Maximum Value' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		minValue: {
 			id: 'minValue',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Minimum Value' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
@@ -72,7 +72,7 @@ export const numericInputDescriptor: DescriptorContentType = {
 		},
 		pattern: {
 			id: 'pattern',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Match Pattern' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/pageNavOrder.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/pageNavOrder.ts
@@ -37,14 +37,14 @@ export const pageNavOrderDescriptor: DescriptorContentType = {
 	fields: {
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: false,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/repeat.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/repeat.ts
@@ -32,14 +32,14 @@ export const repeatDescriptor: DescriptorContentType = {
 	fields: {
 		minOccurs: {
 			id: 'minOccurs',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Minimum Occurrences' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		maxOccurs: {
 			id: 'maxOccurs',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Maximum Occurrences' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/rte.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/rte.ts
@@ -46,7 +46,7 @@ export const rteDescriptor: DescriptorContentType = {
 	fields: {
 		height: {
 			id: 'height',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Height' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
@@ -67,7 +67,7 @@ export const rteDescriptor: DescriptorContentType = {
 		},
 		rteConfiguration: {
 			id: 'rteConfiguration',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'RTE Configuration' }),
 			defaultValue: 'generic',
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/rte.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/rte.ts
@@ -53,14 +53,14 @@ export const rteDescriptor: DescriptorContentType = {
 		},
 		autoGrow: {
 			id: 'autoGrow',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Auto Grow' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		enableSpellCheck: {
 			id: 'enableSpellCheck',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Enable Spell Check' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
@@ -110,7 +110,7 @@ export const rteDescriptor: DescriptorContentType = {
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/textarea.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/textarea.ts
@@ -51,28 +51,28 @@ export const textareaDescriptor: DescriptorContentType = {
 		},
 		allowResize: {
 			id: 'allowResize',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow Resize' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		escapeContent: {
 			id: 'escapeContent',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Escape Content' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/textarea.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/textarea.ts
@@ -37,14 +37,14 @@ export const textareaDescriptor: DescriptorContentType = {
 	fields: {
 		rows: {
 			id: 'rows',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Rows' }),
 			defaultValue: 5,
 			validations: immutableEmptyObject
 		},
 		maxlength: {
 			id: 'maxlength',
-			type: 'numeric-input',
+			type: 'int',
 			name: defineMessage({ defaultMessage: 'Maximum Length' }),
 			defaultValue: 100000,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/time.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/time.ts
@@ -45,21 +45,21 @@ export const timeDescriptor: DescriptorContentType = {
 	fields: {
 		showClear: {
 			id: 'showClear',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Show Clear' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		showNowLink: {
 			id: 'showNowLink',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Show Now Link' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		populate: {
 			id: 'populate',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Populated' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
@@ -73,28 +73,28 @@ export const timeDescriptor: DescriptorContentType = {
 		},
 		useCustomTimezone: {
 			id: 'useCustomTimezone',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Use Custom Timezone' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		readonlyEdit: {
 			id: 'readonlyEdit',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only on Edit' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/time.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/time.ts
@@ -66,7 +66,7 @@ export const timeDescriptor: DescriptorContentType = {
 		},
 		populateDateExp: {
 			id: 'populateDateExp',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Populate Expression' }),
 			defaultValue: 'now',
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/transcodedVideoPicker.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/transcodedVideoPicker.ts
@@ -46,14 +46,14 @@ export const transcodedVideoPickerDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/uuid.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/uuid.ts
@@ -28,7 +28,7 @@ export const uuidDescriptor: DescriptorContentType = {
 	fields: {
 		hidden: {
 			id: 'hidden',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Hidden' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/videoPicker.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/videoPicker.ts
@@ -30,14 +30,14 @@ export const videoPickerDescriptor: DescriptorContentType = {
 		},
 		readonly: {
 			id: 'readonly',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Read Only' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/audioBrowseRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/audioBrowseRepo.ts
@@ -42,7 +42,7 @@ export const audioBrowseRepoDataSourceDescriptor: DescriptorContentType = {
 		},
 		useSearch: {
 			id: 'useSearch',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Use Search' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/components.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/components.ts
@@ -91,7 +91,7 @@ export const componentsDataSourceDescriptor: DescriptorContentType = {
 		},
 		tags: {
 			id: 'tags',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Tags' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/components.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/components.ts
@@ -42,28 +42,28 @@ export const componentsDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		allowEmbedded: {
 			id: 'allowEmbedded',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow Embedded' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
 		},
 		allowShared: {
 			id: 'allowShared',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Allow New Shared' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
 		},
 		enableBrowse: {
 			id: 'enableBrowse',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Enable Browsing Shared' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
 		},
 		enableSearch: {
 			id: 'enableSearch',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Enable Search' }),
 			defaultValue: false,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/configuredList.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/configuredList.ts
@@ -106,7 +106,7 @@ export const configuredListDataSourceDescriptor: DescriptorContentType = {
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'required' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/configuredList.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/configuredList.ts
@@ -76,7 +76,7 @@ export const configuredListDataSourceDescriptor: DescriptorContentType = {
 		},
 		listName: {
 			id: 'listName',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'List Name' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/embeddedContent.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/embeddedContent.ts
@@ -33,7 +33,7 @@ export const embeddedContentDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		contentType: {
 			id: 'contentType',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Content Type' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/flashDesktopUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/flashDesktopUpload.ts
@@ -45,7 +45,7 @@ export const flashDesktopUploadDataSourceDescriptor: DescriptorContentType = {
 		},
 		required: {
 			id: 'required',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: true,
 			validations: { required: { id: 'required', value: true, level: 'required' } }

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/flashDesktopUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/flashDesktopUpload.ts
@@ -38,7 +38,7 @@ export const flashDesktopUploadDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: '/',
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgRepositoryUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgRepositoryUpload.ts
@@ -43,7 +43,7 @@ export const imgRepositoryUploadDataSourceDescriptor: DescriptorContentType = {
 		},
 		useSearch: {
 			id: 'useSearch',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Use Search' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgS3Repo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgS3Repo.ts
@@ -33,14 +33,14 @@ export const imgS3RepoDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		path: {
 			id: 'path',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgS3Upload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgS3Upload.ts
@@ -33,14 +33,14 @@ export const imgS3UploadDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgWebDavRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgWebDavRepo.ts
@@ -33,14 +33,14 @@ export const imgWebDavRepoDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgWebDavUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgWebDavUpload.ts
@@ -33,14 +33,14 @@ export const imgWebDavUploadDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/index.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/index.ts
@@ -49,7 +49,7 @@ import { defineMessage } from 'react-intl';
 export const commonDataSourceDescriptors: LookupTable<DescriptorField> = {
 	title: {
 		id: 'title',
-		type: 'input',
+		type: 'string',
 		name: defineMessage({ defaultMessage: 'Title' }),
 		defaultValue: undefined,
 		validations: {

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/keyValueList.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/keyValueList.ts
@@ -73,7 +73,7 @@ export const keyValueListDataSourceDescriptor: DescriptorContentType = {
 		},
 		showkeys: {
 			id: 'showkeys',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Show keys' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/s3Repo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/s3Repo.ts
@@ -33,14 +33,14 @@ export const s3RepoDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		path: {
 			id: 'path',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/s3Upload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/s3Upload.ts
@@ -33,14 +33,14 @@ export const s3UploadDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/sharedContent.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/sharedContent.ts
@@ -33,21 +33,21 @@ export const sharedContentDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		enableCreateNew: {
 			id: 'enableCreateNew',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Enable Create New' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
 		},
 		enableBrowseExisting: {
 			id: 'enableBrowseExisting',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Enable Browse Existing' }),
 			defaultValue: true,
 			validations: immutableEmptyObject
 		},
 		enableSearchExisting: {
 			id: 'enableSearchExisting',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Enable Search Existing' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/sharedContent.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/sharedContent.ts
@@ -74,7 +74,7 @@ export const sharedContentDataSourceDescriptor: DescriptorContentType = {
 		},
 		type: {
 			id: 'type',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Default Type' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoBrowseRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoBrowseRepo.ts
@@ -42,7 +42,7 @@ export const videoBrowseRepoDataSourceDescriptor: DescriptorContentType = {
 		},
 		useSearch: {
 			id: 'useSearch',
-			type: 'checkbox',
+			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Use Search' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Repo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Repo.ts
@@ -33,14 +33,14 @@ export const videoS3RepoDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		path: {
 			id: 'path',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Transcoding.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Transcoding.ts
@@ -33,14 +33,14 @@ export const videoS3TranscodingDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		inputProfileId: {
 			id: 'inputProfileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Input Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		outputProfileId: {
 			id: 'outputProfileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Output Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Upload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoS3Upload.ts
@@ -33,14 +33,14 @@ export const videoS3UploadDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoWebDavRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoWebDavRepo.ts
@@ -33,14 +33,14 @@ export const videoWebDavRepoDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoWebDavUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoWebDavUpload.ts
@@ -33,14 +33,14 @@ export const videoWebDavUploadDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/webDavRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/webDavRepo.ts
@@ -33,14 +33,14 @@ export const webDavRepoDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/webDavUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/webDavUpload.ts
@@ -33,14 +33,14 @@ export const webDavUploadDataSourceDescriptor: DescriptorContentType = {
 	fields: {
 		repoPath: {
 			id: 'repoPath',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Repository Path' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
 		},
 		profileId: {
 			id: 'profileId',
-			type: 'input',
+			type: 'string',
 			name: defineMessage({ defaultMessage: 'Profile ID' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject


### PR DESCRIPTION
Updated fields types in descriptors to match legacy:
- 'checkbox' => 'boolean'
- 'input' => 'string'
- 'numeric-input' => 'int'
The controlsMap is already updated to map those fields to the proper controls.

https://github.com/craftercms/craftercms/issues/7418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated field type definitions across multiple content management form controls and data sources to use standardized semantic types. Text-based inputs now use string type, numeric inputs use integer type, and boolean options use boolean type instead of checkbox. This enhances consistency and improves form field validation and rendering throughout the content type management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->