### PR TITLE
[8569] Update staging publishing target indicator in UI

### DIFF
--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -101,7 +101,7 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 			}}
 		>
 			{/* @see https://github.com/craftercms/craftercms/issues/5442 */}
-			{inWorkflow && !shouldItemShowAsStaged(item as ContentItem)
+			{inWorkflow && !shouldItemShowAsStaged(item)
 				? showWorkflowState && (
 						<ItemStateIcon
 							{...stateIconProps}
@@ -169,10 +169,11 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
  * Staging has priority over modified and null. Additionally, if an item is submitted to live, submitted to staging, or
  * scheduled, it should not be shown as staged.
  */
-function shouldItemShowAsStaged(item: ContentItem): boolean {
+function shouldItemShowAsStaged(item: ContentItem | LightItem): boolean {
+	if (!('stateMap' in item) || !item.stateMap) return false;
 	return (
 		item.stateMap?.staged &&
-		(item.stateMap?.new || (item as ContentItem).stateMap?.modified) &&
+		(item.stateMap?.new || item.stateMap?.modified) &&
 		!item.stateMap?.submittedToLive &&
 		!item.stateMap?.submittedToStaging &&
 		!item.stateMap?.scheduled

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -32,8 +32,9 @@ import { DisabledItemIcon } from '../DisabledItemIcon';
 
 export type ItemDisplayClassKey = 'root' | 'label' | 'labelPreviewable' | 'icon' | 'typeIcon';
 
-export interface ItemDisplayProps<LabelTypographyComponent extends React.ElementType = 'span'>
-	extends React.HTMLAttributes<HTMLSpanElement> {
+export interface ItemDisplayProps<
+	LabelTypographyComponent extends React.ElementType = 'span'
+> extends React.HTMLAttributes<HTMLSpanElement> {
 	showPublishingTarget?: boolean;
 	showWorkflowState?: boolean;
 	showItemType?: boolean;
@@ -85,6 +86,9 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 	// inWorkflow will only be true for type ContentItem (if they met the workflow criteria). Casting to ContentItem
 	// is only done on scenarios where `isWorkflow` is true.
 	const inWorkflow = isInWorkflow((item as ContentItem).stateMap) || item.systemType === 'folder';
+	const isStagedNewOrModified =
+		(item as ContentItem).stateMap?.staged &&
+		((item as ContentItem).stateMap?.new || (item as ContentItem).stateMap?.modified);
 	return (
 		<Box
 			component={component}
@@ -100,7 +104,8 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 			}}
 		>
 			{/* @see https://github.com/craftercms/craftercms/issues/5442 */}
-			{inWorkflow
+			{/* When new or modified */}
+			{inWorkflow && !isStagedNewOrModified
 				? showWorkflowState && (
 						<ItemStateIcon
 							{...stateIconProps}

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -104,7 +104,7 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 			}}
 		>
 			{/* @see https://github.com/craftercms/craftercms/issues/5442 */}
-			{/* When new or modified */}
+			{/* When new or modified, staging has priority. So if item is staged and new/modified show PublishingTargetIcon */}
 			{inWorkflow && !isStagedNewOrModified
 				? showWorkflowState && (
 						<ItemStateIcon

--- a/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
+++ b/ui/app/src/components/ItemDisplay/ItemDisplay.tsx
@@ -86,9 +86,6 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 	// inWorkflow will only be true for type ContentItem (if they met the workflow criteria). Casting to ContentItem
 	// is only done on scenarios where `isWorkflow` is true.
 	const inWorkflow = isInWorkflow((item as ContentItem).stateMap) || item.systemType === 'folder';
-	const isStagedNewOrModified =
-		(item as ContentItem).stateMap?.staged &&
-		((item as ContentItem).stateMap?.new || (item as ContentItem).stateMap?.modified);
 	return (
 		<Box
 			component={component}
@@ -104,8 +101,7 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 			}}
 		>
 			{/* @see https://github.com/craftercms/craftercms/issues/5442 */}
-			{/* When new or modified, staging has priority. So if item is staged and new/modified show PublishingTargetIcon */}
-			{inWorkflow && !isStagedNewOrModified
+			{inWorkflow && !shouldItemShowAsStaged(item as ContentItem)
 				? showWorkflowState && (
 						<ItemStateIcon
 							{...stateIconProps}
@@ -163,5 +159,24 @@ const ItemDisplay = forwardRef<HTMLSpanElement, ItemDisplayProps>((props, ref) =
 		</Box>
 	);
 });
+
+/**
+ * Determines if the item's icon should be displayed as staged.
+ *
+ * @param item - The content item to check.
+ * @returns True if the item should be displayed as staged, false otherwise.
+ *
+ * Staging has priority over modified and null. Additionally, if an item is submitted to live, submitted to staging, or
+ * scheduled, it should not be shown as staged.
+ */
+function shouldItemShowAsStaged(item: ContentItem): boolean {
+	return (
+		item.stateMap?.staged &&
+		(item.stateMap?.new || (item as ContentItem).stateMap?.modified) &&
+		!item.stateMap?.submittedToLive &&
+		!item.stateMap?.submittedToStaging &&
+		!item.stateMap?.scheduled
+	);
+}
 
 export default ItemDisplay;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Item display logic updated so items in "staged" state correctly show the staged icon instead of the workflow icon, and staged items that are live-submitted or scheduled no longer incorrectly display staging.
* **Documentation**
  * Added internal helper documentation clarifying staged-display priority and exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->