### PR TITLE
[8329] Do not show insert icon in RTE Insert Media and Insert Video when no datasource is configured

### DIFF
--- a/ui/app/src/assets/guestMessages.ts
+++ b/ui/app/src/assets/guestMessages.ts
@@ -150,7 +150,8 @@ export const guestMessages = defineMessages({
 	},
 	noDataSourcesSet: {
 		id: 'validations.noDataSourcesSet',
-		defaultMessage: 'There are no data sources set for this field'
+		defaultMessage:
+			'No data sources are configured for this editor. Please contact your administrator to complete this configuration.'
 	},
 	noPathSetInDataSource: {
 		id: 'validations.noPathSetInDataSource',

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/rte.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/rte.ts
@@ -34,7 +34,8 @@ export const rteDescriptor: DescriptorContentType = {
 				'imageManager',
 				'videoManager',
 				'audioManager',
-				'fileManager'
+				'fileManager',
+				'addMedia'
 			]
 		}),
 		createVirtualSection({
@@ -113,6 +114,13 @@ export const rteDescriptor: DescriptorContentType = {
 			type: 'boolean',
 			name: defineMessage({ defaultMessage: 'Required' }),
 			defaultValue: undefined,
+			validations: immutableEmptyObject
+		},
+		addMedia: {
+			id: 'addMedia',
+			type: 'boolean',
+			name: defineMessage({ defaultMessage: 'Add Media' }),
+			defaultValue: true,
 			validations: immutableEmptyObject
 		}
 	},

--- a/ui/app/src/models/ContentType.ts
+++ b/ui/app/src/models/ContentType.ts
@@ -51,7 +51,8 @@ export type ValidationKeys =
 	| 'allowAudioUpload'
 	| 'allowAudioFromRepo'
 	| 'pattern'
-	| 'allowDuplicates';
+	| 'allowDuplicates'
+	| 'addMedia';
 
 export type ContentTypeFieldValidations = Record<ValidationKeys, ContentTypeFieldValidation>;
 

--- a/ui/app/src/services/contentTypes.ts
+++ b/ui/app/src/services/contentTypes.ts
@@ -27,7 +27,8 @@ import {
 	LegacyFormDefinition,
 	LegacyFormDefinitionField,
 	LegacyFormDefinitionProperty,
-	LegacyFormDefinitionSection
+	LegacyFormDefinitionSection,
+	ValidationKeys
 } from '../models/ContentType';
 import { LookupTable } from '../models/LookupTable';
 import { camelize, capitalize, isBlank, toColor } from '../utils/string';
@@ -231,6 +232,13 @@ function getFieldDataSourceValidations(
 							};
 						}
 					});
+				}
+				if (prop.name === 'addMedia') {
+					table[systemValidationsKeysMap['addMedia']] = {
+						id: systemValidationsKeysMap['addMedia'] as ValidationKeys,
+						value: prop.value.trim() === 'true',
+						level: 'required'
+					};
 				}
 				return table;
 			},

