### PR TITLE
[8193] Limit min/max size in nodeselector descriptor

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/nodeSelector.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/nodeSelector.ts
@@ -40,14 +40,18 @@ export const nodeSelectorDescriptor: DescriptorContentType = {
 			type: 'int',
 			name: defineMessage({ defaultMessage: 'Minimum Size' }),
 			defaultValue: undefined,
-			validations: immutableEmptyObject
+			validations: {
+				minValue: createValidation('minValue', 0)
+			}
 		},
 		maxSize: {
 			id: 'maxSize',
 			type: 'int',
 			name: defineMessage({ defaultMessage: 'Maximum Size' }),
 			defaultValue: undefined,
-			validations: immutableEmptyObject
+			validations: {
+				minValue: createValidation('minValue', 1)
+			}
 		},
 		itemManager: {
 			id: 'itemManager',

--- a/ui/app/src/models/ContentType.ts
+++ b/ui/app/src/models/ContentType.ts
@@ -16,9 +16,10 @@
 
 import { LookupTable } from './LookupTable';
 import { XmlKeys } from '../components/FormsEngine/lib/formConsts';
+import { DescriptorFieldValidationKeys } from '../components/ContentTypeManagement/utils';
 
 export interface ContentTypeFieldValidation<T = any> {
-	id: ValidationKeys;
+	id: ValidationKeys | DescriptorFieldValidationKeys;
 	value: T;
 	level: 'required' | 'suggestion';
 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented stricter validation rules for node selector configuration, adding minimum value constraints to size fields to ensure valid specifications and prevent configuration errors.

* **Refactor**
  * Extended the validation framework to support additional validation key sources, enabling more flexible and comprehensive constraint definitions for field validations across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->