### PR TITLE
[8440] Issues with Time/Region controllers on Publish For Later

### DIFF
--- a/ui/app/src/components/DateTimeTimezonePicker/DateTimeTimezonePicker.tsx
+++ b/ui/app/src/components/DateTimeTimezonePicker/DateTimeTimezonePicker.tsx
@@ -89,10 +89,11 @@ export function DateTimeTimezonePicker(props: DateTimeTimezonePickerProps) {
 		onChange
 	});
 	const handleChange = ((newValue) => {
-		setSelectedDate(newValue);
 		if (!newValue) return;
-		if (newValue.toISOString() !== moment(effectRefs.current.dateProp).toISOString()) {
+		// Only set the value change if the date is valid and different from current.
+		if (newValue.isValid() && newValue.toISOString() !== moment(effectRefs.current.dateProp).toISOString()) {
 			effectRefs.current.onChange?.(createTransposedToTimezoneDate(newValue, selectedTimezone));
+			setSelectedDate(newValue);
 		}
 	}) as DateTimePickerProps['onChange'];
 	const handleTimezoneChange = ((event, value) => {


### PR DESCRIPTION
- Fixed the selector accepting the following input `11/14/2025 hh:mm PM` as valid.

https://github.com/craftercms/craftercms/issues/8440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date/time/timezone picker to prevent redundant updates and ensure only valid, substantive changes are processed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->