--- a/ui/app/src/utils/contentType.ts
+++ b/ui/app/src/utils/contentType.ts
@@ -305,7 +305,8 @@ export const systemValidationsKeysMap = {
 	videoBrowseRepo: 'allowVideosFromRepo',
 	audioDesktopUpload: 'allowAudioUpload',
 	audioBrowseRepo: 'allowAudioFromRepo',
-	fileBrowseRepo: 'allowFilesFromRepo'
+	fileBrowseRepo: 'allowFilesFromRepo',
+	addMedia: 'addMedia'
 };
 
 export const componentsDataSourceContentTypesPropertyNames = [

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -114,6 +114,7 @@ export function initTinyMCE(
 	record.element.classList.remove(emptyFieldClass);
 
 	const maxLength = validations?.maxLength ? parseInt(validations.maxLength.value) : null;
+	const allowAddMedia = validations?.addMedia ? validations.addMedia.value : false;
 	window.tinymce.init({
 		license_key: 'gpl',
 		target: rteEl,
@@ -160,50 +161,52 @@ export function initTinyMCE(
 		media_live_embeds: true,
 		file_picker_types: 'image media',
 		craftercms_paste_cleanup: rteSetup?.tinymceOptions?.craftercms_paste_cleanup ?? true, // If doesn't exist or if true => true
-		file_picker_callback: function (cb, value, meta) {
-			// meta contains info about type (image, media, etc). Used to properly add DS to dialogs.
-			// meta.filetype === 'file | image | media'
-			const datasources = {};
-			Object.values(field.validations).forEach((validation) => {
-				if (
-					[
-						'allowImageUpload',
-						'allowImagesFromRepo',
-						'allowVideoUpload',
-						'allowVideosFromRepo',
-						'allowAudioUpload',
-						'allowAudioFromRepo',
-						'allowFilesFromRepo'
-					].includes(validation.id)
-				) {
-					datasources[validation.id] = validation;
+		file_picker_callback: allowAddMedia
+			? function (cb, value, meta) {
+					// meta contains info about type (image, media, etc). Used to properly add DS to dialogs.
+					// meta.filetype === 'file | image | media'
+					const datasources = {};
+					Object.values(field.validations).forEach((validation) => {
+						if (
+							[
+								'allowImageUpload',
+								'allowImagesFromRepo',
+								'allowVideoUpload',
+								'allowVideosFromRepo',
+								'allowAudioUpload',
+								'allowAudioFromRepo',
+								'allowFilesFromRepo'
+							].includes(validation.id)
+						) {
+							datasources[validation.id] = validation;
+						}
+					});
+					const browseBtn = document.querySelector('.tox-dialog .tox-browse-url');
+
+					post(
+						showRtePickerActions({
+							datasources,
+							model,
+							type: meta.filetype,
+							rect: browseBtn.getBoundingClientRect()
+						})
+					);
+
+					message$
+						.pipe(
+							filter((e) => e.type === rtePickerActionResult.type),
+							take(1)
+						)
+						.subscribe(({ payload }) => {
+							if (payload) {
+								// For selections of pages or components from the 'Insert link' dialog, use the preview URL (the actual page or component link)
+								// instead of the repoURL returned by the browse dialog.
+								const path = meta.filetype === 'file' ? getPreviewURLFromPath(payload.path) : payload.path;
+								cb(path, { alt: payload.name });
+							}
+						});
 				}
-			});
-			const browseBtn = document.querySelector('.tox-dialog .tox-browse-url');
-
-			post(
-				showRtePickerActions({
-					datasources,
-					model,
-					type: meta.filetype,
-					rect: browseBtn.getBoundingClientRect()
-				})
-			);
-
-			message$
-				.pipe(
-					filter((e) => e.type === rtePickerActionResult.type),
-					take(1)
-				)
-				.subscribe(({ payload }) => {
-					if (payload) {
-						// For selections of pages or components from the 'Insert link' dialog, use the preview URL (the actual page or component link)
-						// instead of the repoURL returned by the browse dialog.
-						const path = meta.filetype === 'file' ? getPreviewURLFromPath(payload.path) : payload.path;
-						cb(path, { alt: payload.name });
-					}
-				});
-		},
+			: null,
 		setup(editor: Editor) {
 			let changed = false;
 			const pluginManager = window.tinymce.util.Tools.resolve('tinymce.PluginManager');

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -114,7 +114,8 @@ export function initTinyMCE(
 	record.element.classList.remove(emptyFieldClass);
 
 	const maxLength = validations?.maxLength ? parseInt(validations.maxLength.value) : null;
-	const allowAddMedia = validations?.addMedia ? validations.addMedia.value : false;
+	// If the validation is not set, we set allowAddMedia to true for backwards compatibility.
+	const allowAddMedia = validations?.addMedia ? validations.addMedia.value : true;
 	window.tinymce.init({
 		license_key: 'gpl',
 		target: rteEl,

--- a/ui/guest/src/controls/rte.ts
+++ b/ui/guest/src/controls/rte.ts
@@ -161,6 +161,7 @@ export function initTinyMCE(
 		media_live_embeds: true,
 		file_picker_types: 'image media',
 		craftercms_paste_cleanup: rteSetup?.tinymceOptions?.craftercms_paste_cleanup ?? true, // If doesn't exist or if true => true
+		// If the allowAddMedia validation is set to false, then the callback is not set, so the add media/file options won't be shown in the editor.
 		file_picker_callback: allowAddMedia
 			? function (cb, value, meta) {
 					// meta contains info about type (image, media, etc). Used to properly add DS to dialogs.


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8329

- Added a control prop to enable/disable adding media
- Updated no datasources message to `No data sources are configured for this editor. Please contact your administrator to complete this configuration.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Add Media" configuration option to the Rich Text Editor to enable or disable media upload controls.

* **Improvements**
  * Updated no-data-sources message to clearly instruct users to contact their administrator for setup.
  * When Add Media is disabled, the editor will hide/disable media upload UI for a cleaner experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->