### PR TITLE
[8549] Quick create enhancements

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/controls/PathWithMacroCreator.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/PathWithMacroCreator.tsx
@@ -156,7 +156,10 @@ export function PathWithMacroCreator(props: PathWithMacroCreatorProps) {
 					endAdornment={
 						<>
 							<Tooltip title={<FormattedMessage defaultMessage="Select path" />}>
-								<IconButton aria-label="Maximize" onClick={() => onOpenPathSelectionDialog()}>
+								<IconButton
+									aria-label={formatMessage({ defaultMessage: 'Select path' })}
+									onClick={() => onOpenPathSelectionDialog()}
+								>
 									<SearchRoundedIcon />
 								</IconButton>
 							</Tooltip>

--- a/ui/app/src/components/ContentTypeManagement/controls/PathWithMacroCreator.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/PathWithMacroCreator.tsx
@@ -164,7 +164,10 @@ export function PathWithMacroCreator(props: PathWithMacroCreatorProps) {
 								</IconButton>
 							</Tooltip>
 							<Tooltip title={<FormattedMessage defaultMessage="Add macro" />}>
-								<IconButton onClick={() => dialogState.onOpen()}>
+								<IconButton
+									aria-label={formatMessage({ defaultMessage: 'Add macro' })}
+									onClick={() => dialogState.onOpen()}
+								>
 									<AddCircleOutlineOutlinedIcon />
 								</IconButton>
 							</Tooltip>

--- a/ui/app/src/components/ContentTypeManagement/controls/PathWithMacroCreator.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/PathWithMacroCreator.tsx
@@ -30,6 +30,11 @@ import ListItemButton from '@mui/material/ListItemButton';
 import { EnhancedDialog } from '../../EnhancedDialog';
 import { DialogBody } from '../../DialogBody';
 import useEnhancedDialogState from '../../../hooks/useEnhancedDialogState';
+import { useStableFormContext } from '../../FormsEngine/lib/formsEngineContext';
+import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
+import { nanoid } from 'nanoid';
+import { popDialog, pushDialog } from '../../../state/actions/dialogStack';
+import { useDispatch } from 'react-redux';
 
 export interface PathWithMacroCreatorProps extends TypeBuilderControl {
 	value: string;
@@ -64,10 +69,14 @@ const macroCreatorLookupTable = {
 
 export function PathWithMacroCreator(props: PathWithMacroCreatorProps) {
 	const { field, value, setValue, readonly, autoFocus } = props;
+	const { originalValues } = useStableFormContext();
+	const type = originalValues.type;
+	const defaultPath = type === 'page' ? '/site/website/' : '/site/components/';
 	const htmlId = useId();
 	const maxLength = field.validations.maxLength?.value;
 	const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement>(undefined);
 	const { formatMessage } = useIntl();
+	const dispatch = useDispatch();
 	const dialogState = useEnhancedDialogState();
 	const inputRef = useRef<HTMLInputElement>(undefined);
 	const addMacroRef = useRef<{
@@ -95,6 +104,26 @@ export function PathWithMacroCreator(props: PathWithMacroCreatorProps) {
 		}
 	};
 
+	const onOpenPathSelectionDialog = () => {
+		const id = nanoid();
+		dispatch(
+			pushDialog({
+				id,
+				component: 'craftercms.components.PathSelectionDialog',
+				props: {
+					rootPath: '/site',
+					allowSwitchingRootPath: false,
+					initialPath: '/site',
+					onClose: () => dispatch(popDialog({ id })),
+					onOk: ({ path }) => {
+						setValue(path);
+						dispatch(popDialog({ id }));
+					}
+				}
+			})
+		);
+	};
+
 	useEffect(() => {
 		// Focus the input when it has been updated after adding a macro.
 		if (addMacroRef.current.triggered) {
@@ -116,14 +145,27 @@ export function PathWithMacroCreator(props: PathWithMacroCreatorProps) {
 					inputProps={{ maxLength }}
 					value={value}
 					onChange={handleChange}
+					placeholder={defaultPath}
+					onFocus={() => {
+						if (!value) {
+							setValue(defaultPath);
+						}
+					}}
 					disabled={readonly}
 					spellCheck={false}
 					endAdornment={
-						<Tooltip title={<FormattedMessage defaultMessage="Add macro" />}>
-							<IconButton onClick={() => dialogState.onOpen()}>
-								<AddCircleOutlineOutlinedIcon />
-							</IconButton>
-						</Tooltip>
+						<>
+							<Tooltip title={<FormattedMessage defaultMessage="Select path" />}>
+								<IconButton aria-label="Maximize" onClick={() => onOpenPathSelectionDialog()}>
+									<SearchRoundedIcon />
+								</IconButton>
+							</Tooltip>
+							<Tooltip title={<FormattedMessage defaultMessage="Add macro" />}>
+								<IconButton onClick={() => dialogState.onOpen()}>
+									<AddCircleOutlineOutlinedIcon />
+								</IconButton>
+							</Tooltip>
+						</>
 					}
 				/>
 			</FormsEngineField>

--- a/ui/app/src/components/QuickCreate/QuickCreate.tsx
+++ b/ui/app/src/components/QuickCreate/QuickCreate.tsx
@@ -14,15 +14,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef, useEffect, useState } from 'react';
-import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import React, { forwardRef, useEffect, useMemo, useState } from 'react';
+import { defineMessages, FormattedMessage, IntlShape, useIntl } from 'react-intl';
 import IconButton from '@mui/material/IconButton';
 import AddCircleIcon from '@mui/icons-material/AddRounded';
 import Menu, { menuClasses } from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import { useDispatch } from 'react-redux';
-import { newContentCreationComplete, showEditDialog } from '../../state/actions/dialogs';
+import { newContentCreationComplete } from '../../state/actions/dialogs';
 import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
@@ -48,6 +48,11 @@ import { createComponentId, pickShowContentFormAction } from '../../utils/system
 import useEnv from '../../hooks/useEnv';
 import { nanoid } from 'nanoid';
 import { batchActions } from '../../state/actions/misc';
+import useContentTypes from '../../hooks/useContentTypes';
+import useArchetypes from '../../hooks/useArchetypes';
+import type { ContentType, LookupTable } from '../../models';
+import type { Archetype } from '../ContentTypeManagement/descriptors/archetypes';
+import Box from '@mui/material/Box';
 
 const translations = defineMessages({
 	quickCreateBtnLabel: {
@@ -101,11 +106,15 @@ export function QuickCreateMenu(props: QuickCreateMenuProps) {
 	const itemNewContentButton = item?.availableActionsMap.createContent;
 	const { error, isFetching, items: quickCreateItems } = useQuickCreateState();
 	const systemVersion = useSystemVersion();
+	const contentTypes = useContentTypes();
 
 	const onFormDisplay = (item: QuickCreateItem) => {
 		const { contentTypeId, path } = item;
+		const contentType = contentTypes?.[contentTypeId];
+		const type = contentType?.type ?? 'component';
+		const defaultPath = type === 'page' ? '/site/website/' : '/site/components/';
 		const formatPath = processPathMacros({
-			path,
+			path: path ? path : defaultPath,
 			// Since we can't support these at this stage of creation, at least this will avoid the form opening with an error
 			objectId: '(objectId)',
 			objectGroupId: '(objectGroupId)',
@@ -134,21 +143,10 @@ export function QuickCreateMenu(props: QuickCreateMenuProps) {
 				onClose={onClose}
 			>
 				{itemNewContentButton && (
-					<MenuItem onClick={onNewContentSelected} sx={{ fontSize: 14, borderBottom: 1, borderBottomColor: 'divider' }}>
+					<MenuItem onClick={onNewContentSelected} sx={{ fontSize: 14 }}>
 						<FormattedMessage id="quickCreateMenu.title" defaultMessage="New Content" />
 					</MenuItem>
 				)}
-				<Typography
-					component="h4"
-					sx={(theme) => ({
-						fontSize: 12,
-						backgroundColor: theme.palette.background.default,
-						color: theme.palette.text.secondary,
-						padding: '5px 16px'
-					})}
-				>
-					<FormattedMessage id="quickCreateMenu.sectionTitle" defaultMessage="Quick Create" />
-				</Typography>
 				{error ? (
 					<ApiResponseErrorState error={error} />
 				) : isFetching ? (
@@ -167,18 +165,40 @@ export function QuickCreateMenu(props: QuickCreateMenuProps) {
 
 function QuickCreateSection(props: QuickCreateSectionProps) {
 	const { version, quickCreateItems, classes, onItemSelected } = props;
+	const archetypes = useArchetypes();
+	const contentTypes = useContentTypes();
+	const { formatMessage } = useIntl();
+
+	const groupedItems = useMemo(() => {
+		return getGroupedQuickCreateItems(quickCreateItems, archetypes, contentTypes, formatMessage);
+	}, [quickCreateItems, archetypes, contentTypes, formatMessage]);
 
 	return (
 		<>
-			{quickCreateItems.map((item) => (
-				<MenuItem
-					key={item.path}
-					onClick={() => onItemSelected(item)}
-					className={classes?.menuItem}
-					sx={{ fontSize: 14 }}
-				>
-					{item.label}
-				</MenuItem>
+			{Object.keys(groupedItems).map((archetype, index) => (
+				<Box key={index}>
+					<Typography
+						component="h4"
+						sx={(theme) => ({
+							fontSize: 12,
+							backgroundColor: theme.palette.background.default,
+							color: theme.palette.text.secondary,
+							padding: '5px 16px'
+						})}
+					>
+						{archetype}
+					</Typography>
+					{groupedItems[archetype].map((item, index) => (
+						<MenuItem
+							key={index}
+							onClick={() => onItemSelected(item)}
+							className={classes?.menuItem}
+							sx={{ fontSize: 14 }}
+						>
+							{item.label}
+						</MenuItem>
+					))}
+				</Box>
 			))}
 			{quickCreateItems.length === 0 && (
 				<Card
@@ -330,5 +350,28 @@ const QuickCreate = forwardRef<HTMLButtonElement, { item?: ContentItem }>((props
 		</>
 	);
 });
+
+function getGroupedQuickCreateItems(
+	quickCreateItems: QuickCreateItem[],
+	archetypes: LookupTable<Archetype>,
+	contentTypes: LookupTable<ContentType>,
+	formatMessage: IntlShape['formatMessage']
+) {
+	const grouped: Record<string, QuickCreateItem[]> = {};
+	quickCreateItems
+		.slice()
+		.sort((a, b) => a.label.localeCompare(b.label))
+		.forEach((item) => {
+			const contentType = contentTypes?.[item.contentTypeId];
+			const archetype = archetypes?.[contentType?.type];
+			const archetypeLabel = archetype?.name || formatMessage({ defaultMessage: 'Other' });
+			if (!grouped[archetypeLabel]) {
+				grouped[archetypeLabel] = [];
+			}
+			grouped[archetypeLabel].push(item);
+		});
+
+	return grouped;
+}
 
 export default QuickCreate;

--- a/ui/app/src/state/epics/configuration.ts
+++ b/ui/app/src/state/epics/configuration.ts
@@ -40,6 +40,7 @@ import {
 import { defineMessages } from 'react-intl';
 import { Observable } from 'rxjs';
 import StandardAction from '../../models/StandardAction';
+import { fetchQuickCreateList } from '../actions/content';
 
 const configurationMessages = defineMessages({
 	localeError: {
@@ -58,7 +59,7 @@ function handleSystemEvent(action: StandardAction): StandardAction[] {
 	} else if (targetPath === '/config/studio/site-config.xml') {
 		return [fetchSiteConfig()];
 	} else if (/^\/config\/studio\/content-types\/.*\/form-definition\.xml$/.test(targetPath)) {
-		return [contentTypeUpdated()];
+		return [contentTypeUpdated(), fetchQuickCreateList()];
 	}
 	return [];
 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8549

- Update without need of a full-page refresh (after updating content types)
- Update to have good defaults
- Group by archetypes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Path selection dialog with search for choosing target paths.
  * Quick Create menu now shows content items grouped by archetype.

* **Improvements**
  * Smarter default path suggestions based on content type.
  * Streamlined controls: separate buttons for path selection and adding macros.
  * Quick Create list refreshes after content-type updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->