### PR TITLE
[7418] Update DescriptorContentType to have metadata and remove root level supportedPostFixes

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
@@ -23,7 +23,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { FormattedMessage, useIntl } from 'react-intl';
 import AddCircleOutlineOutlinedIcon from '@mui/icons-material/AddCircleOutlineOutlined';
 import { DropDownMenu } from '../../DropDownMenuButton';
-import { postFixesMap, PostFixesType } from '../postFixesMap';
+import { suffixesMap, SuffixesType } from '../suffixesMap';
 import { useStableFormContext } from '../../FormsEngine/lib/formsEngineContext';
 import { useAtomValue } from 'jotai';
 import useUpdateRefs from '../../../hooks/useUpdateRefs';
@@ -33,7 +33,7 @@ export interface VariableProps extends ControlProps {
 }
 
 const disabledFields = ['internal-name', 'file-name'];
-const disablePostFixes = ['internal-name', 'file-name', 'disabled'];
+const disableSuffixes = ['internal-name', 'file-name', 'disabled'];
 
 export function Variable(props: VariableProps) {
 	const { field, value, setValue, readonly, autoFocus, contentType } = props;
@@ -41,14 +41,14 @@ export function Variable(props: VariableProps) {
 	const htmlId = useId();
 	const maxLength = field.validations.maxLength?.value;
 	const controlDescriptor = contentType?.id && controlDescriptors[contentType?.id];
-	const supportedPostFixes: PostFixesType[] = controlDescriptor?.supportedPostFixes;
+	const supportedSuffixes: SuffixesType[] = controlDescriptor?.metadata?.suffixes;
 	const { formatMessage } = useIntl();
 	const disabled = readonly || disabledFields.includes(value);
-	const showPostFixes = supportedPostFixes && !disablePostFixes.includes(value);
+	const showSuffixes = supportedSuffixes && !disableSuffixes.includes(value);
 	const effectRefs = useUpdateRefs({
 		value,
 		setValue,
-		supportedPostFixes,
+		supportedSuffixes,
 		allowAutoValue,
 		disabled
 	});
@@ -59,10 +59,10 @@ export function Variable(props: VariableProps) {
 	const inputRef = useRef<HTMLInputElement>(null); // ref for the input
 
 	useEffect(() => {
-		const { setValue, supportedPostFixes, allowAutoValue, disabled } = effectRefs.current;
+		const { setValue, supportedSuffixes, allowAutoValue, disabled } = effectRefs.current;
 		// If allowAutoValue is true and the field is not disabled, set the value from the title.
 		if (allowAutoValue && !disabled && title) {
-			setValue(getValueFromTitle(title, supportedPostFixes));
+			setValue(getValueFromTitle(title, supportedSuffixes));
 		}
 	}, [title, effectRefs]);
 
@@ -73,8 +73,8 @@ export function Variable(props: VariableProps) {
 		setValue(newValue);
 	};
 
-	const onAddPostFix = (postFix: string) => {
-		setValue(getValueWithPostFix(value, postFix, supportedPostFixes));
+	const onAddSuffix = (suffix: string) => {
+		setValue(getValueWithSuffix(value, suffix, supportedSuffixes));
 		setTimeout(() => {
 			inputRef.current?.focus(); // Focus the input after updating the value
 			const length = inputRef.current.value.length; // Get the length of the input value
@@ -94,15 +94,15 @@ export function Variable(props: VariableProps) {
 				disabled={disabled}
 				inputRef={inputRef}
 				endAdornment={
-					showPostFixes && (
-						<Tooltip title={<FormattedMessage defaultMessage="Add/update postfix" />}>
+					showSuffixes && (
+						<Tooltip title={<FormattedMessage defaultMessage="Add/update suffix" />}>
 							<DropDownMenu
-								onMenuItemClick={(event, optionId) => onAddPostFix(optionId)}
-								options={supportedPostFixes.map((postFix) => {
-									const translation = formatMessage(postFixesMap[postFix]);
+								onMenuItemClick={(event, optionId) => onAddSuffix(optionId)}
+								options={supportedSuffixes.map((suffix) => {
+									const translation = formatMessage(suffixesMap[suffix]);
 									return {
-										id: postFix,
-										primaryText: postFix,
+										id: suffix,
+										primaryText: suffix,
 										secondaryText: translation
 									};
 								})}
@@ -142,19 +142,19 @@ const cleanVariable = (value) => {
 	return value.replace(/-/g, '_').replace(/[^A-Za-z0-9-_]/g, '');
 };
 
-const getValueWithPostFix = (value: string, postFix: string, supportedPostFixes: PostFixesType[]): string => {
-	const currentPostFix = value.match(/_[a-z]+$/)?.[0];
-	const isPostfix = currentPostFix && supportedPostFixes?.includes(currentPostFix as PostFixesType);
-	return isPostfix ? value.replace(/_[a-z]+$/, `${postFix}`) : `${value}${postFix}`;
+const getValueWithSuffix = (value: string, suffix: string, supportedSuffixes: SuffixesType[]): string => {
+	const currentSuffix = value.match(/_[a-z]+$/)?.[0];
+	const isSuffix = currentSuffix && supportedSuffixes?.includes(currentSuffix as SuffixesType);
+	return isSuffix ? value.replace(/_[a-z]+$/, `${suffix}`) : `${value}${suffix}`;
 };
 
-const getValueFromTitle = (title: string, supportedPostFixes: PostFixesType[]): string => {
+const getValueFromTitle = (title: string, supportedSuffixes: SuffixesType[]): string => {
 	let newValue = cleanVariable(title);
 	// Lowercase the first letter
 	newValue = newValue.charAt(0).toLowerCase() + newValue.slice(1);
-	// If there are supported post fixes and the value is not in the disablePostFixes list, add the first one.
-	if (supportedPostFixes?.length && !disablePostFixes.includes(newValue)) {
-		newValue = getValueWithPostFix(newValue, supportedPostFixes[0], supportedPostFixes);
+	// If there are supported post fixes and the value is not in the disableSuffixes list, add the first one.
+	if (supportedSuffixes?.length && !disableSuffixes.includes(newValue)) {
+		newValue = getValueWithSuffix(newValue, supportedSuffixes[0], supportedSuffixes);
 	}
 	return newValue;
 };

--- a/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
@@ -152,7 +152,7 @@ const getValueFromTitle = (title: string, supportedSuffixes: SuffixesType[]): st
 	let newValue = cleanVariable(title);
 	// Lowercase the first letter
 	newValue = newValue.charAt(0).toLowerCase() + newValue.slice(1);
-	// If there are supported post fixes and the value is not in the disableSuffixes list, add the first one.
+	// If there are supported suffixes and the value is not in the disableSuffixes list, add the first one.
 	if (supportedSuffixes?.length && !disableSuffixes.includes(newValue)) {
 		newValue = getValueWithSuffix(newValue, supportedSuffixes[0], supportedSuffixes);
 	}

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkbox.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkbox.ts
@@ -50,7 +50,9 @@ export const checkboxDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_b']
+	metadata: {
+		suffixes: ['_b']
+	}
 };
 
 export default checkboxDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkboxGroup.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/checkboxGroup.ts
@@ -84,7 +84,9 @@ export const checkboxGroupDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_o']
+	metadata: {
+		suffixes: ['_o']
+	}
 };
 
 export default checkboxGroupDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/dateTime.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/dateTime.ts
@@ -124,7 +124,9 @@ export const dateTimeDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_dt']
+	metadata: {
+		suffixes: ['_dt']
+	}
 };
 
 export default dateTimeDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/dropdown.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/dropdown.ts
@@ -66,7 +66,9 @@ export const dropdownDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_s', '_i', '_f']
+	metadata: {
+		suffixes: ['_s', '_i', '_f']
+	}
 };
 
 export default dropdownDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/imagePicker.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/imagePicker.ts
@@ -87,7 +87,9 @@ export const imagePickerDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_s']
+	metadata: {
+		suffixes: ['_s']
+	}
 };
 
 export default imagePickerDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/input.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/input.ts
@@ -78,7 +78,9 @@ export const inputDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_s', '_t']
+	metadata: {
+		suffixes: ['_s', '_t']
+	}
 };
 
 export default inputDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/label.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/label.ts
@@ -45,7 +45,9 @@ export const labelDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_s']
+	metadata: {
+		suffixes: ['_s']
+	}
 };
 
 export default labelDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/nodeSelector.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/nodeSelector.ts
@@ -94,7 +94,9 @@ export const nodeSelectorDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_o']
+	metadata: {
+		suffixes: ['_o']
+	}
 };
 
 export default nodeSelectorDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/numericInput.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/numericInput.ts
@@ -78,7 +78,9 @@ export const numericInputDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_i', '_l', '_f', '_d']
+	metadata: {
+		suffixes: ['_i', '_l', '_f', '_d']
+	}
 };
 
 export default numericInputDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/repeat.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/repeat.ts
@@ -45,7 +45,9 @@ export const repeatDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_o']
+	metadata: {
+		suffixes: ['_o']
+	}
 };
 
 export default repeatDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/rte.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/rte.ts
@@ -116,7 +116,9 @@ export const rteDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_html']
+	metadata: {
+		suffixes: ['_html']
+	}
 };
 
 export default rteDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/textarea.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/textarea.ts
@@ -78,7 +78,9 @@ export const textareaDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_t', '_s']
+	metadata: {
+		suffixes: ['_t', '_s']
+	}
 };
 
 export default textareaDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/time.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/time.ts
@@ -100,7 +100,9 @@ export const timeDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_to']
+	metadata: {
+		suffixes: ['_to']
+	}
 };
 
 export default timeDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/transcodedVideoPicker.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/transcodedVideoPicker.ts
@@ -59,7 +59,9 @@ export const transcodedVideoPickerDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_o']
+	metadata: {
+		suffixes: ['_o']
+	}
 };
 
 export default transcodedVideoPickerDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/videoPicker.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/videoPicker.ts
@@ -43,7 +43,9 @@ export const videoPickerDescriptor: DescriptorContentType = {
 			validations: immutableEmptyObject
 		}
 	},
-	supportedPostFixes: ['_o']
+	metadata: {
+		suffixes: ['_o']
+	}
 };
 
 export default videoPickerDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/suffixesMap.ts
+++ b/ui/app/src/components/ContentTypeManagement/suffixesMap.ts
@@ -16,7 +16,7 @@
 
 import { defineMessage, MessageDescriptor } from 'react-intl';
 
-export type PostFixesType =
+export type SuffixesType =
 	| '_s'
 	| '_t'
 	| '_i'
@@ -31,7 +31,7 @@ export type PostFixesType =
 	| '_en'
 	| '_txt';
 
-export const postFixesMap: Record<PostFixesType, MessageDescriptor> = {
+export const suffixesMap: Record<SuffixesType, MessageDescriptor> = {
 	_s: defineMessage({ defaultMessage: 'For string.' }),
 	_t: defineMessage({ defaultMessage: 'For multiple words or tokens.' }),
 	_i: defineMessage({ defaultMessage: 'For integer number.' }),

--- a/ui/app/src/components/ContentTypeManagement/utils.ts
+++ b/ui/app/src/components/ContentTypeManagement/utils.ts
@@ -307,7 +307,10 @@ export type DescriptorContentType = Pick<ContentType, 'id'> & {
 	sections: DescriptorSection[];
 	fields: LookupTable<DescriptorField>;
 	type?: 'image' | 'item' | 'audio' | 'flash' | 'video' | 'transcoded-video';
-	supportedPostFixes?: string[];
+	metadata?: {
+		suffixes?: string[];
+		additionalFields?: string[];
+	};
 };
 
 export type DescriptorSection = Omit<ContentTypeSection, 'title' | 'description'> & {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated postfix → suffix terminology and moved suffix configuration into a metadata container across content type management for consistency.
* **Bug Fixes / UX**
  * UI text and tooltip updated from "postfix" to "suffix"; suffix selector and add/update control behavior and initial value derivation now use the unified suffix configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->