### PR TITLE
[8434] Publish Queue: Cancel Package dialog should be closed after successful operation

### DIFF
--- a/ui/app/src/components/PublishingQueue/PublishingPackage.tsx
+++ b/ui/app/src/components/PublishingQueue/PublishingPackage.tsx
@@ -145,6 +145,7 @@ export function PublishingPackage(props: PublishingPackageProps) {
 	}
 
 	const onCancelDialogSuccess = () => {
+		cancelPackageDialogState.onClose();
 		getPackages(siteId);
 	};
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the cancel dialog for publishing packages would remain open after successfully canceling an operation. The dialog now properly closes before the package list refreshes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->