### PR TITLE
[8419] Improve Change Type dialog/flow

### DIFF
--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialog.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialog.tsx
@@ -35,6 +35,7 @@ export function ChangeContentTypeDialog(props: ChangeContentTypeDialogProps) {
 				item={item}
 				initialCompact={initialCompact}
 				onContentTypeSelected={onContentTypeSelected}
+				onClose={props.onClose}
 			/>
 		</EnhancedDialog>
 	);

--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
@@ -17,7 +17,7 @@
 import { ChangeContentTypeDialogContainerProps } from './utils';
 import React from 'react';
 import DialogBody from '../DialogBody/DialogBody';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import SelectTypeView from '../ContentTypeManagement/components/SelectTypeView';
 import { getNormalizedFolderPathForApi1GetTypes } from '../../utils/contentType';
 import { TypeListProps } from '../ContentTypeManagement/components/TypeList';
@@ -26,51 +26,90 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import useFetchAllowedTypesForPath from '../../hooks/useFetchAllowedTypesForPath';
 import { ObjectTypeOption } from '../ContentTypeFilter';
+import { DialogFooter } from '../DialogFooter';
+import SecondaryButton from '../SecondaryButton';
+import { EmptyState } from '../EmptyState';
+import { useDispatch } from 'react-redux';
+import { nanoid } from 'nanoid';
+import { pushConfirmDialog } from '../../utils/system';
+import { popDialog } from '../../state/actions/dialogStack';
 
 export function ChangeContentTypeDialogContainer(props: ChangeContentTypeDialogContainerProps) {
-	const { item, onContentTypeSelected, initialCompact = false } = props;
+	const { item, onContentTypeSelected, initialCompact = false, onClose } = props;
+	const dispatch = useDispatch();
+	const { formatMessage } = useIntl();
 
 	const handleContentTypeSelected: TypeListProps['onCardClick'] = (_, contentType) => {
-		onContentTypeSelected?.({
-			path: item.path,
-			contentType: contentType
-		});
+		const dialogId = nanoid();
+		dispatch(
+			pushConfirmDialog({
+				id: dialogId,
+				props: {
+					title: formatMessage({ defaultMessage: 'Change Type' }),
+					body: formatMessage({
+						defaultMessage: 'The following operation may result in data loss. Would you like to proceed?'
+					}),
+					onCancel: () => dispatch(popDialog({ id: dialogId })),
+					onOk: () => {
+						dispatch(popDialog({ id: dialogId }));
+						onContentTypeSelected?.({
+							path: item.path,
+							contentType: contentType
+						});
+					}
+				}
+			})
+		);
 	};
 
 	const { contentTypes, isFetching } = useFetchAllowedTypesForPath(
 		getNormalizedFolderPathForApi1GetTypes(item),
-		(types) => types.filter((type) => type.type === item.systemType)
+		(types) => types.filter((type) => type.type === item.systemType && item.contentTypeId != type.id)
 	);
 
 	return (
-		<DialogBody sx={{ minHeight: 670 }}>
-			<SelectTypeView
-				initialCompact={initialCompact}
-				initialObjectTypeFilter={item.systemType as ObjectTypeOption}
-				contentTypesList={contentTypes}
-				slotProps={{
-					listing: {
-						skeleton: isFetching,
-						skeletonItemCount: 4,
-						onCardClick: handleContentTypeSelected,
-						selectedTypeId: item.contentTypeId
-					},
-					bar: {
-						slotProps: {
-							contentTypesFilter: { disabled: true }
-						},
-						leftChildren: (
-							<Box sx={{ pl: 2, mr: 2, maxWidth: 300 }}>
-								<Typography variant="body2" color="textSecondary">
-									<FormattedMessage defaultMessage="Target Item" />
-								</Typography>
-								<ItemDisplay item={item} showNavigableAsLinks={false} />
-							</Box>
-						)
-					}
-				}}
-			/>
-		</DialogBody>
+		<>
+			<DialogBody sx={{ minHeight: 670, justifyContent: contentTypes?.length ? 'start' : 'center' }}>
+				{contentTypes?.length ? (
+					<SelectTypeView
+						initialCompact={initialCompact}
+						initialObjectTypeFilter={item.systemType as ObjectTypeOption}
+						contentTypesList={contentTypes}
+						slotProps={{
+							listing: {
+								skeleton: isFetching,
+								skeletonItemCount: 4,
+								onCardClick: handleContentTypeSelected,
+								selectedTypeId: item.contentTypeId
+							},
+							bar: {
+								slotProps: {
+									contentTypesFilter: { disabled: true }
+								},
+								leftChildren: (
+									<Box sx={{ pl: 2, mr: 2, maxWidth: 300 }}>
+										<Typography variant="body2" color="textSecondary">
+											<FormattedMessage defaultMessage="Target Item" />
+										</Typography>
+										<ItemDisplay item={item} showNavigableAsLinks={false} />
+									</Box>
+								)
+							}
+						}}
+					/>
+				) : (
+					<EmptyState
+						title={<FormattedMessage defaultMessage="No types available for the item." />}
+						sxs={{ root: { height: '100%' } }}
+					/>
+				)}
+			</DialogBody>
+			<DialogFooter>
+				<SecondaryButton onClick={(e) => onClose(e, null)}>
+					<FormattedMessage defaultMessage="Cancel" />
+				</SecondaryButton>
+			</DialogFooter>
+		</>
 	);
 }
 

