### PR TITLE
[8583] Retrieve OOB controls/datasources from config file

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -145,9 +145,9 @@ interface EditAppContextProps {
 }
 
 export interface ContentTypeManagementConfig {
-	controls: LookupTable<{ descriptor: DescriptorContentType; icon: { id: string }; id: string }>;
+	controls: LookupTable<{ descriptor?: DescriptorContentType; icon: { id: string }; id: string }>;
 	controlExclusions: string[];
-	dataSources: LookupTable<{ descriptor: DescriptorContentType; icon: { id: string }; id: string }>;
+	dataSources: LookupTable<{ descriptor?: DescriptorContentType; icon: { id: string }; id: string }>;
 	dataSourceExclusions: string[];
 }
 
@@ -768,7 +768,7 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 					setConfig({
 						controls: parseConfigPlugins(contentTypesConfig.controls),
 						controlExclusions: asArray(contentTypesConfig.controlExclusions),
-						dataSources: parseConfigPlugins(contentTypesConfig.dataSources),
+						dataSources: parseConfigPlugins(contentTypesConfig.datasources),
 						dataSourceExclusions: asArray(contentTypesConfig.dataSourceExclusions)
 					});
 				}
@@ -841,6 +841,7 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 				fieldIdPath={insertFieldData.fieldPath}
 				onClose={() => setInsertFieldData({ sectionId: null })}
 				onInsertField={handleInsertField}
+				configControls={config?.controls}
 				configDescriptors={configControlDescriptors}
 				controlExclusions={config.controlExclusions}
 			/>
@@ -849,6 +850,7 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 				onInsert={handleInsertDataSource}
 				open={openDataSourceInserter}
 				onClose={() => setOpenDataSourceInserter(false)}
+				configDataSources={config?.dataSources}
 				configDescriptors={configDataSourceDescriptors}
 				dataSourceExclusions={config.dataSourceExclusions}
 			/>
