### PR TITLE
[7095] Rename dialog offers the ability to edit a broken reference but will not allow the user to open the content form

### DIFF
--- a/ui/app/src/components/RenameAssetDialog/RenameAssetDialog.tsx
+++ b/ui/app/src/components/RenameAssetDialog/RenameAssetDialog.tsx
@@ -28,6 +28,7 @@ import type { Subscription } from 'rxjs';
 import { getHostToHostBus } from '../../utils/subjects';
 import { filter } from 'rxjs/operators';
 import { contentEvent } from '../../state/actions/system';
+import useUpdateRefs from '../../hooks/useUpdateRefs';
 
 export function RenameAssetDialog(props: RenameAssetDialogProps) {
 	const { item, allowBraces, onRenamed, type, error, ...rest } = props;
@@ -36,6 +37,9 @@ export function RenameAssetDialog(props: RenameAssetDialogProps) {
 	const [fetchingDependantItems, setFetchingDependantItems] = useState(false);
 	const subRef = useRef<Subscription | null>(null);
 	const dispatch = useDispatch();
+	const refs = useUpdateRefs({
+		dependantItems
+	});
 
 	const fetchDependant = useCallback(() => {
 		if (item) {
@@ -57,14 +61,22 @@ export function RenameAssetDialog(props: RenameAssetDialogProps) {
 	useEffect(() => {
 		fetchDependant();
 		const hostToHost$ = getHostToHostBus();
-		const subscription = hostToHost$.pipe(filter((e) => e.type === contentEvent.type)).subscribe(() => {
-			fetchDependant();
-		});
+		const subscription = hostToHost$
+			.pipe(
+				filter((e) => {
+					const isContentEvent = e.type === contentEvent.type;
+					if (!isContentEvent) return false;
+					return refs.current.dependantItems.some((dependant) => dependant.path === e.payload?.targetPath);
+				})
+			)
+			.subscribe(() => {
+				fetchDependant();
+			});
 		return () => {
 			subRef.current?.unsubscribe();
 			subscription.unsubscribe();
 		};
-	}, [fetchDependant]);
+	}, [fetchDependant, refs]);
 
 	return (
 		<EnhancedDialog

--- a/ui/app/src/components/RenameAssetDialog/RenameAssetDialog.tsx
+++ b/ui/app/src/components/RenameAssetDialog/RenameAssetDialog.tsx
@@ -25,6 +25,9 @@ import { parseLegacyItemToContentItem } from '../../utils/content';
 import { pushErrorDialog } from '../../utils/system';
 import useActiveSiteId from '../../hooks/useActiveSiteId';
 import type { Subscription } from 'rxjs';
+import { getHostToHostBus } from '../../utils/subjects';
+import { filter } from 'rxjs/operators';
+import { contentEvent } from '../../state/actions/system';
 
 export function RenameAssetDialog(props: RenameAssetDialogProps) {
 	const { item, allowBraces, onRenamed, type, error, ...rest } = props;
@@ -53,7 +56,14 @@ export function RenameAssetDialog(props: RenameAssetDialogProps) {
 
 	useEffect(() => {
 		fetchDependant();
-		return () => subRef.current?.unsubscribe();
+		const hostToHost$ = getHostToHostBus();
+		const subscription = hostToHost$.pipe(filter((e) => e.type === contentEvent.type)).subscribe(() => {
+			fetchDependant();
+		});
+		return () => {
+			subRef.current?.unsubscribe();
+			subscription.unsubscribe();
+		};
 	}, [fetchDependant]);
 
 	return (

--- a/ui/app/src/components/RenameContentDialog/RenameContentDialog.tsx
+++ b/ui/app/src/components/RenameContentDialog/RenameContentDialog.tsx
@@ -27,6 +27,7 @@ import { ContentItem } from '../../models';
 import { getHostToHostBus } from '../../utils/subjects';
 import { filter } from 'rxjs/operators';
 import { contentEvent } from '../../state/actions/system';
+import useUpdateRefs from '../../hooks/useUpdateRefs';
 
 export interface RenameContentDialogProps extends EnhancedDialogProps {
 	path: string;
@@ -43,6 +44,9 @@ export function RenameContentDialog(props: RenameContentDialogProps) {
 	const [error, setError] = useState(null);
 	const siteId = useActiveSiteId();
 	const pendingChangesCloseRequest = useWithPendingChangesCloseRequest(dialogProps.onClose);
+	const refs = useUpdateRefs({
+		dependantItems
+	});
 
 	const fetchDependant = useCallback(() => {
 		setFetchingDependantItems(true);
@@ -67,14 +71,22 @@ export function RenameContentDialog(props: RenameContentDialogProps) {
 		if (!isBlank(value) && !isBlank(path)) {
 			fetchDependant();
 			const hostToHost$ = getHostToHostBus();
-			const subscription = hostToHost$.pipe(filter((e) => e.type === contentEvent.type)).subscribe(() => {
-				fetchDependant();
-			});
+			const subscription = hostToHost$
+				.pipe(
+					filter((e) => {
+						const isContentEvent = e.type === contentEvent.type;
+						if (!isContentEvent) return false;
+						return refs.current.dependantItems.some((dependant) => dependant.path === e.payload?.targetPath);
+					})
+				)
+				.subscribe(() => {
+					fetchDependant();
+				});
 			return () => {
 				subscription.unsubscribe();
 			};
 		}
-	}, [fetchDependant, path, value]);
+	}, [fetchDependant, path, value, refs]);
 
 	return (
 		<EnhancedDialog

--- a/ui/app/src/components/RenameContentDialog/RenameContentDialog.tsx
+++ b/ui/app/src/components/RenameContentDialog/RenameContentDialog.tsx
@@ -24,6 +24,9 @@ import { parseLegacyItemToContentItem } from '../../utils/content';
 import useWithPendingChangesCloseRequest from '../../hooks/useWithPendingChangesCloseRequest';
 import { ensureSingleSlash, isBlank } from '../../utils/string';
 import { ContentItem } from '../../models';
+import { getHostToHostBus } from '../../utils/subjects';
+import { filter } from 'rxjs/operators';
+import { contentEvent } from '../../state/actions/system';
 
 export interface RenameContentDialogProps extends EnhancedDialogProps {
 	path: string;
@@ -63,6 +66,13 @@ export function RenameContentDialog(props: RenameContentDialogProps) {
 	useEffect(() => {
 		if (!isBlank(value) && !isBlank(path)) {
 			fetchDependant();
+			const hostToHost$ = getHostToHostBus();
+			const subscription = hostToHost$.pipe(filter((e) => e.type === contentEvent.type)).subscribe(() => {
+				fetchDependant();
+			});
+			return () => {
+				subscription.unsubscribe();
+			};
 		}
 	}, [fetchDependant, path, value]);
 

--- a/ui/app/src/components/RenameContentDialog/RenameContentDialog.tsx
+++ b/ui/app/src/components/RenameContentDialog/RenameContentDialog.tsx
@@ -39,7 +39,7 @@ export interface RenameContentDialogProps extends EnhancedDialogProps {
 
 export function RenameContentDialog(props: RenameContentDialogProps) {
 	const { path, value, validRenameValue, onRenamed, ...dialogProps } = props;
-	const [dependantItems, setDependantItems] = useState<ContentItem[]>(null);
+	const [dependantItems, setDependantItems] = useState<ContentItem[]>([]);
 	const [fetchingDependantItems, setFetchingDependantItems] = useState(false);
 	const [error, setError] = useState(null);
 	const siteId = useActiveSiteId();


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rename asset and content dialogs now auto-refresh when related items are changed elsewhere in the app.
  * Dependency lists in rename dialogs update in real-time to show current relationships without manual refresh.
  * Improved reliability of dependency updates to ensure displayed information stays current after external edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->