### PR TITLE
[8271] Extend the video player in the Form Engine and the preview dialog to play .avi and .mov

### DIFF
--- a/ui/app/src/components/PathNavigator/utils.ts
+++ b/ui/app/src/components/PathNavigator/utils.ts
@@ -43,8 +43,15 @@ export function isTextContent(mimeType: string): boolean {
 	);
 }
 
+const blackListMediaTypes = [
+	'video/x-msvideo' // .avi files are not supported by browsers and the video player can't play them.
+];
+
 export function isMediaContent(mimeType: string) {
-	return /^image\//.test(mimeType) || /^video\//.test(mimeType) || /^audio\//.test(mimeType);
+	return (
+		(/^image\//.test(mimeType) || /^video\//.test(mimeType) || /^audio\//.test(mimeType)) &&
+		!blackListMediaTypes.includes(mimeType)
+	);
 }
 
 export function isPreviewable(item: Pick<ContentItem, 'mimeType' | 'systemType'>): boolean {

--- a/ui/app/src/components/PreviewSearchPanel/PreviewSearchPanel.tsx
+++ b/ui/app/src/components/PreviewSearchPanel/PreviewSearchPanel.tsx
@@ -106,7 +106,16 @@ const initialSearchParameters: Partial<ElasticParams> = {
 	orOperator: true
 };
 
-const mimeTypes = ['image/png', 'image/jpeg', 'image/gif', 'video/mp4', 'image/svg+xml', 'image/webp'];
+const mimeTypes = [
+	'image/png',
+	'image/jpeg',
+	'image/gif',
+	'video/mp4',
+	'image/svg+xml',
+	'image/webp',
+	'video/quicktime',
+	'video/x-msvideo'
+];
 
 export function PreviewSearchPanel() {
 	const { formatMessage } = useIntl();

--- a/ui/app/src/state/reducers/preview.ts
+++ b/ui/app/src/state/reducers/preview.ts
@@ -126,7 +126,15 @@ const assetsPanelInitialState = createEntityState({
 		offset: 0,
 		limit: 10,
 		filters: {
-			'mime-type': ['image/png', 'image/jpeg', 'image/gif', 'video/mp4', 'image/svg+xml', 'image/webp']
+			'mime-type': [
+				'image/png',
+				'image/jpeg',
+				'image/gif',
+				'video/mp4',
+				'image/svg+xml',
+				'image/webp',
+				'video/quicktime'
+			]
 		}
 	}
 }) as PagedEntityState<MediaItem>;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional video formats (QuickTime and x-msvideo) in media preview and search filtering.
  * Implemented media type blacklist for improved content filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->