@@ -1231,26 +1233,30 @@ async function validityAtomsHaveErrors(
 }
 
 function parseConfigPlugins(
-	plugins: { descriptor: DescriptorContentType; icon: { id: string }; id: string }[]
-): ContentTypeManagementConfig['controls'] {
+	plugins: { descriptor?: DescriptorContentType; icon: { id: string }; id: string }[]
+): LookupTable<{ descriptor?: DescriptorContentType; icon: { id: string }; id: string }> {
 	if (!plugins) return;
-	const parsedControls = asArray(plugins).map((plugin) => {
-		const fields = Object.values(plugin.descriptor.fields ?? {})?.map((field) => {
+	const parsedPlugins = asArray(plugins).map((plugin) => {
+		if (plugin.descriptor) {
+			const fields = Object.values(plugin.descriptor.fields ?? {})?.map((field) => {
+				return {
+					...field,
+					validations: field.validations ?? {}
+				};
+			});
 			return {
-				...field,
-				validations: field.validations ?? {}
+				...plugin,
+				descriptor: {
+					...plugin.descriptor,
+					fields: createLookupTable(fields),
+					sections: asArray(plugin.descriptor?.sections) ?? []
+				}
 			};
-		});
-		return {
-			...plugin,
-			descriptor: {
-				...plugin.descriptor,
-				fields: createLookupTable(fields),
-				sections: asArray(plugin.descriptor?.sections) ?? []
-			}
-		};
+		} else {
+			return plugin;
+		}
 	});
-	return createLookupTable(parsedControls);
+	return createLookupTable(parsedPlugins);
 }
 
 function getNewFieldFromDescriptor(fieldType: string, descriptor: DescriptorContentType): NewContentTypeField {

--- a/ui/app/src/components/ContentTypeManagement/components/PickControlDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickControlDialog.tsx
@@ -30,6 +30,7 @@ export interface PickControlDialogProps extends EnhancedDialogProps {
 	type: ContentType;
 	fieldIdPath?: string;
 	onInsertField: (fieldType: string, position: number) => void;
+	configControls?: ContentTypeManagementConfig['controls'];
 	configDescriptors?: DescriptorContentType[];
 	controlExclusions: ContentTypeManagementConfig['controlExclusions'];
 }
@@ -44,11 +45,22 @@ export const systemFieldsIds: BuiltInControlType[] = [
 	'disabled',
 	'page-nav-order',
 	'locale-selector',
-	'expired-date'
+	'expired-date',
+	'forcehttps',
+	'uuid'
 ];
 
 export function PickControlDialog(props: PickControlDialogProps) {
-	const { onInsertField, type, sectionId, fieldIdPath, configDescriptors, controlExclusions, ...dialogProps } = props;
+	const {
+		onInsertField,
+		type,
+		sectionId,
+		fieldIdPath,
+		configControls,
+		configDescriptors,
+		controlExclusions,
+		...dialogProps
+	} = props;
 	const { sectionFields } = useMemo(() => {
 		let sectionFields: ContentTypeField[];
 		if (nou(fieldIdPath)) {
@@ -70,9 +82,12 @@ export function PickControlDialog(props: PickControlDialogProps) {
 
 	// Before rendering the PickFieldDialog we need to do two things:
 	// 1. Filter out the controls that are in the controlExclusions list.
-	// 2. Add the configDescriptors (plugins) to the list of controls.
+	// 2. Filter out OOB controls not in the configuration list.
+	// 3. Add the configDescriptors (plugins) to the list of controls.
 	const typesFullList = [
-		...types.filter((type) => !(controlExclusions ?? []).includes(type.id)),
+		...types.filter((type) => {
+			return configControls?.[type.id] && !(controlExclusions ?? []).includes(type.id);
+		}),
 		...(configDescriptors ?? [])
 	];
 
@@ -82,6 +97,7 @@ export function PickControlDialog(props: PickControlDialogProps) {
 			onInsert={onInsertField}
 			type={type}
 			title={<FormattedMessage defaultMessage="Insert Control" />}
+			configLookup={configControls}
 			typesFullList={typesFullList}
 			typesCurrentList={sectionFields}
 			systemFieldsIds={systemFieldsIds}

--- a/ui/app/src/components/ContentTypeManagement/components/PickDataSourceDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickDataSourceDialog.tsx
@@ -44,7 +44,7 @@ export function PickDataSourceDialog(props: PickDataSourceDialogProps) {
 		...types.filter((type) => {
 			return configDataSources?.[type.id] && !(dataSourceExclusions ?? []).includes(type.id);
 		}),
-		...configDescriptors
+		...(configDescriptors ?? [])
 	];
 
 	return (

--- a/ui/app/src/components/ContentTypeManagement/components/PickDataSourceDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickDataSourceDialog.tsx
@@ -26,6 +26,7 @@ import { ContentTypeManagementConfig } from './EditTypeView';
 export interface PickDataSourceDialogProps extends EnhancedDialogProps {
 	type: ContentType;
 	onInsert: PickFieldDialogProps['onInsert'];
+	configDataSources?: ContentTypeManagementConfig['dataSources'];
 	configDescriptors?: DescriptorContentType[];
 	dataSourceExclusions: ContentTypeManagementConfig['controlExclusions'];
 }
@@ -33,13 +34,16 @@ export interface PickDataSourceDialogProps extends EnhancedDialogProps {
 const types = Object.values(dataSourceDescriptors).sort((a, b) => (a?.name > b?.name ? 1 : -1));
 
 export function PickDataSourceDialog(props: PickDataSourceDialogProps) {
-	const { configDescriptors, dataSourceExclusions, ...rest } = props;
+	const { configDataSources, configDescriptors, dataSourceExclusions, ...rest } = props;
 
 	// Before rendering the PickFieldDialog we need to do two things:
 	// 1. Filter out the dataSources that are in the dataSourceExclusions list.
-	// 2. Add the configDescriptors (plugins) to the list of datasources.
+	// 2. Filter out OOB datasources not in the configuration list.
+	// 3. Add the configDescriptors (plugins) to the list of datasources.
 	const typesFullList = [
-		...types.filter((type) => !(dataSourceExclusions ?? []).includes(type.id)),
+		...types.filter((type) => {
+			return configDataSources?.[type.id] && !(dataSourceExclusions ?? []).includes(type.id);
+		}),
 		...configDescriptors
 	];
 
@@ -47,6 +51,7 @@ export function PickDataSourceDialog(props: PickDataSourceDialogProps) {
 		<PickFieldDialog
 			{...rest}
 			title={<FormattedMessage defaultMessage="Insert Data Source" />}
+			configLookup={configDataSources}
 			typesFullList={typesFullList}
 			typesCurrentList={props.type.dataSources}
 		/>

--- a/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
@@ -39,9 +39,12 @@ import RadioGroup from '@mui/material/RadioGroup';
 import Radio from '@mui/material/Radio';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Divider from '@mui/material/Divider';
+import LookupTable from '../../../models/LookupTable';
+import { SystemIcon } from '../../SystemIcon';
 
 export interface PickFieldDialogProps extends EnhancedDialogProps {
 	type: ContentType;
+	configLookup?: LookupTable<{ descriptor?: DescriptorContentType; icon: { id: string }; id: string }>; // TODO: not a li
 	typesFullList: DescriptorContentType[];
 	typesCurrentList: DescriptorField[] | DataSource[];
 	title: ReactNode;
@@ -53,7 +56,8 @@ export interface PickFieldDialogProps extends EnhancedDialogProps {
 export interface PickFieldDialogBodyProps extends Omit<PickFieldDialogProps, 'title'> {}
 
 export function PickFieldDialogBody(props: PickFieldDialogBodyProps) {
-	const { type, typesFullList, typesCurrentList, onInsert, onClose, systemFieldsTitle, systemFieldsIds } = props;
+	const { configLookup, typesFullList, typesCurrentList, onInsert, onClose, systemFieldsTitle, systemFieldsIds } =
+		props;
 	const [selectedField, setSelectedField] = useState<PartialContentType>(undefined);
 	const [selectedView, setSelectedView] = useState<number>(0);
 	const [position, setPosition] = useState<number>(typesCurrentList?.length ?? 0);
@@ -89,6 +93,7 @@ export function PickFieldDialogBody(props: PickFieldDialogBodyProps) {
 			<DialogBody sx={{ transition: 'height 0.3s ease-in-out', minHeight: '40vh' }}>
 				{selectedView === 0 ? (
 					<SelectField
+						configLookup={configLookup}
 						typesFullList={typesFullList}
 						selectedField={selectedField}
 						setSelectedField={onSelectField}
@@ -205,11 +210,13 @@ export function PickFieldDialog({
 export function SelectField(props: {
 	typesFullList: DescriptorContentType[];
 	selectedField: PartialContentType;
+	configLookup?: PickFieldDialogProps['configLookup'];
 	setSelectedField: (field: PartialContentType) => void;
 	systemFieldsIds?: PickFieldDialogProps['systemFieldsIds'];
 	systemFieldsTitle?: PickFieldDialogProps['systemFieldsTitle'];
 }) {
 	const {
+		configLookup,
 		typesFullList,
 		selectedField,
 		setSelectedField,
@@ -256,7 +263,11 @@ export function SelectField(props: {
 								selected={selectedField?.id === field.id}
 							>
 								<ListItemIcon>
-									<StarBorderIcon />
+									{configLookup?.[field.id]?.icon?.id ? (
+										<SystemIcon icon={configLookup[field.id].icon} />
+									) : (
+										<StarBorderIcon />
+									)}
 								</ListItemIcon>
 								<ListItemText primary={field.name} secondary={field.description} />
 							</ListItemButton>
@@ -269,7 +280,11 @@ export function SelectField(props: {
 				{filteredFields.map((field, index) => (
 					<ListItemButton key={index} onClick={() => setSelectedField(field)} selected={selectedField?.id === field.id}>
 						<ListItemIcon>
-							<StarBorderIcon />
+							{configLookup?.[field.id]?.icon?.id ? (
+								<SystemIcon icon={configLookup[field.id].icon} />
+							) : (
+								<StarBorderIcon />
+							)}
 						</ListItemIcon>
 						<ListItemText primary={field.name} secondary={field.description} />
 					</ListItemButton>

--- a/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
@@ -41,6 +41,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Divider from '@mui/material/Divider';
 import LookupTable from '../../../models/LookupTable';
 import { SystemIcon } from '../../SystemIcon';
+import ComponentIcon from '../../../icons/Component';
 
 export interface PickFieldDialogProps extends EnhancedDialogProps {
 	type: ContentType;
@@ -112,7 +113,11 @@ export function PickFieldDialogBody(props: PickFieldDialogBodyProps) {
 							</Box>
 							<ListItem>
 								<ListItemIcon>
-									<StarBorderIcon />
+									{selectedField && configLookup?.[selectedField.id]?.icon?.id ? (
+										<SystemIcon icon={configLookup[selectedField.id].icon} />
+									) : (
+										<ComponentIcon />
+									)}
 								</ListItemIcon>
 								<ListItemText primary={selectedField.name} secondary={selectedField.description} />
 							</ListItem>
@@ -266,7 +271,7 @@ export function SelectField(props: {
 									{configLookup?.[field.id]?.icon?.id ? (
 										<SystemIcon icon={configLookup[field.id].icon} />
 									) : (
-										<StarBorderIcon />
+										<ComponentIcon />
 									)}
 								</ListItemIcon>
 								<ListItemText primary={field.name} secondary={field.description} />
@@ -283,7 +288,7 @@ export function SelectField(props: {
 							{configLookup?.[field.id]?.icon?.id ? (
 								<SystemIcon icon={configLookup[field.id].icon} />
 							) : (
-								<StarBorderIcon />
+								<ComponentIcon />
 							)}
 						</ListItemIcon>
 						<ListItemText primary={field.name} secondary={field.description} />


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data source configuration loading so configured data sources are recognized correctly.

* **New Features**
  * Selection dialogs show custom icons for controls and data sources.
  * Dialogs respect configured controls/data sources, including previously out-of-bound items when present.
  * Added built-in fields: forcehttps and uuid.
  * Configuration now accepts controls and data sources with optional descriptor metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->