### PR TITLE
[8547] Workflow states options should only display valid options

### DIFF
--- a/ui/app/src/components/SetWorkflowStateDialog/SetItemStateDialog.tsx
+++ b/ui/app/src/components/SetWorkflowStateDialog/SetItemStateDialog.tsx
@@ -22,6 +22,7 @@ import { StatesToUpdate } from '../../services/workflow';
 export interface SetItemStateDialogProps {
 	open: boolean;
 	title: React.ReactNode;
+	hasStaging: boolean;
 	onClose(): void;
 	onClosed?(): void;
 	onConfirm(update: StatesToUpdate): void;

--- a/ui/app/src/components/SetWorkflowStateDialog/SetItemStateDialogContainer.tsx
+++ b/ui/app/src/components/SetWorkflowStateDialog/SetItemStateDialogContainer.tsx
@@ -33,7 +33,7 @@ import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material';
 
 export function SetItemStateDialogContainer(props: SetItemStateDialogProps) {
-	const { onClose, onClosed, title } = props;
+	const { onClose, onClosed, title, hasStaging } = props;
 	const [update, setUpdate] = useSpreadState({
 		clearSystemProcessing: false,
 		clearUserLocked: false,
@@ -161,48 +161,50 @@ export function SetItemStateDialogContainer(props: SetItemStateDialogProps) {
 							/>
 						</Box>
 					</Box>
-					<Box display="flex" alignItems="center">
-						<Bracket width="12px" height="42px" sx={{ marginRight: '10px' }} />
-						<Box display="flex" flexDirection="column">
-							<FormControlLabel
-								control={
-									<Switch
-										checked={update.staged}
-										color="primary"
-										onChange={(e) => {
-											setUpdate({
-												staged: e.target.checked,
-												clearStaged: e.target.checked ? false : update.clearStaged
-											});
-										}}
-									/>
-								}
-								label={
-									<FormattedMessage
-										id="setWorkflowStateDialog.setAsPublishedToStaging"
-										defaultMessage="Set as published to staging"
-									/>
-								}
-							/>
-							<FormControlLabel
-								control={
-									<Switch
-										checked={update.clearStaged}
-										color="primary"
-										onChange={(e) => {
-											setUpdate({ clearStaged: e.target.checked, staged: e.target.checked ? false : update.staged });
-										}}
-									/>
-								}
-								label={
-									<FormattedMessage
-										id="setWorkflowStateDialog.clearAsPublishedToStaging"
-										defaultMessage="Clear as published to staging"
-									/>
-								}
-							/>
+					{hasStaging && (
+						<Box display="flex" alignItems="center">
+							<Bracket width="12px" height="42px" sx={{ marginRight: '10px' }} />
+							<Box display="flex" flexDirection="column">
+								<FormControlLabel
+									control={
+										<Switch
+											checked={update.staged}
+											color="primary"
+											onChange={(e) => {
+												setUpdate({
+													staged: e.target.checked,
+													clearStaged: e.target.checked ? false : update.clearStaged
+												});
+											}}
+										/>
+									}
+									label={
+										<FormattedMessage
+											id="setWorkflowStateDialog.setAsPublishedToStaging"
+											defaultMessage="Set as published to staging"
+										/>
+									}
+								/>
+								<FormControlLabel
+									control={
+										<Switch
+											checked={update.clearStaged}
+											color="primary"
+											onChange={(e) => {
+												setUpdate({ clearStaged: e.target.checked, staged: e.target.checked ? false : update.staged });
+											}}
+										/>
+									}
+									label={
+										<FormattedMessage
+											id="setWorkflowStateDialog.clearAsPublishedToStaging"
+											defaultMessage="Clear as published to staging"
+										/>
+									}
+								/>
+							</Box>
 						</Box>
-					</Box>
+					)}
 				</FormGroup>
 			</DialogBody>
 			<DialogFooter>

--- a/ui/app/src/components/WorkflowStateManagement/WorkflowStateManagement.tsx
+++ b/ui/app/src/components/WorkflowStateManagement/WorkflowStateManagement.tsx
@@ -539,6 +539,7 @@ export function WorkflowStateManagement(props: WorkflowStateManagementProps) {
 					/>
 				}
 				open={openSetStateDialog}
+				hasStaging={hasStaging}
 				onClose={onSetItemStateDialogClose}
 				onConfirm={onSetItemStateDialogConfirm}
 			/>

--- a/ui/app/src/components/WorkflowStateManagement/WorkflowStateManagement.tsx
+++ b/ui/app/src/components/WorkflowStateManagement/WorkflowStateManagement.tsx
@@ -56,6 +56,7 @@ import { fetchPublishingTargets } from '../../services/publishing';
 import { ApiResponseErrorState } from '../ApiResponseErrorState';
 import { EmptyState } from '../EmptyState';
 import { pushErrorDialog } from '../../utils/system';
+import { extractErrorPayload } from '../../utils/ajax';
 
 const workflowStateManagementMessages = defineMessages({
 	statesUpdatedMessage: {
@@ -155,6 +156,9 @@ export function WorkflowStateManagement(props: WorkflowStateManagementProps) {
 		const sub = fetchPublishingTargets(siteId).subscribe({
 			next({ publishingTargets: targets }) {
 				setHasStaging(targets.some((target) => target.name === 'staging'));
+			},
+			error(error) {
+				dispatch(pushErrorDialog({ props: { error: extractErrorPayload(error) } }));
 			}
 		});
 		return () => {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staging-related controls in workflow state dialogs are now conditionally visible based on configuration, simplifying the UI when staging isn't available.
  * Dialogs accept a flag to control staging visibility, enabling downstream components to toggle staging behavior.

* **Bug Fixes / Improvements**
  * Improved error handling when fetching publishing targets to surface clearer error dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->