### PR TITLE
[7123] Search and Browse dialogs should either hide existing selected items or show them as already selected

### DIFF
--- a/ui/app/src/components/FormsEngine/controls/ImagePicker.tsx
+++ b/ui/app/src/components/FormsEngine/controls/ImagePicker.tsx
@@ -204,6 +204,7 @@ export function ImagePicker(props: ImagePickerProps) {
 					dispatch,
 					path: processPath(choice.path),
 					multiSelect: false,
+					preselectedPaths: [value],
 					onSuccess(imageData: MediaItem) {
 						// Check if the image meets restrictions
 						validateImageRestrictions(imageData.path, restrictions).then((meetsRestrictions) => {
@@ -230,6 +231,7 @@ export function ImagePicker(props: ImagePickerProps) {
 				showSearchDialog({
 					dispatch,
 					path: ensureSingleSlash(`${processPath(choice.path)}/.+`),
+					preselectedPaths: [value],
 					onAcceptSelection(images) {
 						validateImageRestrictions(images[0], restrictions).then((meetsRestrictions) => {
 							if (!meetsRestrictions) {

--- a/ui/app/src/components/FormsEngine/controls/ImagePicker.tsx
+++ b/ui/app/src/components/FormsEngine/controls/ImagePicker.tsx
@@ -204,7 +204,7 @@ export function ImagePicker(props: ImagePickerProps) {
 					dispatch,
 					path: processPath(choice.path),
 					multiSelect: false,
-					preselectedPaths: [value],
+					preselectedPaths: value ? [value] : [],
 					onSuccess(imageData: MediaItem) {
 						// Check if the image meets restrictions
 						validateImageRestrictions(imageData.path, restrictions).then((meetsRestrictions) => {
@@ -231,7 +231,7 @@ export function ImagePicker(props: ImagePickerProps) {
 				showSearchDialog({
 					dispatch,
 					path: ensureSingleSlash(`${processPath(choice.path)}/.+`),
-					preselectedPaths: [value],
+					preselectedPaths: value ? [value] : [],
 					onAcceptSelection(images) {
 						validateImageRestrictions(images[0], restrictions).then((meetsRestrictions) => {
 							if (!meetsRestrictions) {

--- a/ui/app/src/components/FormsEngine/controls/NodeSelector.tsx
+++ b/ui/app/src/components/FormsEngine/controls/NodeSelector.tsx
@@ -482,6 +482,7 @@ function NodeSelector(props: NodeSelectorProps) {
 					dispatch,
 					path: processPath(pickerChoice.path),
 					contentTypes: pickerChoice.allowedContentTypes,
+					preselectedPaths: value.map((item) => item.key).filter(Boolean),
 					onSuccess(items: MediaItem | MediaItem[]) {
 						const nextValue = value.concat();
 						asArray(items).forEach((item) => {
@@ -504,6 +505,7 @@ function NodeSelector(props: NodeSelectorProps) {
 					dispatch,
 					path: ensureSingleSlash(`${processPath(pickerChoice.path)}/.+`),
 					contentTypes: pickerChoice.allowedContentTypes,
+					preselectedPaths: value.map((item) => item.key).filter(Boolean),
 					onAcceptSelection(paths, items) {
 						const nextValue = value.concat();
 						items?.forEach((item) => {

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -266,13 +266,15 @@ export const showBrowseFilesDialog = ({
 	onSuccess,
 	path,
 	contentTypes,
-	multiSelect = true
+	multiSelect = true,
+	preselectedPaths = []
 }: {
 	path: string;
 	dispatch: ReduxDispatch;
 	onSuccess: BrowseFilesDialogProps['onSuccess'];
 	contentTypes?: string[];
 	multiSelect?: boolean;
+	preselectedPaths?: string[];
 }): void => {
 	const id = nanoid();
 	dispatch(
@@ -284,6 +286,7 @@ export const showBrowseFilesDialog = ({
 				multiSelect,
 				allowUpload: false,
 				contentTypes: contentTypes ?? [],
+				preselectedPaths,
 				onClose: () => dispatch(popDialog({ id })),
 				onSuccess(items) {
 					dispatch(popDialog({ id }));
@@ -297,11 +300,13 @@ export const showBrowseFilesDialog = ({
 export const showSearchDialog = ({
 	dispatch,
 	path,
+	preselectedPaths = [],
 	contentTypes,
 	onAcceptSelection
 }: {
 	path: string;
 	contentTypes?: string[];
+	preselectedPaths?: string[];
 	dispatch: ReduxDispatch;
 	onAcceptSelection: SearchProps['onAcceptSelection'];
 }): void => {
@@ -318,6 +323,7 @@ export const showSearchDialog = ({
 					sortBy: 'internalName',
 					...(contentTypes && { filters: { 'content-type': contentTypes } })
 				},
+				preselectedPaths,
 				onClose: () => dispatch(popDialog({ id })),
 				onAcceptSelection(paths, items) {
 					dispatch(popDialog({ id }));


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image picker now preserves and preselects the current image when opening Browse or Search dialogs.
  * Node selector now preselects existing items when opening Browse or Search dialogs, streamlining multi-item selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->