### PR TITLE
[8484] Content Type list UI enhancements

### DIFF
--- a/ui/app/src/components/AccountManagement/utils.tsx
+++ b/ui/app/src/components/AccountManagement/utils.tsx
@@ -38,7 +38,8 @@ import {
 	removeStoredShowToolsPanel,
 	removeCompareVersionDialogViewModes,
 	removeViewVersionDialogViewModes,
-	removeTypeViewCompactMode
+	removeTypeViewCompactMode,
+	removeViewGroupedTypes
 } from '../../utils/state';
 
 export const preferencesGroups: Array<{
@@ -138,6 +139,7 @@ export const preferencesGroups: Array<{
 			removeCompareVersionDialogViewModes(props.username);
 			removeViewVersionDialogViewModes(props.username);
 			removeTypeViewCompactMode(props.username);
+			removeViewGroupedTypes(props.username);
 		}
 	}
 ];

--- a/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
@@ -128,7 +128,9 @@ export function SelectTypeView(props: SelectContentTypeProps) {
 			{groupTypes ? (
 				Object.entries(getGroupedTypes()).map(([archetype, types]) => (
 					<Box key={archetype} sx={{ mb: 4 }}>
-						<Typography variant="h6">{archeTypes[archetype].label}</Typography>
+						<Typography variant="h6" sx={{ mb: 1 }}>
+							{archeTypes[archetype].label}
+						</Typography>
 						<TypeList {...slotProps.listing} showTypeId compact={compact} contentTypes={types} />
 					</Box>
 				))

--- a/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
@@ -24,9 +24,16 @@ import { filterTypesByKeywordsAndObjectType } from '../../../utils/contentType';
 import useUpdateRefs from '../../../hooks/useUpdateRefs';
 import ContentType from '../../../models/ContentType';
 import { consolidateSx } from '../../../utils/system';
-import { getTypeViewCompactMode, setTypeViewCompactMode } from '../../../utils/state';
+import {
+	getTypeViewCompactMode,
+	getViewGroupedTypes,
+	setTypeViewCompactMode,
+	setViewGroupedTypes
+} from '../../../utils/state';
 import useActiveUser from '../../../hooks/useActiveUser';
 import { nnou } from '../../../utils/object';
+import type { LookupTable } from '../../../models';
+import Typography from '@mui/material/Typography';
 
 export interface SelectContentTypeProps {
 	sx?: BoxProps['sx'];
@@ -48,16 +55,23 @@ export function SelectTypeView(props: SelectContentTypeProps) {
 	const [keywords, setKeywords] = useState('');
 	const [filteredTypes, setFilteredTypes] = useState<ContentType[]>();
 	const [objectTypeFilter, setObjectTypeFilter] = useState<ObjectTypeOption>(initialObjectTypeFilter);
+	const [sortOrder, setSortOrder] = useState<'ascending' | 'descending'>('ascending');
 	const onKeyword$ = useDebouncedInput((keywords) => {
 		setFilteredTypes(filterTypesByKeywordsAndObjectType(contentTypesList, keywords, objectTypeFilter));
 	});
+	const storedViewGrouped = getViewGroupedTypes(username);
+	const [groupTypes, setGroupTypes] = useState<boolean>(nnou(storedViewGrouped) ? storedViewGrouped : true);
+	// TODO: List archetypes from config
+	const archeTypes = {
+		page: { label: 'Page', value: 'page' },
+		component: { label: 'Component', value: 'component' }
+	};
 
 	const effectRefs = useUpdateRefs({ keywords, filterTypes: filterTypesByKeywordsAndObjectType });
 	useEffect(() => {
-		setFilteredTypes(
-			filterTypesByKeywordsAndObjectType(contentTypesList, effectRefs.current.keywords, objectTypeFilter)
-		);
-	}, [contentTypesList, objectTypeFilter, effectRefs]);
+		const types = filterTypesByKeywordsAndObjectType(contentTypesList, effectRefs.current.keywords, objectTypeFilter);
+		setFilteredTypes(sortContentTypes(types, sortOrder));
+	}, [contentTypesList, objectTypeFilter, effectRefs, sortOrder]);
 
 	const handleKeywordsChange: TypeListControlBarProps['onKeywordsChange'] = (value) => {
 		setKeywords(value);
@@ -69,20 +83,71 @@ export function SelectTypeView(props: SelectContentTypeProps) {
 		setTypeViewCompactMode(username, value);
 	};
 
+	const handleSetGrouped = (value: boolean) => {
+		setGroupTypes(value);
+		setViewGroupedTypes(username, value);
+	};
+
+	const handleToggleSortOrder = (contentTypes: ContentType[]) => {
+		const newOrder = sortOrder === 'ascending' ? 'descending' : 'ascending';
+		setSortOrder(newOrder);
+		if (contentTypes) {
+			setFilteredTypes(sortContentTypes(contentTypes, newOrder));
+		}
+	};
+
+	const getGroupedTypes = () => {
+		// Group types by archetype, keeping the sorting for each group
+		const grouped: LookupTable<ContentType[]> = {};
+		if (filteredTypes) {
+			Object.values(archeTypes).forEach((archetype) => {
+				const typesForArchetype = filteredTypes.filter((contentType) => contentType.type === archetype.value);
+				if (typesForArchetype.length > 0) {
+					grouped[archetype.value] = sortContentTypes(typesForArchetype, sortOrder);
+				}
+			});
+		}
+		return grouped;
+	};
+
 	return (
 		<Box {...slotProps.box} sx={consolidateSx(sx, slotProps?.box?.sx)}>
 			<TypeListControlBar
 				{...slotProps.bar}
 				compact={compact}
 				onCompactChange={handleSetCompact}
+				groupTypes={groupTypes}
+				onGroupTypesChange={handleSetGrouped}
 				keywords={keywords}
 				onKeywordsChange={handleKeywordsChange}
+				sortOrder={sortOrder}
+				onToggleSortOrder={() => handleToggleSortOrder(filteredTypes)}
 				objectTypeFilter={objectTypeFilter}
 				onObjectTypeFilterChange={setObjectTypeFilter}
 			/>
-			<TypeList {...slotProps.listing} showTypeId compact={compact} contentTypes={filteredTypes} />
+			{groupTypes ? (
+				Object.entries(getGroupedTypes()).map(([archetype, types]) => (
+					<Box key={archetype} sx={{ mb: 4 }}>
+						<Typography variant="h6">{archeTypes[archetype].label}</Typography>
+						<Box sx={{ mb: 2, fontSize: '1.25rem', fontWeight: 'bold' }}></Box>
+						<TypeList {...slotProps.listing} showTypeId compact={compact} contentTypes={types} />
+					</Box>
+				))
+			) : (
+				<TypeList {...slotProps.listing} showTypeId compact={compact} contentTypes={filteredTypes} />
+			)}
 		</Box>
 	);
 }
+
+const sortContentTypes = (types: ContentType[], order: 'ascending' | 'descending') => {
+	return [...types].sort((a, b) => {
+		const aValue = a.name.toLowerCase();
+		const bValue = b.name.toLowerCase();
+		if (aValue < bValue) return order === 'ascending' ? -1 : 1;
+		if (aValue > bValue) return order === 'ascending' ? 1 : -1;
+		return 0;
+	});
+};
 
 export default SelectTypeView;

--- a/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
@@ -102,7 +102,7 @@ export function SelectTypeView(props: SelectContentTypeProps) {
 	 * @returns {LookupTable<ContentType[]>} An object where the keys are archetype values and the values
 	 * are arrays of `ContentType` objects sorted by the current sort order.
 	 */
-	const getGroupedTypes = (): LookupTable<ContentType> => {
+	const getGroupedTypes = (): LookupTable<ContentType[]> => {
 		const grouped: LookupTable<ContentType[]> = {};
 		if (filteredTypes) {
 			Object.values(archeTypes).forEach((archetype) => {
@@ -146,7 +146,15 @@ export function SelectTypeView(props: SelectContentTypeProps) {
 	);
 }
 
-const sortContentTypes = (types: ContentType[], order: 'ascending' | 'descending') => {
+/**
+ * Sorts an array of content types alphabetically by their name property, either in ascending or descending order.
+ *
+ * @param {ContentType[]} types - The array of content types to be sorted.
+ * @param {'ascending' | 'descending'} order - The order in which to sort the content types.
+ *        Use 'ascending' for A-Z sorting and 'descending' for Z-A sorting.
+ * @returns {ContentType[]} A new array of content types sorted by name in the specified order.
+ */
+const sortContentTypes = (types: ContentType[], order: 'ascending' | 'descending'): ContentType[] => {
 	return [...types].sort((a, b) => {
 		const aValue = a.name.toLowerCase();
 		const bValue = b.name.toLowerCase();

--- a/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
@@ -129,7 +129,6 @@ export function SelectTypeView(props: SelectContentTypeProps) {
 				Object.entries(getGroupedTypes()).map(([archetype, types]) => (
 					<Box key={archetype} sx={{ mb: 4 }}>
 						<Typography variant="h6">{archeTypes[archetype].label}</Typography>
-						<Box sx={{ mb: 2, fontSize: '1.25rem', fontWeight: 'bold' }}></Box>
 						<TypeList {...slotProps.listing} showTypeId compact={compact} contentTypes={types} />
 					</Box>
 				))

--- a/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/SelectTypeView.tsx
@@ -96,8 +96,13 @@ export function SelectTypeView(props: SelectContentTypeProps) {
 		}
 	};
 
-	const getGroupedTypes = () => {
-		// Group types by archetype, keeping the sorting for each group
+	/**
+	 * Groups content types by their archetype while maintaining the sorting order for each group.
+	 *
+	 * @returns {LookupTable<ContentType[]>} An object where the keys are archetype values and the values
+	 * are arrays of `ContentType` objects sorted by the current sort order.
+	 */
+	const getGroupedTypes = (): LookupTable<ContentType> => {
 		const grouped: LookupTable<ContentType[]> = {};
 		if (filteredTypes) {
 			Object.values(archeTypes).forEach((archetype) => {

--- a/ui/app/src/components/ContentTypeManagement/components/TypeCard.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeCard.tsx
@@ -87,7 +87,10 @@ export function TypeCard(props: TypeCardProps) {
 			{...cardProps}
 			sx={consolidateSx(
 				baseCardSx,
-				{ borderLeft: (theme) => `${theme.spacing(1)} solid`, borderLeftColor: toColor(type.id) },
+				{
+					borderLeft: (theme) => `${theme.spacing(1)} solid`,
+					borderLeftColor: type ? toColor(type.id) : null
+				},
 				!hasActionArea && styleOverrides?.actionArea,
 				sx
 			)}

--- a/ui/app/src/components/ContentTypeManagement/components/TypeCard.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeCard.tsx
@@ -23,6 +23,7 @@ import CardActionArea from '@mui/material/CardActionArea';
 import type { BoxProps } from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
 import { TypeCardMedia } from './TypeCardMedia';
+import { toColor } from '../../../utils/string';
 
 export interface TypeCardProps extends Omit<CardProps, 'onClick'> {
 	type: ContentType;
@@ -82,7 +83,15 @@ export function TypeCard(props: TypeCardProps) {
 		</>
 	);
 	return (
-		<Card {...cardProps} sx={consolidateSx(baseCardSx, !hasActionArea && styleOverrides?.actionArea, sx)}>
+		<Card
+			{...cardProps}
+			sx={consolidateSx(
+				baseCardSx,
+				{ borderLeft: (theme) => `${theme.spacing(1)} solid`, borderLeftColor: toColor(type.id) },
+				!hasActionArea && styleOverrides?.actionArea,
+				sx
+			)}
+		>
 			{hasActionArea ? (
 				<CardActionArea sx={styleOverrides?.actionArea} onClick={(e) => onClick(e, type)}>
 					{cardBody}

--- a/ui/app/src/components/ContentTypeManagement/components/TypeCard.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeCard.tsx
@@ -64,7 +64,7 @@ export function TypeCard(props: TypeCardProps) {
 	const cardBody = (
 		<>
 			<CardHeader
-				sx={{ flexGrow: 1 }}
+				sx={{ flexGrow: 1, flex: 1, overflow: 'hidden' }}
 				title={heading}
 				subheader={subheading}
 				slotProps={{

--- a/ui/app/src/components/ContentTypeManagement/components/TypeCardMedia.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeCardMedia.tsx
@@ -55,9 +55,7 @@ export function TypeCardMedia(props: ContentTypeCardMediaProps) {
 					height: '200px',
 					display: 'block',
 					bgcolor: theme.palette.mode === 'light' ? 'grey.100' : 'grey.900',
-					objectFit: 'cover',
-					borderLeft: (theme) => `${theme.spacing(1)} solid`,
-					borderLeftColor: toColor(typeId)
+					objectFit: 'cover'
 				},
 				skeleton ? { transform: 'none' } : { '&:not([src])': { opacity: 0 } },
 				sx

--- a/ui/app/src/components/ContentTypeManagement/components/TypeCardMedia.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeCardMedia.tsx
@@ -21,7 +21,6 @@ import { fetchPreviewImage } from '../../../services/contentTypes';
 import CardMedia, { CardMediaProps } from '@mui/material/CardMedia';
 import { consolidateSx } from '../../../utils/system';
 import Skeleton from '@mui/material/Skeleton';
-import { toColor } from '../../../utils/string';
 
 export interface ContentTypeCardMediaProps extends CardMediaProps {
 	typeId: string;

--- a/ui/app/src/components/ContentTypeManagement/components/TypeCardMedia.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeCardMedia.tsx
@@ -21,6 +21,7 @@ import { fetchPreviewImage } from '../../../services/contentTypes';
 import CardMedia, { CardMediaProps } from '@mui/material/CardMedia';
 import { consolidateSx } from '../../../utils/system';
 import Skeleton from '@mui/material/Skeleton';
+import { toColor } from '../../../utils/string';
 
 export interface ContentTypeCardMediaProps extends CardMediaProps {
 	typeId: string;
@@ -54,7 +55,9 @@ export function TypeCardMedia(props: ContentTypeCardMediaProps) {
 					height: '200px',
 					display: 'block',
 					bgcolor: theme.palette.mode === 'light' ? 'grey.100' : 'grey.900',
-					objectFit: 'contain'
+					objectFit: 'cover',
+					borderLeft: (theme) => `${theme.spacing(1)} solid`,
+					borderLeftColor: toColor(typeId)
 				},
 				skeleton ? { transform: 'none' } : { '&:not([src])': { opacity: 0 } },
 				sx

--- a/ui/app/src/components/ContentTypeManagement/components/TypeList.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeList.tsx
@@ -67,10 +67,7 @@ export function TypeList(props: TypeListProps) {
 								showTypeId={showTypeId}
 								compact={compact}
 								onClick={isSelected ? undefined : (e) => onCardClick?.(e, type)}
-								sx={[
-									isSelected && { border: `2px solid ${palette.blue.tint}`, opacity: 0.7, boxShadow: 0 },
-									{ flexBasis: 0 }
-								]}
+								sx={[isSelected && { border: `2px solid ${palette.blue.tint}`, opacity: 0.7, boxShadow: 0 }]}
 							/>
 						);
 					})}

--- a/ui/app/src/components/ContentTypeManagement/components/TypeList.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeList.tsx
@@ -47,7 +47,13 @@ export function TypeList(props: TypeListProps) {
 		return <EmptyState title={<FormattedMessage defaultMessage="No content types available for display." />} />;
 	}
 	return (
-		<Box display="flex" gap={2} flexWrap="wrap">
+		<Box
+			gap={2}
+			sx={{
+				display: 'grid',
+				gridTemplateColumns: 'repeat(auto-fill, minmax(270px, 1fr))'
+			}}
+		>
 			{skeleton
 				? new Array(skeletonItemCount)
 						.fill(null)
@@ -61,7 +67,10 @@ export function TypeList(props: TypeListProps) {
 								showTypeId={showTypeId}
 								compact={compact}
 								onClick={isSelected ? undefined : (e) => onCardClick?.(e, type)}
-								sx={[isSelected && { border: `2px solid ${palette.blue.tint}`, opacity: 0.7, boxShadow: 0 }]}
+								sx={[
+									isSelected && { border: `2px solid ${palette.blue.tint}`, opacity: 0.7, boxShadow: 0 },
+									{ flexBasis: 0 }
+								]}
 							/>
 						);
 					})}

--- a/ui/app/src/components/ContentTypeManagement/components/TypeListControlBar.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/TypeListControlBar.tsx
@@ -25,7 +25,10 @@ import Switch from '@mui/material/Switch';
 import { FormattedMessage } from 'react-intl';
 import { BoxProps } from '@mui/material/Box';
 import { consolidateSx } from '../../../utils/system';
-import type { SelectProps } from '@mui/material/Select';
+import { type SelectProps } from '@mui/material/Select';
+import Button from '@mui/material/Button';
+import ArrowUpwardRoundedIcon from '@mui/icons-material/ArrowUpwardRounded';
+import ArrowDownwardRoundedIcon from '@mui/icons-material/ArrowDownwardRounded';
 
 export interface TypeListControlBarProps {
 	compact: boolean;
@@ -34,6 +37,10 @@ export interface TypeListControlBarProps {
 	onKeywordsChange(value: string): void;
 	objectTypeFilter: ObjectTypeOption;
 	onObjectTypeFilterChange(value: ObjectTypeOption): void;
+	sortOrder?: 'descending' | 'ascending';
+	onToggleSortOrder?(): void;
+	groupTypes: boolean;
+	onGroupTypesChange(value: boolean): void;
 	searchInputRef?: Ref<HTMLInputElement>;
 	leftChildren?: ReactNode;
 	slotProps?: Partial<{
@@ -52,11 +59,16 @@ export function TypeListControlBar(props: TypeListControlBarProps) {
 		objectTypeFilter,
 		onKeywordsChange,
 		onObjectTypeFilterChange,
+		sortOrder,
+		onToggleSortOrder,
 		onCompactChange,
 		searchInputRef,
 		leftChildren,
-		slotProps
+		slotProps,
+		groupTypes,
+		onGroupTypesChange
 	} = props;
+
 	return (
 		<Paper {...slotProps} sx={consolidateSx({ p: 1, mb: 2, display: 'flex' }, slotProps?.paper?.sx)}>
 			{leftChildren && (
@@ -98,10 +110,35 @@ export function TypeListControlBar(props: TypeListControlBarProps) {
 				)}
 			/>
 			<FormControlLabel
+				control={<Switch checked={groupTypes} onChange={(e, checked) => onGroupTypesChange(checked)} />}
+				label={<FormattedMessage defaultMessage="Group Types" />}
+				slotProps={{ typography: { variant: 'body2' } }}
+			/>
+			<FormControlLabel
 				control={<Switch checked={compact} onChange={(e, checked) => onCompactChange(checked)} />}
 				label={<FormattedMessage defaultMessage="Compact" />}
 				slotProps={{ typography: { variant: 'body2' } }}
 			/>
+			{onToggleSortOrder && (
+				<Button
+					variant="text"
+					endIcon={
+						sortOrder === 'ascending' ? (
+							<ArrowUpwardRoundedIcon color="primary" />
+						) : (
+							<ArrowDownwardRoundedIcon color="primary" />
+						)
+					}
+					onClick={onToggleSortOrder}
+					sx={{
+						color: 'text.primary',
+						fontWeight: 'normal',
+						fontSize: (theme) => theme.typography.fontSize
+					}}
+				>
+					<FormattedMessage defaultMessage="Sort" />
+				</Button>
+			)}
 		</Paper>
 	);
 }

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -500,3 +500,16 @@ export function getTypeViewCompactMode(user: string): boolean {
 export function removeTypeViewCompactMode(user: string) {
 	window.localStorage.removeItem(`craftercms.${user}.typeViewCompactMode`);
 }
+
+export function setViewGroupedTypes(user: string, value: boolean) {
+	window.localStorage.setItem(`craftercms.${user}.viewGroupedTypes`, JSON.stringify(value));
+}
+
+export function getViewGroupedTypes(user: string): boolean {
+	const value = window.localStorage.getItem(`craftercms.${user}.viewGroupedTypes`);
+	return value ? value === 'true' : null;
+}
+
+export function removeViewGroupedTypes(user: string) {
+	window.localStorage.removeItem(`craftercms.${user}.viewGroupedTypes`);
+}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8484

- Fix TypeList grid for all cards to be the same width
- Fix TypeCard overflow styles
- Add sort by name to TypeList
- Add option to group types by archetypes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle to group content types by archetype with labeled sections.
  * Sort control to order types ascending/descending; both controls available in the list toolbar.
  * Grouping and sort preferences persisted per user.

* **Style**
  * Responsive grid layout for content type cards.
  * Improved card header overflow and tighter media fit with colorized accents.

* **Chores**
  * Account cleanup now also removes the saved grouping preference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->