### PR TITLE
[8555] Handle request publish activity as package

### DIFF
--- a/ui/app/src/components/ActivityDashlet/utils.tsx
+++ b/ui/app/src/components/ActivityDashlet/utils.tsx
@@ -125,16 +125,10 @@ export function renderActivity(
 				/>
 			);
 		case 'REQUEST_PUBLISH':
-			return item.label === null ? (
+			return (
 				<FormattedMessage
-					id="activityDashlet.deletedItemRequestPublishActivityMessage"
-					defaultMessage="Requested publishing for an item that no longer exists"
-				/>
-			) : (
-				<FormattedMessage
-					id="activityDashlet.requestPublishActivityMessage"
-					defaultMessage="Requested publishing for <anchor>{item}</anchor> {systemType}"
-					values={{ item: [item.label, item.systemType, item.previewUrl, item.path], anchor, systemType }}
+					defaultMessage="Requested <render_package_link>a package</render_package_link> for publishing"
+					values={{ render_package_link }}
 				/>
 			);
 		case 'APPROVE':


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified activity dashboard messaging for package publishing requests to display a consistent message regardless of item status, replacing context-dependent messages that previously referenced specific item details or indicated deleted items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->