### PR TITLE
[7870] Modifying Page URL does not reload page URL on Save & Close

### DIFF
--- a/ui/app/src/utils/system.ts
+++ b/ui/app/src/utils/system.ts
@@ -131,6 +131,7 @@ export function pickShowContentFormAction(oldProps: LegacyFormDialogProps) {
 								const params = new URLSearchParams(window.location.hash.replace(/^#\/?\?/, ''));
 								const previewURL = params.get('page');
 								if (
+									previewURL &&
 									isPagePath(oldProps.path) &&
 									getPathFromPreviewURL(previewURL) === oldProps.path &&
 									oldProps.path !== result.path

--- a/ui/app/src/utils/system.ts
+++ b/ui/app/src/utils/system.ts
@@ -30,6 +30,8 @@ import type { LegacyFormDialogProps } from '../components/LegacyFormDialog/utils
 import { nanoid } from 'nanoid';
 import { DialogStackItem } from '../models';
 import type { ConfirmDialogProps, ErrorDialogProps } from '../components';
+import { getPathFromPreviewURL, getPreviewURLFromPath } from './path';
+import { isPagePath } from '../components/FormsEngine/lib/formUtils';
 
 export type SystemLinkId =
 	| 'preview'
@@ -124,8 +126,28 @@ export function pickShowContentFormAction(oldProps: LegacyFormDialogProps) {
 							? { create: { path: oldProps.path, contentTypeId: oldProps.contentTypeId } }
 							: { update: { path: oldProps.path, changeTypeId: oldProps.changeTemplate } }),
 						readonly: oldProps.readonly ?? false,
-						onSave() {
-							if (isPreviewAppUrl()) getHostToGuestBus().next(reloadRequest());
+						onSave(result) {
+							if (isPreviewAppUrl()) {
+								const params = new URLSearchParams(window.location.hash.replace(/^#\/?\?/, ''));
+								const previewURL = params.get('page');
+								if (
+									isPagePath(oldProps.path) &&
+									getPathFromPreviewURL(previewURL) === oldProps.path &&
+									oldProps.path !== result.path
+								) {
+									// oldProps.path is as page and the same as the preview page path, but the new path is different,
+									// which means there was a rename of the page currently being previewed. Then we need to update the
+									// preview URL to reflect the new page path.
+									window.location.href = getSystemLink({
+										page: getPreviewURLFromPath(result.path),
+										systemLinkId: 'preview',
+										site: oldProps.site,
+										authoringBase: oldProps.authoringBase
+									});
+								} else {
+									getHostToGuestBus().next(reloadRequest());
+								}
+							}
 							// FE2 TODO: handling oldProps.onSaveSuccess required?
 						}
 					} as FormsEngineProps

--- a/ui/app/src/utils/system.ts
+++ b/ui/app/src/utils/system.ts
@@ -132,6 +132,7 @@ export function pickShowContentFormAction(oldProps: LegacyFormDialogProps) {
 								const previewURL = params.get('page');
 								if (
 									previewURL &&
+									result.path &&
 									isPagePath(oldProps.path) &&
 									getPathFromPreviewURL(previewURL) === oldProps.path &&
 									oldProps.path !== result.path

--- a/ui/app/src/utils/system.ts
+++ b/ui/app/src/utils/system.ts
@@ -136,7 +136,7 @@ export function pickShowContentFormAction(oldProps: LegacyFormDialogProps) {
 									getPathFromPreviewURL(previewURL) === oldProps.path &&
 									oldProps.path !== result.path
 								) {
-									// oldProps.path is as page and the same as the preview page path, but the new path is different,
+									// oldProps.path is a page and the same as the preview page path, but the new path is different,
 									// which means there was a rename of the page currently being previewed. Then we need to update the
 									// preview URL to reflect the new page path.
 									window.location.href = getSystemLink({


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7870

Original issue is no longer happening now that the new dialogs system is in. Updated the dialogs to subscribe at the websocket to check for content events and re-fetch dependant items if neccessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL handling when renaming content in preview mode—the browser address bar now updates correctly to reflect the new page path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->