### PR TITLE
[8444] Approver user listed in Dashboard is always the user that requested the publish

### DIFF
--- a/ui/app/src/components/ScheduledDashlet/ScheduledDashlet.tsx
+++ b/ui/app/src/components/ScheduledDashlet/ScheduledDashlet.tsx
@@ -338,7 +338,8 @@ export function ScheduledDashlet(props: ScheduledDashletProps) {
 									<FormattedMessage
 										defaultMessage="Approved by {name} to go {publishingTarget, select, live { <render_target>live</render_target>} other {<render_target>staging</render_target>}} on {submittedDate}"
 										values={{
-											name: pkg.submitter?.username,
+											// If a reviewer approved, show their name; otherwise show submitter name
+											name: pkg.reviewer?.username ?? pkg.submitter?.username,
 											publishingTarget: pkg.target,
 											render_target(target: ReactNode[]) {
 												return (


### PR DESCRIPTION
Ref #8444
https://github.com/craftercms/craftercms/issues/8444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Approved by..." message in scheduled dashlets to display the reviewer's username when available, with a fallback to the submitter's username if no reviewer is assigned.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->