--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
@@ -64,6 +64,7 @@ export function ChangeContentTypeDialogContainer(props: ChangeContentTypeDialogC
 
 	const { contentTypes, isFetching } = useFetchAllowedTypesForPath(
 		getNormalizedFolderPathForApi1GetTypes(item),
+		// Filter only compatible types, and filter out current type.
 		(types) => types.filter((type) => type.type === item.systemType && item.contentTypeId != type.id)
 	);
 

--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
@@ -67,11 +67,13 @@ export function ChangeContentTypeDialogContainer(props: ChangeContentTypeDialogC
 		// Filter only compatible types, and filter out current type.
 		(types) => types.filter((type) => type.type === item.systemType && item.contentTypeId != type.id)
 	);
+	// Show the select type view if there are content types to show, or if it's still loading (to show the skeleton). Otherwise, show the empty state.
+	const showSelectTpeView = contentTypes?.length || isFetching;
 
 	return (
 		<>
-			<DialogBody sx={{ minHeight: 670, justifyContent: contentTypes?.length ? 'start' : 'center' }}>
-				{contentTypes?.length ? (
+			<DialogBody sx={{ minHeight: 670, justifyContent: showSelectTpeView ? 'start' : 'center' }}>
+				{showSelectTpeView ? (
 					<SelectTypeView
 						initialCompact={initialCompact}
 						initialObjectTypeFilter={item.systemType as ObjectTypeOption}

--- a/ui/app/src/components/ChangeContentTypeDialog/utils.ts
+++ b/ui/app/src/components/ChangeContentTypeDialog/utils.ts
@@ -36,5 +36,4 @@ export interface ChangeContentTypeDialogStateProps extends ChangeContentTypeDial
 }
 
 export interface ChangeContentTypeDialogContainerProps
-	extends ChangeContentTypeDialogBaseProps,
-		Pick<ChangeContentTypeDialogProps, 'onContentTypeSelected'> {}
+	extends ChangeContentTypeDialogBaseProps, Pick<ChangeContentTypeDialogProps, 'onContentTypeSelected' | 'onClose'> {}

--- a/ui/app/src/utils/itemActions.ts
+++ b/ui/app/src/utils/itemActions.ts
@@ -637,37 +637,21 @@ export const itemActionDispatcher = ({
 				break;
 			}
 			case 'changeContentType': {
-				const dialogId = nanoid();
+				const changeContentTypeDialogId = nanoid();
 				dispatch(
-					pushConfirmDialog({
-						id: dialogId,
+					pushDialog({
+						id: changeContentTypeDialogId,
+						component: createComponentId('ChangeContentTypeDialog'),
 						props: {
-							title: formatMessage(translations.changeContentType),
-							body: formatMessage(translations.changeContentTypeBody),
-							onCancel: () => dispatch(popDialog({ id: dialogId })),
-							onOk: () => {
-								const changeContentTypeDialogId = nanoid();
+							item,
+							onContentTypeSelected: ({ contentType }) => {
 								dispatch(
 									batchActions([
-										popDialog({ id: dialogId }),
-										pushDialog({
-											id: changeContentTypeDialogId,
-											component: createComponentId('ChangeContentTypeDialog'),
-											props: {
-												item,
-												onContentTypeSelected: ({ contentType }) => {
-													dispatch(
-														batchActions([
-															popDialog({ id: changeContentTypeDialogId }),
-															changeContentType({
-																originalContentTypeId: item.contentTypeId,
-																path: item.path,
-																newContentTypeId: contentType.id
-															})
-														])
-													);
-												}
-											}
+										popDialog({ id: changeContentTypeDialogId }),
+										changeContentType({
+											originalContentTypeId: item.contentTypeId,
+											path: item.path,
+											newContentTypeId: contentType.id
 										})
 									])
 								);


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8419

- Update to show change type confirmation after selecting the new type, instead of when opening the dialog
- Add cancel button to dialog
- Do not show current type (show empty state if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selecting a new content type now opens a confirmation dialog before the change is applied.
  * Added a Cancel button to the Change Content Type dialog to dismiss it.

* **Improvements**
  * The item's current content type is excluded from the selectable list.
  * Improved dialog text localization and better handling of loading/empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->