### PR TITLE
[8483] Update Form Header to resize on scroll instead of scrolling out from view

### DIFF
--- a/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -562,6 +562,7 @@ function FormOrchestrator(props: FormsEngineProps) {
 	const activeSite = useActiveSite();
 	const siteId = activeSite.id;
 	const containerRef = useRef<HTMLDivElement>(undefined);
+	const mainContentRef = useRef<HTMLDivElement>(undefined);
 	const {
 		isFullScreen = false,
 		updateSubmittingOrHasPendingChanges,
@@ -593,6 +594,8 @@ function FormOrchestrator(props: FormsEngineProps) {
 	const useCollapsedToC = useAtomValue(atoms.useCollapsedToC);
 	const tableOfContents = <TableOfContents fieldsToRender={fieldsToRender} containerRef={containerRef} />;
 	const effectRefs = useUpdateRefs({ fieldsToRender, versionCommentAtom: stableFormContext.atoms.versionComment });
+	const [collapseHeader, setCollapseHeader] = useState(false);
+	const scrollTimeout = useRef(null);
 
 	// Changes comment generation & change detection/tracking
 	useEffect(() => {
@@ -712,16 +715,39 @@ function FormOrchestrator(props: FormsEngineProps) {
 		}
 	};
 
+	// This hook sets up a scroll event listener on the `mainContent` element to monitor its scroll position and
+	// adjust the header's collapse state based on the scroll position.
+	useEffect(() => {
+		const mainContent = mainContentRef.current;
+		if (!mainContent) return;
+
+		const handleScroll = () => {
+			const scrollTop = mainContent.scrollTop;
+			// Only trigger resize when scroll stops for 50ms
+			if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+			scrollTimeout.current = setTimeout(() => {
+				setCollapseHeader(scrollTop > 60);
+			}, 50);
+		};
+
+		mainContent.addEventListener('scroll', handleScroll);
+		return () => {
+			mainContent.removeEventListener('scroll', handleScroll);
+			if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+		};
+	}, []);
+
 	const bodyFragment = (
 		<FormLayout
 			stackIndex={stackIndex}
 			containerRef={containerRef}
+			mainContentRef={mainContentRef}
 			hasStackedForms={hasStackedForms}
 			// If the form is rendered in/as a dialog, take up the whole screen minus
 			// top/bottom margins (2 top, 2 bottom). If not a dialog, take up the whole screen.
 			targetHeight={getTargetHeight(isDialog, isFullScreen, theme)}
 			headerFragment={
-				<>
+				<Box id="header" sx={{ minHeight: 50 }}>
 					<Box component={Container} display="flex" alignItems="center" justifyContent="space-between" pt={2}>
 						<Typography variant="body2" color="textSecondary">
 							<span title={siteId}>{activeSite.name}</span> / <span title={contentType.id}>{contentType.name}</span>
@@ -751,18 +777,18 @@ function FormOrchestrator(props: FormsEngineProps) {
 						</Box>
 					</Box>
 					{isRepeatMode ? (
-						<RepeatModeHeader repeat={repeat} />
+						<RepeatModeHeader repeat={repeat} collapse={collapseHeader} />
 					) : isCreateMode ? (
-						<CreateModeHeader path={create?.path} />
+						<CreateModeHeader path={create?.path} collapse={collapseHeader} />
 					) : (
-						<EditModeHeader isEmbedded={isEmbedded} />
+						<EditModeHeader isEmbedded={isEmbedded} collapse={collapseHeader} />
 					)}
-				</>
+				</Box>
 			}
 			mainContentGrid={
 				<>
 					<Grid size={useCollapsedToC ? 'auto' : 'grow'}>
-						<StickyBox data-area-id="stickySidebar">
+						<StickyBox data-area-id="stickySidebar" sx={{ height: 'auto' }}>
 							{useCollapsedToC ? (
 								<IconButton size="small" onClick={handleOpenDrawerSidebar}>
 									<MenuRounded />
@@ -834,7 +860,7 @@ function FormOrchestrator(props: FormsEngineProps) {
 						<FormBackToTop containerRef={containerRef} />
 					</Grid>
 					<Grid size="grow">
-						<StickyBox className="space-y">
+						<StickyBox className="space-y" sx={{ height: 'auto' }}>
 							{readonly ? (
 								<>
 									<Alert severity="info" variant="outlined" icon={<EditOffOutlined />}>

--- a/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -20,7 +20,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import useActiveSite from '../../hooks/useActiveSite';
 import useContentTypes from '../../hooks/useContentTypes';
-import React, { createElement, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { createElement, type RefCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ContentTypeField, PublishPackage } from '../../models';
 import {
 	FormsEngineAtoms,
@@ -562,7 +562,6 @@ function FormOrchestrator(props: FormsEngineProps) {
 	const activeSite = useActiveSite();
 	const siteId = activeSite.id;
 	const containerRef = useRef<HTMLDivElement>(undefined);
-	const mainContentRef = useRef<HTMLDivElement>(undefined);
 	const {
 		isFullScreen = false,
 		updateSubmittingOrHasPendingChanges,
@@ -715,10 +714,10 @@ function FormOrchestrator(props: FormsEngineProps) {
 		}
 	};
 
+	const [mainContent, setMainContent] = useState(null);
 	// This hook sets up a scroll event listener on the `mainContent` element to monitor its scroll position and
 	// adjust the header's collapse state based on the scroll position.
 	useEffect(() => {
-		const mainContent = mainContentRef.current;
 		if (!mainContent) return;
 
 		const handleScroll = () => {
@@ -735,13 +734,17 @@ function FormOrchestrator(props: FormsEngineProps) {
 			mainContent.removeEventListener('scroll', handleScroll);
 			if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
 		};
-	}, []);
+	}, [mainContent]);
+
+	const mainContentRefCallback: RefCallback<HTMLDivElement> = (element) => {
+		setMainContent(element);
+	};
 
 	const bodyFragment = (
 		<FormLayout
 			stackIndex={stackIndex}
 			containerRef={containerRef}
-			mainContentRef={mainContentRef}
+			mainContentRefCallback={mainContentRefCallback}
 			hasStackedForms={hasStackedForms}
 			// If the form is rendered in/as a dialog, take up the whole screen minus
 			// top/bottom margins (2 top, 2 bottom). If not a dialog, take up the whole screen.

--- a/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -715,35 +715,40 @@ function FormOrchestrator(props: FormsEngineProps) {
 	};
 
 	const [mainContent, setMainContent] = useState(null);
-	// This hook sets up a scroll event listener on the `mainContent` element to monitor its scroll position and
-	// adjust the header's collapse state based on the scroll position.
-	useEffect(() => {
-		if (!mainContent) return;
-
-		const handleScroll = () => {
-			const scrollTop = mainContent.scrollTop;
-			// Only trigger resize when scroll stops for 50ms
-			if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
-			scrollTimeout.current = setTimeout(() => {
-				setCollapseHeader(scrollTop > 60);
-			}, 50);
-		};
-
-		mainContent.addEventListener('scroll', handleScroll);
-		return () => {
-			mainContent.removeEventListener('scroll', handleScroll);
-			if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
-		};
-	}, [mainContent]);
+	const sentinelRef = useRef<HTMLDivElement>(null);
 
 	const mainContentRefCallback: RefCallback<HTMLDivElement> = (element) => {
 		setMainContent(element);
 	};
 
+	// Monitor when sentinel element crosses the threshold
+	useEffect(() => {
+		if (!mainContent || !sentinelRef.current) return;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				// When sentinel is NOT intersecting (scrolled past 60px, sentinel's top position), collapse header
+				setCollapseHeader(!entry.isIntersecting);
+			},
+			{
+				root: mainContent,
+				threshold: 0,
+				rootMargin: '0px'
+			}
+		);
+
+		observer.observe(sentinelRef.current);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [mainContent]);
+
 	const bodyFragment = (
 		<FormLayout
 			stackIndex={stackIndex}
 			containerRef={containerRef}
+			sentinelRef={sentinelRef}
 			mainContentRefCallback={mainContentRefCallback}
 			hasStackedForms={hasStackedForms}
 			// If the form is rendered in/as a dialog, take up the whole screen minus

--- a/ui/app/src/components/FormsEngine/components/CreateModeHeader.tsx
+++ b/ui/app/src/components/FormsEngine/components/CreateModeHeader.tsx
@@ -20,6 +20,7 @@ import { ItemMetaContext } from '../lib/formsEngineContext';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import ItemTypeIcon from '../../ItemTypeIcon';
+import Collapse from '@mui/material/Collapse';
 
 const itemTypeTranslations = defineMessages({
 	component: { defaultMessage: 'Component' },
@@ -27,7 +28,7 @@ const itemTypeTranslations = defineMessages({
 	taxonomy: { defaultMessage: 'Taxonomy' }
 });
 
-export function CreateModeHeader({ path }: { path: string }) {
+export function CreateModeHeader({ path, collapse = false }: { path: string; collapse?: boolean }) {
 	const { formatMessage } = useIntl();
 	const { contentType } = useContext(ItemMetaContext);
 	const itemType = contentType.type;
@@ -44,7 +45,9 @@ export function CreateModeHeader({ path }: { path: string }) {
 					}}
 				/>
 			</Typography>
-			<Typography color="textSecondary" variant="body2" children={path} />
+			<Collapse in={!collapse}>
+				<Typography color="textSecondary" variant="body2" children={path} />
+			</Collapse>
 		</Container>
 	);
 }

--- a/ui/app/src/components/FormsEngine/components/EditModeHeader.tsx
+++ b/ui/app/src/components/FormsEngine/components/EditModeHeader.tsx
@@ -40,9 +40,9 @@ import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded';
 import MenuOpenIcon from '@mui/icons-material/MenuOpenRounded';
 import { XmlKeys } from '../lib/formConsts';
 import { useAtom } from 'jotai';
+import Collapse from '@mui/material/Collapse';
 
-export function EditModeHeader({ isEmbedded }: { isEmbedded: boolean }) {
-	const theme = useTheme();
+export function EditModeHeader({ isEmbedded, collapse = false }: { isEmbedded: boolean; collapse?: boolean }) {
 	const { atoms } = useContext(StableFormContext);
 	const { id: objectId } = useContext(ItemMetaContext);
 	const item = useContext(ItemContext);
@@ -50,8 +50,6 @@ export function EditModeHeader({ isEmbedded }: { isEmbedded: boolean }) {
 	const readonly = useAtomValue(atoms.readonly);
 	const localeConf = useLocale();
 	const isLargeContainer = useAtomValue(atoms.isLargeContainer);
-	const [collapseToC, setCollapseToC] = useAtom(atoms.collapseToC);
-	const useCollapsedToC = useAtomValue(atoms.useCollapsedToC);
 	const { formatMessage } = useIntl();
 	const itemLabel = isEmbedded
 		? (getFieldAtomValue(atoms.valueByFieldId[XmlKeys.internalName], store) as string)
@@ -74,178 +72,192 @@ export function EditModeHeader({ isEmbedded }: { isEmbedded: boolean }) {
 	return (
 		<>
 			<Container className="space-y" sx={{ py: 1 }}>
-				<Box display="flex" alignItems="end" justifyContent="space-between">
-					<Box className="space-y" sx={{ flexBasis: '50%' }}>
-						{/* Item display */}
-						<Box display="flex" alignItems="center" className="space-x">
-							<ItemTypeIcon item={typeIconItem} sx={{ color: 'info.main' }} />
-							<Typography>{itemLabel}</Typography>
-							{readonly && (
-								<Chip
-									sx={{ [`.${chipClasses.label}`]: { display: 'flex', alignItems: 'center' } }}
-									color="warning"
-									variant="outlined"
-									label={
-										<>
-											<FormattedMessage defaultMessage="Readonly" />
-											<EditOffOutlined fontSize="small" sx={{ ml: 1 }} />
-										</>
-									}
-								/>
-							)}
-						</Box>
-						{/* Item metadata */}
-						<div>
-							<Typography
-								variant="body2"
-								color="textSecondary"
-								display="flex"
-								alignItems="center"
-								sx={{ flexWrap: 'wrap', em: { fontWeight: 600 } }}
-							>
-								<Box component="span" display="flex" alignItems="center" marginRight={1}>
-									<CalendarTodayRounded sx={{ mr: 0.25 }} fontSize="inherit" />
-									<span>
-										<FormattedMessage
-											defaultMessage="Created {when} by <who>who</who>"
-											values={{
-												who: () => (
-													<em key="0" title={formattedCreator.tooltip}>
-														{formattedCreator.display}
-													</em>
-												),
-												when: formattedCreationDate
-											}}
-										/>
-									</span>
-								</Box>
-								<Box component="span" display="flex" alignItems="center">
-									<EditOutlined sx={{ mr: 0.25 }} fontSize="inherit" />
-									<span>
-										<FormattedMessage
-											defaultMessage="Updated {when} by <who>who</who>"
-											values={{
-												who: () => (
-													<em key="0" title={formattedModifier.tooltip}>
-														{formattedModifier.display}
-													</em>
-												),
-												when: formattedModifiedDate
-											}}
-										/>
-									</span>
-								</Box>
-							</Typography>
-							<Typography
-								variant="body2"
-								color="textSecondary"
-								display="flex"
-								alignItems="center"
-								sx={{ flexWrap: 'wrap' }}
-							>
-								<Box component="span" display="flex" alignItems="center" marginRight={1}>
-									<ItemPublishingTargetIcon fontSize="inherit" sxs={{ root: { marginRight: 0.25 } }} item={item} />{' '}
-									{getItemPublishingTargetText(item.stateMap, formatMessage)}
-								</Box>
-								<Box component="span" display="flex" alignItems="center">
-									<ItemStateIcon fontSize="inherit" sxs={{ root: { mr: 0.25 } }} item={item} />{' '}
-									{getItemStateText(item.stateMap, formatMessage, { user: item.lockOwner?.username })}
-								</Box>
-							</Typography>
-						</div>
-					</Box>
-					<Box className="space-y" display="flex" flexDirection="column" alignItems="end" sx={{ maxWidth: '50%' }}>
-						<Typography
-							component="span"
-							variant="body2"
-							color="textSecondary"
-							display="flex"
-							alignItems="center"
-							sx={{ overflow: 'hidden', maxWidth: '100%' }}
-						>
-							<Box
-								component="span"
-								title={item.path}
-								sx={{ whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden' }}
-							>
-								{item.path}
-								{/* Super-long test path: /Lorem/Ipsum/is/simply/dummy/text/of/the/printing/and/typesetting/industry/Lorem/Ipsum/has/been/the/industrys/standard/dummy/text/ever/since/the/1500s/when/an/unknown/printer/took/a/galley/of/type/and/scrambled/it/to/make/a/type/specimen/book.xml */}
-							</Box>
-							<Tooltip title={<FormattedMessage defaultMessage="Copy path to clipboard" />}>
-								<IconButton size="small" onClick={() => copyToClipboard(item.path)} sx={{ padding: '1px', ml: 1 }}>
-									<ContentCopyRounded fontSize="inherit" sx={{ color: 'text.secondary' }} />
-								</IconButton>
-							</Tooltip>
-						</Typography>
-						<Typography
-							component="span"
-							variant="body2"
-							color="textSecondary"
-							display="flex"
-							alignItems="center"
-							sx={{ overflow: 'hidden', maxWidth: '100%' }}
-						>
-							<Box
-								component="span"
-								title={objectId}
-								sx={{ whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden' }}
-							>
-								{objectId}
-							</Box>
-							<Tooltip title={<FormattedMessage defaultMessage="Copy ID to clipboard" />}>
-								<IconButton
-									size="small"
-									sx={{ padding: '1px', ml: 1 }}
-									onClick={() =>
-										copyToClipboard(getFieldAtomValue(atoms.valueByFieldId[XmlKeys.modelId], store) as string)
-									}
-								>
-									<ContentCopyRounded fontSize="inherit" sx={{ color: 'text.secondary' }} />
-								</IconButton>
-							</Tooltip>
-						</Typography>
-					</Box>
+				{/* Item display */}
+				<Box display="flex" alignItems="center" className="space-x">
+					{isLargeContainer && collapse && <CollapseToCButton />}
+					<ItemTypeIcon item={typeIconItem} sx={{ color: 'info.main' }} />
+					<Typography>{itemLabel}</Typography>
+					{readonly && (
+						<Chip
+							sx={{ [`.${chipClasses.label}`]: { display: 'flex', alignItems: 'center' } }}
+							color="warning"
+							variant="outlined"
+							label={
+								<>
+									<FormattedMessage defaultMessage="Readonly" />
+									<EditOffOutlined fontSize="small" sx={{ ml: 1 }} />
+								</>
+							}
+						/>
+					)}
 				</Box>
+				<Collapse in={!collapse}>
+					<Box display="flex" alignItems="end" justifyContent="space-between">
+						<Box className="space-y" sx={{ flexBasis: '50%' }}>
+							{/* Item metadata */}
+							<div>
+								<Typography
+									variant="body2"
+									color="textSecondary"
+									display="flex"
+									alignItems="center"
+									sx={{ flexWrap: 'wrap', em: { fontWeight: 600 } }}
+								>
+									<Box component="span" display="flex" alignItems="center" marginRight={1}>
+										<CalendarTodayRounded sx={{ mr: 0.25 }} fontSize="inherit" />
+										<span>
+											<FormattedMessage
+												defaultMessage="Created {when} by <who>who</who>"
+												values={{
+													who: () => (
+														<em key="0" title={formattedCreator.tooltip}>
+															{formattedCreator.display}
+														</em>
+													),
+													when: formattedCreationDate
+												}}
+											/>
+										</span>
+									</Box>
+									<Box component="span" display="flex" alignItems="center">
+										<EditOutlined sx={{ mr: 0.25 }} fontSize="inherit" />
+										<span>
+											<FormattedMessage
+												defaultMessage="Updated {when} by <who>who</who>"
+												values={{
+													who: () => (
+														<em key="0" title={formattedModifier.tooltip}>
+															{formattedModifier.display}
+														</em>
+													),
+													when: formattedModifiedDate
+												}}
+											/>
+										</span>
+									</Box>
+								</Typography>
+								<Typography
+									variant="body2"
+									color="textSecondary"
+									display="flex"
+									alignItems="center"
+									sx={{ flexWrap: 'wrap' }}
+								>
+									<Box component="span" display="flex" alignItems="center" marginRight={1}>
+										<ItemPublishingTargetIcon fontSize="inherit" sxs={{ root: { marginRight: 0.25 } }} item={item} />{' '}
+										{getItemPublishingTargetText(item.stateMap, formatMessage)}
+									</Box>
+									<Box component="span" display="flex" alignItems="center">
+										<ItemStateIcon fontSize="inherit" sxs={{ root: { mr: 0.25 } }} item={item} />{' '}
+										{getItemStateText(item.stateMap, formatMessage, { user: item.lockOwner?.username })}
+									</Box>
+								</Typography>
+							</div>
+						</Box>
+						<Box className="space-y" display="flex" flexDirection="column" alignItems="end" sx={{ maxWidth: '50%' }}>
+							<Typography
+								component="span"
+								variant="body2"
+								color="textSecondary"
+								display="flex"
+								alignItems="center"
+								sx={{ overflow: 'hidden', maxWidth: '100%' }}
+							>
+								<Box
+									component="span"
+									title={item.path}
+									sx={{ whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden' }}
+								>
+									{item.path}
+									{/* Super-long test path: /Lorem/Ipsum/is/simply/dummy/text/of/the/printing/and/typesetting/industry/Lorem/Ipsum/has/been/the/industrys/standard/dummy/text/ever/since/the/1500s/when/an/unknown/printer/took/a/galley/of/type/and/scrambled/it/to/make/a/type/specimen/book.xml */}
+								</Box>
+								<Tooltip title={<FormattedMessage defaultMessage="Copy path to clipboard" />}>
+									<IconButton size="small" onClick={() => copyToClipboard(item.path)} sx={{ padding: '1px', ml: 1 }}>
+										<ContentCopyRounded fontSize="inherit" sx={{ color: 'text.secondary' }} />
+									</IconButton>
+								</Tooltip>
+							</Typography>
+							<Typography
+								component="span"
+								variant="body2"
+								color="textSecondary"
+								display="flex"
+								alignItems="center"
+								sx={{ overflow: 'hidden', maxWidth: '100%' }}
+							>
+								<Box
+									component="span"
+									title={objectId}
+									sx={{ whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden' }}
+								>
+									{objectId}
+								</Box>
+								<Tooltip title={<FormattedMessage defaultMessage="Copy ID to clipboard" />}>
+									<IconButton
+										size="small"
+										sx={{ padding: '1px', ml: 1 }}
+										onClick={() =>
+											copyToClipboard(getFieldAtomValue(atoms.valueByFieldId[XmlKeys.modelId], store) as string)
+										}
+									>
+										<ContentCopyRounded fontSize="inherit" sx={{ color: 'text.secondary' }} />
+									</IconButton>
+								</Tooltip>
+							</Typography>
+						</Box>
+					</Box>
+				</Collapse>
 			</Container>
-			<Container maxWidth="xl" sx={{ display: 'flex' }}>
-				{isLargeContainer && (
-					<Tooltip title={<FormattedMessage defaultMessage="Collapse table of contents" />}>
-						<IconButton
-							size="small"
-							onClick={() => setCollapseToC(!collapseToC)}
-							sx={{
-								// TODO: Tabs will be done at a later phase.
-								// visibility: activeTab === 0 ? undefined : 'hidden',
-								mr: 0.5
-							}}
-						>
-							<MenuOpenIcon
-								sx={{
-									// Add transform to rotate 180deg when collapsed
-									transform: useCollapsedToC ? 'rotate(180deg)' : 'none',
-									// Animate the rotation
-									transition: theme.transitions.create('transform', {
-										duration: theme.transitions.duration.shortest
-									})
-								}}
-							/>
-						</IconButton>
-					</Tooltip>
-				)}
-				{/*
-        TODO: Disabling Tabs. Differed feature.
-        <Tabs value={activeTab} onChange={handleTabChange} sx={{ minHeight: 0 }}>
-          <DenseTab label={<FormattedMessage defaultMessage="Form" />} />
-          <DenseTab label={<FormattedMessage defaultMessage="Preview" />} />
-          <DenseTab label={<FormattedMessage defaultMessage="History" />} />
-          <DenseTab label={<FormattedMessage defaultMessage="References" />} />
-          <DenseTab label={<FormattedMessage defaultMessage="Template" />} />
-          <DenseTab label={<FormattedMessage defaultMessage="Controller" />} />
-          <DenseTab label={<FormattedMessage defaultMessage="Settings" />} />
-        </Tabs>
-        */}
-			</Container>
+			<Collapse in={!collapse}>
+				<Container maxWidth="xl" sx={{ display: 'flex' }}>
+					{isLargeContainer && <CollapseToCButton />}
+					{/*
+					TODO: Disabling Tabs. Differed feature.
+					<Tabs value={activeTab} onChange={handleTabChange} sx={{ minHeight: 0 }}>
+						<DenseTab label={<FormattedMessage defaultMessage="Form" />} />
+						<DenseTab label={<FormattedMessage defaultMessage="Preview" />} />
+						<DenseTab label={<FormattedMessage defaultMessage="History" />} />
+						<DenseTab label={<FormattedMessage defaultMessage="References" />} />
+						<DenseTab label={<FormattedMessage defaultMessage="Template" />} />
+						<DenseTab label={<FormattedMessage defaultMessage="Controller" />} />
+						<DenseTab label={<FormattedMessage defaultMessage="Settings" />} />
+					</Tabs>
+					*/}
+				</Container>
+			</Collapse>
 		</>
+	);
+}
+
+function CollapseToCButton() {
+	const theme = useTheme();
+	const { atoms } = useContext(StableFormContext);
+	const [collapseToC, setCollapseToC] = useAtom(atoms.collapseToC);
+	const useCollapsedToC = useAtomValue(atoms.useCollapsedToC);
+
+	return (
+		<Tooltip title={<FormattedMessage defaultMessage="Collapse table of contents" />}>
+			<IconButton
+				size="small"
+				onClick={() => setCollapseToC(!collapseToC)}
+				sx={{
+					// TODO: Tabs will be done at a later phase.
+					// visibility: activeTab === 0 ? undefined : 'hidden',
+					mr: 0.5
+				}}
+			>
+				<MenuOpenIcon
+					sx={{
+						// Add transform to rotate 180deg when collapsed
+						transform: useCollapsedToC ? 'rotate(180deg)' : 'none',
+						// Animate the rotation
+						transition: theme.transitions.create('transform', {
+							duration: theme.transitions.duration.shortest
+						})
+					}}
+				/>
+			</IconButton>
+		</Tooltip>
 	);
 }
 

--- a/ui/app/src/components/FormsEngine/components/FormLayout.tsx
+++ b/ui/app/src/components/FormsEngine/components/FormLayout.tsx
@@ -43,6 +43,7 @@ export type FormLayoutProps = PropsWithChildren<{
 	mainContentGrid: ReactNode;
 	headerFragment: ReactNode;
 	containerRef: RefObject<HTMLDivElement>;
+	mainContentRef: RefObject<HTMLDivElement>;
 	hasStackedForms: boolean;
 	stackIndex: number;
 	style?: BoxProps['style'];
@@ -59,8 +60,17 @@ function collectSectionExpandedState(
 }
 
 export const FormLayout = forwardRef<HTMLDivElement, FormLayoutProps>(function (props, ref) {
-	const { children, mainContentGrid, targetHeight, containerRef, headerFragment, hasStackedForms, stackIndex, style } =
-		props;
+	const {
+		children,
+		mainContentGrid,
+		targetHeight,
+		containerRef,
+		mainContentRef,
+		headerFragment,
+		hasStackedForms,
+		stackIndex,
+		style
+	} = props;
 	const theme = useTheme();
 	const store = useJotaiStore();
 	const { api: contextApi } = useContext(StableGlobalContext);
@@ -155,12 +165,15 @@ export const FormLayout = forwardRef<HTMLDivElement, FormLayoutProps>(function (
 				<Divider />
 			</Paper>
 			<Box
+				ref={mainContentRef}
 				sx={{
 					// TODO: Tabs will be done at a later phase.
 					// display: activeTab === 0 ? 'inherit' : 'none',
+					height: '100%',
 					px: 0,
-					py: 2,
-					backgroundColor: theme.palette.background.default
+					pt: 2,
+					backgroundColor: theme.palette.background.default,
+					overflow: 'auto'
 				}}
 			>
 				<Container maxWidth={isLargeContainer ? 'xl' : undefined}>

--- a/ui/app/src/components/FormsEngine/components/FormLayout.tsx
+++ b/ui/app/src/components/FormsEngine/components/FormLayout.tsx
@@ -18,6 +18,7 @@ import React, {
 	forwardRef,
 	PropsWithChildren,
 	ReactNode,
+	type RefCallback,
 	RefObject,
 	useContext,
 	useImperativeHandle,
@@ -43,7 +44,7 @@ export type FormLayoutProps = PropsWithChildren<{
 	mainContentGrid: ReactNode;
 	headerFragment: ReactNode;
 	containerRef: RefObject<HTMLDivElement>;
-	mainContentRef: RefObject<HTMLDivElement>;
+	mainContentRefCallback: RefCallback<HTMLDivElement>;
 	hasStackedForms: boolean;
 	stackIndex: number;
 	style?: BoxProps['style'];
@@ -65,7 +66,7 @@ export const FormLayout = forwardRef<HTMLDivElement, FormLayoutProps>(function (
 		mainContentGrid,
 		targetHeight,
 		containerRef,
-		mainContentRef,
+		mainContentRefCallback,
 		headerFragment,
 		hasStackedForms,
 		stackIndex,
@@ -165,7 +166,7 @@ export const FormLayout = forwardRef<HTMLDivElement, FormLayoutProps>(function (
 				<Divider />
 			</Paper>
 			<Box
-				ref={mainContentRef}
+				ref={mainContentRefCallback}
 				sx={{
 					// TODO: Tabs will be done at a later phase.
 					// display: activeTab === 0 ? 'inherit' : 'none',

--- a/ui/app/src/components/FormsEngine/components/FormLayout.tsx
+++ b/ui/app/src/components/FormsEngine/components/FormLayout.tsx
@@ -44,6 +44,7 @@ export type FormLayoutProps = PropsWithChildren<{
 	mainContentGrid: ReactNode;
 	headerFragment: ReactNode;
 	containerRef: RefObject<HTMLDivElement>;
+	sentinelRef: RefObject<HTMLDivElement>;
 	mainContentRefCallback: RefCallback<HTMLDivElement>;
 	hasStackedForms: boolean;
 	stackIndex: number;
@@ -67,6 +68,7 @@ export const FormLayout = forwardRef<HTMLDivElement, FormLayoutProps>(function (
 		targetHeight,
 		containerRef,
 		mainContentRefCallback,
+		sentinelRef,
 		headerFragment,
 		hasStackedForms,
 		stackIndex,
@@ -170,6 +172,7 @@ export const FormLayout = forwardRef<HTMLDivElement, FormLayoutProps>(function (
 				sx={{
 					// TODO: Tabs will be done at a later phase.
 					// display: activeTab === 0 ? 'inherit' : 'none',
+					position: 'relative',
 					height: '100%',
 					px: 0,
 					pt: 2,
@@ -177,6 +180,17 @@ export const FormLayout = forwardRef<HTMLDivElement, FormLayoutProps>(function (
 					overflow: 'auto'
 				}}
 			>
+				<div
+					ref={sentinelRef}
+					style={{
+						position: 'absolute',
+						top: '60px',
+						height: '1px',
+						width: '1px',
+						pointerEvents: 'none',
+						visibility: 'hidden'
+					}}
+				/>
 				<Container maxWidth={isLargeContainer ? 'xl' : undefined}>
 					<Grid container spacing={2}>
 						{mainContentGrid}

--- a/ui/app/src/components/FormsEngine/components/RepeatModeHeader.tsx
+++ b/ui/app/src/components/FormsEngine/components/RepeatModeHeader.tsx
@@ -20,8 +20,15 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import { FormattedMessage } from 'react-intl';
 import { FormsEngineProps } from '../FormsEngine';
+import Collapse from '@mui/material/Collapse';
 
-export function RepeatModeHeader({ repeat }: { repeat: FormsEngineProps['repeat'] }) {
+export function RepeatModeHeader({
+	repeat,
+	collapse = false
+}: {
+	repeat: FormsEngineProps['repeat'];
+	collapse?: boolean;
+}) {
 	const { contentType } = useContext(ItemMetaContext);
 	return (
 		<Container sx={{ py: 1 }}>
@@ -32,12 +39,14 @@ export function RepeatModeHeader({ repeat }: { repeat: FormsEngineProps['repeat'
 					<FormattedMessage defaultMessage="Item # {number}" values={{ number: repeat.index + 1 }} />
 				)}
 			</Typography>
-			<Typography variant="body2" color="textSecondary">
-				<FormattedMessage
-					defaultMessage="{name} Repeat Group"
-					values={{ name: contentType.fields[repeat.fieldId].name }}
-				/>
-			</Typography>
+			<Collapse in={!collapse}>
+				<Typography variant="body2" color="textSecondary">
+					<FormattedMessage
+						defaultMessage="{name} Repeat Group"
+						values={{ name: contentType.fields[repeat.fieldId].name }}
+					/>
+				</Typography>
+			</Collapse>
 		</Container>
 	);
 }

--- a/ui/app/src/components/FormsEngine/components/StickyBox.tsx
+++ b/ui/app/src/components/FormsEngine/components/StickyBox.tsx
@@ -19,7 +19,7 @@ import Box from '@mui/material/Box';
 import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 
 export const StickyBox = styled(Box)(({ theme }) => ({
-	top: theme.spacing(1),
+	top: 0,
 	height: `var(--container-height)`,
 	position: 'sticky',
 	overflowY: 'auto'

--- a/ui/app/src/components/FormsEngine/components/TableOfContents.tsx
+++ b/ui/app/src/components/FormsEngine/components/TableOfContents.tsx
@@ -104,7 +104,7 @@ export function TableOfContents({ containerRef, fieldsToRender }: TableOfContent
 		<>
 			<SearchBar
 				dense
-				sx={{ mb: 1 }}
+				sx={{ mb: 1, mt: 1 }}
 				showActionButton={searchFieldValue !== ''}
 				keyword={searchFieldValue}
 				onChange={(value) => {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header now collapses when scrolling through forms for improved space utilization.
  * Added copy-to-clipboard buttons for file path and item ID in edit mode.
  * New toggle for collapsing the table of contents in edit mode.

* **Improvements**
  * Refined spacing and layout across headers, sticky regions, and the table of contents.
  * Improved scroll and header behavior for smoother interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->