### PR TITLE
[8320] RTE fails silently on initialization in XB when <!DOCTYPE html> is missing

### DIFF
--- a/ui/app/src/assets/guestMessages.ts
+++ b/ui/app/src/assets/guestMessages.ts
@@ -168,5 +168,10 @@ export const guestMessages = defineMessages({
 		id: 'validations.outdatedExpBuilderVersion',
 		defaultMessage:
 			"Your application's Experience Builder package version is out of date. Please notify the development team to perform the necessary updates to avoid any possible issues."
+	},
+	noDocTypeError: {
+		id: 'validations.noDocTypeError',
+		defaultMessage:
+			'Unable to initialize Rich Text Editor (No document type was found for the current content). Please contact your administrator for assistance.'
 	}
 });

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -128,7 +128,6 @@ export function initTinyMCE(
 	record.element.classList.remove(emptyFieldClass);
 
 	const maxLength = validations?.maxLength ? parseInt(validations.maxLength.value) : null;
-
 	window.tinymce.init({
 		license_key: 'gpl',
 		target: rteEl,

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -21,9 +21,9 @@ import * as contentController from '../contentController';
 import { ContentTypeFieldValidations } from '@craftercms/studio-ui/models/ContentType';
 import { message$, post } from '../utils/communicator';
 import { GuestStandardAction } from '../store/models/GuestStandardAction';
-import { Observable, Subject } from 'rxjs';
+import { NEVER, Observable, Subject } from 'rxjs';
 import { filter, startWith, take } from 'rxjs/operators';
-import { reversePluckProps } from '@craftercms/studio-ui/utils/object';
+import { nou, reversePluckProps } from '@craftercms/studio-ui/utils/object';
 import { showEditDialog, snackGuestMessage } from '@craftercms/studio-ui/state/actions/preview';
 import { RteSetup } from '../models/Rte';
 import { editComponentInline, exitComponentInlineEdit } from '../store/actions';
@@ -114,6 +114,19 @@ export function initTinyMCE(
 	record.element.classList.remove(emptyFieldClass);
 
 	const maxLength = validations?.maxLength ? parseInt(validations.maxLength.value) : null;
+
+	if (nou(document.doctype)) {
+		console.error('Unable to initialize Rich Text Editor. Please contact your administrator for assistance.');
+		post(
+			snackGuestMessage({
+				id: 'noDocTypeError',
+				level: 'required'
+			})
+		);
+		post(unlockItem({ path }));
+		return NEVER;
+	}
+
 	window.tinymce.init({
 		license_key: 'gpl',
 		target: rteEl,

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -38,6 +38,20 @@ export function initTinyMCE(
 	validations: Partial<ContentTypeFieldValidations>,
 	rteSetup?: RteSetup
 ): Observable<GuestStandardAction> {
+	// Tinymce needs the document to be in standards mode to work, if it's not the case, we can't initialize it and we
+	// show an error message instead.
+	if (nou(document.doctype)) {
+		console.error('Unable to initialize Rich Text Editor. Please contact your administrator for assistance.');
+		post(
+			snackGuestMessage({
+				id: 'noDocTypeError',
+				level: 'required'
+			})
+		);
+		post(unlockItem({ path }));
+		return NEVER;
+	}
+
 	const dispatch$ = new Subject<GuestStandardAction>();
 	const { field, model } = iceRegistry.getReferentialEntries(record.iceIds[0]);
 	const type = field?.type;
@@ -114,18 +128,6 @@ export function initTinyMCE(
 	record.element.classList.remove(emptyFieldClass);
 
 	const maxLength = validations?.maxLength ? parseInt(validations.maxLength.value) : null;
-
-	if (nou(document.doctype)) {
-		console.error('Unable to initialize Rich Text Editor. Please contact your administrator for assistance.');
-		post(
-			snackGuestMessage({
-				id: 'noDocTypeError',
-				level: 'required'
-			})
-		);
-		post(unlockItem({ path }));
-		return NEVER;
-	}
 
 	window.tinymce.init({
 		license_key: 'gpl',


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RTE now detects when a document type is missing, aborts initialization gracefully, unlocks the item, and displays a clear error notification guiding users to contact their administrator.
* **Localization**
  * Added a user-facing error message for the RTE initialization failure: "Unable to initialize Rich Text Editor (No document type was found for the current content). Please contact your administrator for assistance."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->