### PR TITLE
[7096] XB does not inform or block the author when an item is in System processing state

### DIFF
--- a/ui/guest/src/react/ExperienceBuilder.tsx
+++ b/ui/guest/src/react/ExperienceBuilder.tsx
@@ -83,7 +83,7 @@ import { GuestState } from '../store/models/GuestStore';
 import { nnou, nullOrUndefined } from '@craftercms/studio-ui/utils/object';
 import { scrollToDropTargets } from '../utils/dom';
 import { checkIfLockedOrModified, dragOk } from '../store/util';
-import { createLocationArgument, isEditActionAvailable } from '../utils/util';
+import { createLocationArgument, getContentItemFromRecord, isEditActionAvailable } from '../utils/util';
 import FieldInstanceSwitcher from './FieldInstanceSwitcher';
 import LookupTable from '@craftercms/studio-ui/models/LookupTable';
 import { Snackbar, SnackbarProps, Theme, ThemeOptions, ThemeProvider } from '@mui/material';
@@ -667,6 +667,13 @@ function ExperienceBuilderInternal(props: InternalGuestProps) {
 									: sxStylesConfig.zoneMarker.selectModeHighlight;
 							}
 							const zoneMarkerSx = deepmerge(sxStylesConfig.zoneMarker.base, zoneMarkerModeStyles, { clone: true });
+							const contentItem = getContentItemFromRecord({
+								record: elementRecord,
+								models: getCachedModels(),
+								contentItemsByPath: getCachedContentItems(),
+								parentModelId: getParentModelId(elementRecord.modelId, getCachedModels(), modelHierarchyMap)
+							});
+							const itemStateMap = contentItem?.stateMap;
 							return (
 								<ZoneMarker
 									key={highlight.id}
@@ -676,6 +683,7 @@ function ExperienceBuilderInternal(props: InternalGuestProps) {
 									lockInfo={lockInfo}
 									isStale={isExternallyModified}
 									isEditable={isEditable}
+									stateMap={itemStateMap}
 									field={field}
 									onPopperClick={
 										isMoveMode && isFieldSelectedMode

--- a/ui/guest/src/react/ZoneMarker.tsx
+++ b/ui/guest/src/react/ZoneMarker.tsx
@@ -33,6 +33,7 @@ import UltraStyledTypography from './UltraStyledTypography';
 import UltraStyledTooltip from './UltraStyledTooltip';
 import { SystemCssProperties } from '@mui/system/styleFunctionSx/styleFunctionSx';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { ItemStateMap } from '@craftercms/studio-ui';
 
 const AllowedTypeCircle = styled('div')({
 	width: 20,
@@ -65,6 +66,7 @@ export interface ZoneMarkerProps {
 	sx?: ZoneMarkerPartialSx;
 	classes?: PartialClassRecord<ZoneMarkerClassKey>;
 	field?: ContentTypeField;
+	stateMap: ItemStateMap;
 }
 
 function getStyles(sx: ZoneMarkerPartialSx): ZoneMarkerFullSx {
@@ -121,7 +123,8 @@ export function ZoneMarker(props: ZoneMarkerProps) {
 		lockInfo = null,
 		isStale = false,
 		isEditable,
-		field
+		field,
+		stateMap
 	} = props;
 	const isLockedItem = Boolean(lockInfo);
 	const [zoneStyle, setZoneStyle] = useState<CSSProperties>();
@@ -138,6 +141,8 @@ export function ZoneMarker(props: ZoneMarkerProps) {
 	useEffect(() => {
 		setZoneStyle(getZoneMarkerStyle(rect));
 	}, [rect]);
+	const isSystemProcessing = Boolean(stateMap?.systemProcessing);
+
 	return (
 		<>
 			<Box
@@ -241,7 +246,11 @@ export function ZoneMarker(props: ZoneMarkerProps) {
 						)}
 						{!isEditable && !isLockedItem && (
 							<Typography noWrap variant="body2" component="div">
-								<FormattedMessage id="zoneMarker.notEditable" defaultMessage="Not editable" />
+								{isSystemProcessing ? (
+									<FormattedMessage id="zoneMarker.systemProcessing" defaultMessage="System processing" />
+								) : (
+									<FormattedMessage id="zoneMarker.notEditable" defaultMessage="Not editable" />
+								)}
 							</Typography>
 						)}
 						{isStale && (

--- a/ui/guest/src/react/ZoneMarker.tsx
+++ b/ui/guest/src/react/ZoneMarker.tsx
@@ -66,7 +66,7 @@ export interface ZoneMarkerProps {
 	sx?: ZoneMarkerPartialSx;
 	classes?: PartialClassRecord<ZoneMarkerClassKey>;
 	field?: ContentTypeField;
-	stateMap: ItemStateMap;
+	stateMap?: ItemStateMap;
 }
 
 function getStyles(sx: ZoneMarkerPartialSx): ZoneMarkerFullSx {

--- a/ui/guest/src/utils/util.ts
+++ b/ui/guest/src/utils/util.ts
@@ -59,11 +59,21 @@ export function isEditActionAvailable(args: {
 	contentItemsByPath: LookupTable<ContentItem>;
 	parentModelId: string | null;
 }): boolean {
+	const contentItem = getContentItemFromRecord(args);
+	return contentItem?.availableActionsMap.edit;
+}
+
+export function getContentItemFromRecord(args: {
+	record: ElementRecord | ICERecord;
+	models: LookupTable<ContentInstance>;
+	contentItemsByPath: LookupTable<ContentItem>;
+	parentModelId: string | null;
+}): ContentItem | null {
 	const { record, models, contentItemsByPath, parentModelId } = args;
 	const model = models[record.modelId];
 	let path = model?.craftercms.path;
 	if (!path) {
 		path = models[parentModelId]?.craftercms.path;
 	}
-	return contentItemsByPath[path]?.availableActionsMap.edit;
+	return contentItemsByPath[path];
 }

--- a/ui/guest/src/utils/util.ts
+++ b/ui/guest/src/utils/util.ts
@@ -60,7 +60,7 @@ export function isEditActionAvailable(args: {
 	parentModelId: string | null;
 }): boolean {
 	const contentItem = getContentItemFromRecord(args);
-	return contentItem?.availableActionsMap.edit;
+	return contentItem?.availableActionsMap.edit ?? false;
 }
 
 export function getContentItemFromRecord(args: {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experience builder now shows "System processing" in zone markers when content is being processed, replacing the generic "Not editable" message for clearer feedback.

* **Improvements**
  * Content item state is now propagated into zone markers for more accurate UI status.
  * Edit availability checks use the resolved content item state, improving reliability of editability indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->