### PR TITLE
[8416] Add Expired Date to the Content Type Editor Add Field's System types

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -1249,7 +1249,7 @@ function parseConfigPlugins(
 function getNewFieldFromDescriptor(fieldType: string, descriptor: DescriptorContentType): NewContentTypeField {
 	const newField: NewContentTypeField = {
 		NEW: true,
-		id: systemFieldsIdsMap[fieldType] ?? '',
+		id: systemFieldsIdsMap[fieldType] ?? null,
 		name: '',
 		helpText: '',
 		description: '',

--- a/ui/app/src/components/ContentTypeManagement/components/PickControlDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickControlDialog.tsx
@@ -43,7 +43,8 @@ export const systemFieldsIds: BuiltInControlType[] = [
 	'internal-name',
 	'disabled',
 	'page-nav-order',
-	'locale-selector'
+	'locale-selector',
+	'expired-date'
 ];
 
 export function PickControlDialog(props: PickControlDialogProps) {

--- a/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
@@ -27,6 +27,7 @@ import { suffixesMap, SuffixesType } from '../suffixesMap';
 import { useStableFormContext } from '../../FormsEngine/lib/formsEngineContext';
 import { useAtomValue } from 'jotai';
 import useUpdateRefs from '../../../hooks/useUpdateRefs';
+import { isFieldReadOnly } from '../../FormsEngine/lib/formUtils';
 
 export interface VariableProps extends ControlProps {
 	value: string;
@@ -43,7 +44,7 @@ export function Variable(props: VariableProps) {
 	const controlDescriptor = contentType?.id && controlDescriptors[contentType?.id];
 	const supportedSuffixes: SuffixesType[] = controlDescriptor?.metadata?.suffixes;
 	const { formatMessage } = useIntl();
-	const disabled = readonly || disabledFields.includes(value);
+	const disabled = isFieldReadOnly(field, readonly) || disabledFields.includes(value);
 	const showSuffixes = supportedSuffixes && !disableSuffixes.includes(value);
 	const effectRefs = useUpdateRefs({
 		value,

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/expiredDate.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/expiredDate.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createValidation, createVirtualSection, DescriptorContentType } from '../../utils';
+import { immutableEmptyObject } from '../../../../utils/object';
+import { defineMessage } from 'react-intl';
+
+export const expiredDateDescriptor: DescriptorContentType = {
+	id: 'expired-date',
+	name: defineMessage({ defaultMessage: 'Expired Date' }),
+	description: defineMessage({ defaultMessage: 'Expired date picker' }),
+	sections: [
+		createVirtualSection({
+			id: 'properties',
+			title: defineMessage({ defaultMessage: 'Options' }),
+			fields: [
+				'showDate',
+				'showTime',
+				'showClear',
+				'showNowLink',
+				'populate',
+				'allowPastDate',
+				'populateDateExp',
+				'useCustomTimezone',
+				'readonly',
+				'readonlyEdit'
+			]
+		}),
+		createVirtualSection({
+			id: 'constraints',
+			title: defineMessage({ defaultMessage: 'Constraints' }),
+			fields: ['required']
+		})
+	],
+	fields: {
+		id: {
+			id: 'id',
+			type: 'variable',
+			name: defineMessage({ defaultMessage: 'Variable Name' }),
+			defaultValue: 'expired_dt',
+			validations: {
+				required: { id: 'required', level: 'required', value: true }
+			}
+		},
+		showDate: {
+			id: 'showDate',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Show Date' }),
+			defaultValue: true,
+			validations: immutableEmptyObject
+		},
+		showTime: {
+			id: 'showTime',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Show Time' }),
+			defaultValue: false,
+			validations: immutableEmptyObject
+		},
+		showClear: {
+			id: 'showClear',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Show Clear' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject
+		},
+		showNowLink: {
+			id: 'showNowLink',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Show Now Link' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject
+		},
+		populate: {
+			id: 'populate',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Populated' }),
+			defaultValue: true,
+			validations: immutableEmptyObject
+		},
+		allowPastDate: {
+			id: 'allowPastDate',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Allow Past Date' }),
+			defaultValue: false,
+			validations: immutableEmptyObject
+		},
+		populateDateExp: {
+			id: 'populateDateExp',
+			type: 'date-time-expression-input',
+			name: defineMessage({ defaultMessage: 'Populate Expression' }),
+			defaultValue: 'now',
+			validations: {
+				type: createValidation('type', 'dateTime')
+			}
+		},
+		useCustomTimezone: {
+			id: 'useCustomTimezone',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Use Custom Timezone' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject
+		},
+		readonly: {
+			id: 'readonly',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Read Only' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject
+		},
+		readonlyEdit: {
+			id: 'readonlyEdit',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Read Only on Edit' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject
+		},
+		required: {
+			id: 'required',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Required' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject
+		}
+	},
+	metadata: {
+		suffixes: ['_dt']
+	}
+};
+
+export default expiredDateDescriptor;

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/expiredDate.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/expiredDate.ts
@@ -53,6 +53,9 @@ export const expiredDateDescriptor: DescriptorContentType = {
 			defaultValue: 'expired_dt',
 			validations: {
 				required: { id: 'required', level: 'required', value: true }
+			},
+			properties: {
+				readonly: { name: 'readonly', type: 'boolean', value: true }
 			}
 		},
 		showDate: {

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/index.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/index.ts
@@ -49,6 +49,7 @@ import { ContentTypeField } from '../../../../models/ContentType';
 import LookupTable from '../../../../models/LookupTable';
 import colorPickerDescriptor from './colorPicker';
 import { defineMessage } from 'react-intl';
+import expiredDateDescriptor from './expiredDate';
 
 const dataSourceRootProperties = ['id', 'type', 'title', 'interface'];
 
@@ -173,7 +174,8 @@ export const controlDescriptors: Record<BuiltInControlType, DescriptorContentTyp
 	'transcoded-video-picker': transcodedVideoPickerDescriptor,
 	uuid: uuidDescriptor,
 	'video-picker': videoPickerDescriptor,
-	colorPicker: colorPickerDescriptor
+	colorPicker: colorPickerDescriptor,
+	'expired-date': expiredDateDescriptor
 };
 
 export const typeBasicDetailsDescriptor: DescriptorContentType = {

--- a/ui/app/src/components/FormsEngine/lib/controlMap.ts
+++ b/ui/app/src/components/FormsEngine/lib/controlMap.ts
@@ -47,7 +47,8 @@ export type BuiltInControlType =
 	| 'transcoded-video-picker'
 	| 'uuid' // TODO: Not in BPs, seems not to be in use
 	| 'video-picker'
-	| 'colorPicker';
+	| 'colorPicker'
+	| 'expired-date';
 
 export const controlMap: Record<BuiltInControlType, ElementType> = {
 	'auto-filename': lazy(() => import('../controls/AutoFileName')),
@@ -77,5 +78,6 @@ export const controlMap: Record<BuiltInControlType, ElementType> = {
 	'transcoded-video-picker': null,
 	uuid: null,
 	'video-picker': null,
-	colorPicker: lazy(() => import('../controls/ColorPicker'))
+	colorPicker: lazy(() => import('../controls/ColorPicker')),
+	'expired-date': lazy(() => import('../controls/DateTime'))
 };

--- a/ui/app/src/components/FormsEngine/lib/valueRetrievers.ts
+++ b/ui/app/src/components/FormsEngine/lib/valueRetrievers.ts
@@ -33,6 +33,7 @@ export const valueRetrieverLookup: Record<BuiltInControlType | DescriptorControl
 	checkbox: booleanFieldExtractor,
 	boolean: booleanFieldExtractor,
 	'date-time': null,
+	'expired-date': null,
 	disabled: booleanFieldExtractor,
 	dropdown: textFieldExtractor,
 	'file-name': textFieldExtractor,

--- a/ui/app/src/components/FormsEngine/lib/valueSerializers.ts
+++ b/ui/app/src/components/FormsEngine/lib/valueSerializers.ts
@@ -42,6 +42,7 @@ export const valueSerializersLookup: Record<BuiltInControlType | DescriptorContr
 	checkbox: undefined,
 	boolean: undefined,
 	'date-time': undefined,
+	'expired-date': undefined,
 	disabled: undefined,
 	dropdown: undefined,
 	'file-name': undefined,

--- a/ui/app/src/services/dashboard.ts
+++ b/ui/app/src/services/dashboard.ts
@@ -197,7 +197,7 @@ export function fetchExpiring(siteId: string, options: FetchExpiringOptions): Ob
 		map((response) =>
 			response?.response?.items.map((item) => ({
 				...item,
-				sandboxItem: prepareVirtualItemProps(item.sandboxItem)
+				contentItem: prepareVirtualItemProps(item.sandboxItem)
 			}))
 		)
 	);


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new "expired-date" field control in content type management with configurable properties (date display, time display, timezone, read-only status) and constraints.

* **Improvements**
  * Enhanced read-only status handling for form fields to properly respect field-level restrictions.
  * Improved dashboard data structure for expiring items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->