### PR TITLE
[8438] Publish On Demand dialog does not display API 4xx error responses

### DIFF
--- a/ui/app/src/components/PublishOnDemandWidget/PublishOnDemandWidget.tsx
+++ b/ui/app/src/components/PublishOnDemandWidget/PublishOnDemandWidget.tsx
@@ -280,12 +280,7 @@ export function PublishOnDemandWidget(props: PublishOnDemandWidgetProps) {
 			},
 			error({ response }) {
 				setIsSubmitting(false);
-				dispatch(
-					showSystemNotification({
-						message: response.message,
-						options: { variant: 'error' }
-					})
-				);
+				dispatch(pushErrorDialog({ props: { error: response.response } }));
 			}
 		});
 	};
@@ -327,10 +322,7 @@ export function PublishOnDemandWidget(props: PublishOnDemandWidgetProps) {
 							},
 							error({ response }) {
 								setIsSubmitting(false);
-								showSystemNotification({
-									message: response.message,
-									options: { variant: 'error' }
-								});
+								dispatch(pushErrorDialog({ props: { error: response.response } }));
 							}
 						});
 					}
@@ -364,12 +356,7 @@ export function PublishOnDemandWidget(props: PublishOnDemandWidgetProps) {
 			},
 			error({ response }) {
 				setIsSubmitting(false);
-				dispatch(
-					showSystemNotification({
-						message: response.message,
-						options: { variant: 'error' }
-					})
-				);
+				dispatch(pushErrorDialog({ props: { error: response.response } }));
 			}
 		});
 	};

--- a/ui/app/src/components/PublishOnDemandWidget/PublishOnDemandWidget.tsx
+++ b/ui/app/src/components/PublishOnDemandWidget/PublishOnDemandWidget.tsx
@@ -50,6 +50,7 @@ import Alert, { alertClasses } from '@mui/material/Alert';
 import { popDialog, pushDialog } from '../../state/actions/dialogStack';
 import { nanoid } from 'nanoid';
 import { createComponentId, pushConfirmDialog, pushErrorDialog } from '../../utils/system';
+import { extractErrorPayload } from '../../utils/ajax';
 
 const messages = defineMessages({
 	publishStudioWarning: {
@@ -278,9 +279,9 @@ export function PublishOnDemandWidget(props: PublishOnDemandWidgetProps) {
 					dispatch(onSuccessProp);
 				}
 			},
-			error({ response }) {
+			error(error) {
 				setIsSubmitting(false);
-				dispatch(pushErrorDialog({ props: { error: response.response } }));
+				dispatch(pushErrorDialog({ props: { error: extractErrorPayload(error) } }));
 			}
 		});
 	};
@@ -320,9 +321,9 @@ export function PublishOnDemandWidget(props: PublishOnDemandWidgetProps) {
 									dispatch(onSuccessProp);
 								}
 							},
-							error({ response }) {
+							error(error) {
 								setIsSubmitting(false);
-								dispatch(pushErrorDialog({ props: { error: response.response } }));
+								dispatch(pushErrorDialog({ props: { error: extractErrorPayload(error) } }));
 							}
 						});
 					}
@@ -354,9 +355,9 @@ export function PublishOnDemandWidget(props: PublishOnDemandWidgetProps) {
 					dispatch(onSuccessProp);
 				}
 			},
-			error({ response }) {
+			error(error) {
 				setIsSubmitting(false);
-				dispatch(pushErrorDialog({ props: { error: response.response } }));
+				dispatch(pushErrorDialog({ props: { error: extractErrorPayload(error) } }));
 			}
 		});
 	};

--- a/ui/app/src/utils/ajax.ts
+++ b/ui/app/src/utils/ajax.ts
@@ -21,6 +21,7 @@ import { Observable, ObservableInput, of } from 'rxjs';
 import { sessionTimeout } from '../state/actions/user';
 import StandardAction from '../models/StandardAction';
 import { UNDEFINED } from './constants';
+import { ApiResponse } from '../models';
 
 type Headers = Record<string, any>;
 
@@ -182,4 +183,8 @@ export const errorSelectorApi1: <T, O extends ObservableInput<any>>(err: any, ca
 	}
 	error.response = { response };
 	throw error;
+};
+
+export const extractErrorPayload = (error: AjaxError): ApiResponse | AjaxError => {
+	return error?.response?.response ?? error?.response ?? error;
 };


### PR DESCRIPTION
Ref #8438

- Fix error handling and updated to use error dialog instead of notification for it to be more visible

https://github.com/craftercms/craftercms/issues/8438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing errors now open an error dialog instead of a transient system notification, making failures more visible and actionable.
  * Improved backend error extraction to ensure clearer, more consistent messages are shown in the dialog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->