### PR TITLE
[8425] It's possible for an error in a single dashlet to break the entire dashboard

### DIFF
--- a/ui/app/src/components/SiteDashboard/SiteDashboard.tsx
+++ b/ui/app/src/components/SiteDashboard/SiteDashboard.tsx
@@ -34,6 +34,7 @@ import DevContentOpsDashlet from '../DevContentOpsDashlet/DevContentOpsDashlet';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { IconGuideDashlet } from '../IconGuideDashlet';
 import { SiteDashboardContext } from './useSiteDashboardContext';
+import { ErrorBoundary } from '../ErrorBoundary';
 
 export interface DashboardProps {
 	mountMode?: string;
@@ -135,7 +136,7 @@ export function Dashboard(props: DashboardProps) {
 									defaultProps: { contentHeight: height, onMinimize, maximizable: true },
 									createMapperFn: (mapper) => (widget, index) => (
 										<Grid size={{ xs: 12, md: 6 }} key={index}>
-											{mapper(widget, index)}
+											<ErrorBoundary>{mapper(widget, index)}</ErrorBoundary>
 										</Grid>
 									)
 								})


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dashboard widget error handling to prevent individual widget failures from affecting the entire dashboard display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->