### PR TITLE
[7511] Removing datasource without disconnecting it from properties corrupts form

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -1190,8 +1190,6 @@ function save(
 		dataSourceDescriptors: LookupTable<DescriptorContentType>;
 	}
 ): Observable<string> {
-	// TODO: clean xml, update type after cleaning up/saving
-
 	let xml = buildXmlFromType(type, configDescriptors);
 	xml = cleanupStaleDatasourceValuesFromXml(xml, type);
 	const requests = [writeConfiguration(siteId, createFormDefinitionPathFromTypeId(type.id), 'studio', xml)];

--- a/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -1403,7 +1403,8 @@ function cleanupStaleDatasourceValuesFromXml(xml: string, type: ContentType): st
 	try {
 		const dataSourceIds = (type.dataSources ?? []).map((ds) => ds.id);
 		const dom = fromString(xml);
-		if (dom) {
+		const parseError = dom?.getElementsByTagName('parsererror')[0];
+		if (dom && !parseError) {
 			// Find all <type> elements
 			const typeElements = Array.from(dom.getElementsByTagName('type'));
 			for (const typeEl of typeElements) {

--- a/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -85,7 +85,7 @@ import { useDispatch } from 'react-redux';
 import { popDialog, pushDialog } from '../../../state/actions/dialogStack';
 import { nanoid } from 'nanoid';
 import useEnv from '../../../hooks/useEnv';
-import { deserialize, fromString } from '../../../utils/xml';
+import { deserialize, fromString, serialize } from '../../../utils/xml';
 import useSpreadState from '../../../hooks/useSpreadState';
 import { asArray } from '../../../utils/array';
 import { fetchContentItem } from '../../../services/content';
@@ -459,9 +459,7 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 				break;
 			case 'save': {
 				if (!performCurrentFormErrorCheckAndWarning()) break;
-				let latestUpdate = commitOpenFormChanges();
-				// latestUpdate = cleanupStaleDatasourceValues(latestUpdate);
-				console.log('cleanupStaleDatasourceValues', cleanupStaleDatasourceValues(latestUpdate));
+				const latestUpdate = commitOpenFormChanges();
 				dialogContext?.updateSubmittingOrHasPendingChanges({ isSubmitting: true });
 				const typeToSave = latestUpdate ?? type;
 				save(site, typeToSave, configDescriptors).subscribe({
@@ -1192,7 +1190,10 @@ function save(
 		dataSourceDescriptors: LookupTable<DescriptorContentType>;
 	}
 ): Observable<string> {
-	const xml = buildXmlFromType(type, configDescriptors);
+	// TODO: clean xml, update type after cleaning up/saving
+
+	let xml = buildXmlFromType(type, configDescriptors);
+	xml = cleanupStaleDatasourceValuesFromXml(xml, type);
 	const requests = [writeConfiguration(siteId, createFormDefinitionPathFromTypeId(type.id), 'studio', xml)];
 
 	if ((type as PossibleContentTypeDraft).NEW) {
@@ -1387,78 +1388,58 @@ function reorderRepGroupFields(
 	}
 }
 
-function cleanupStaleDatasourceValues(type: ContentType) {
-	// Gather all valid datasource IDs
-	const validDataSourceIds = new Set((type.dataSources || []).map((ds) => ds.id));
-
-	// Helper to recursively clean a field (including repeating group fields)
-	function cleanField(field: any): any {
-		let changed = false;
-		const newProperties = field.properties ? { ...field.properties } : undefined;
-		if (newProperties) {
-			for (const [propKey, prop] of Object.entries(newProperties)) {
-				// @ts-ignore
-				if (prop && typeof prop.type === 'string' && prop.type.startsWith('datasource:')) {
-					// @ts-ignore
-					const value = prop.value;
-					if (typeof value === 'string') {
-						const values = value
+/**
+ * Cleans up stale datasource references in the provided XML string.
+ *
+ * This function parses the XML, finds all <type> elements whose text content starts with 'datasource:',
+ * and then checks their sibling <value> elements. The <value> element contains a comma-separated list
+ * of datasource IDs. Any IDs that do not exist in the current list of datasource IDs (from the type object)
+ * are removed. If all IDs are invalid, the <value> element is cleared.
+ *
+ * @param {string} xml - The XML string to clean up.
+ * @param {ContentType} type - The content type object containing the current list of datasource IDs.
+ * @returns {string} - The cleaned XML string with only valid datasource references.
+ */
+function cleanupStaleDatasourceValuesFromXml(xml: string, type: ContentType): string {
+	let cleanXml = xml;
+	try {
+		const dataSourceIds = (type.dataSources ?? []).map((ds) => ds.id);
+		const dom = fromString(xml);
+		if (dom) {
+			// Find all <type> elements
+			const typeElements = Array.from(dom.getElementsByTagName('type'));
+			for (const typeEl of typeElements) {
+				const typeText = typeEl.textContent?.trim() ?? '';
+				if (typeText.startsWith('datasource:')) {
+					// Find sibling <value> element
+					const parent = typeEl.parentElement;
+					let valueEl = null;
+					if (parent) {
+						valueEl = parent.querySelector('value');
+					}
+					if (valueEl && valueEl.textContent) {
+						const values = valueEl.textContent
 							.split(',')
 							.map((v) => v.trim())
 							.filter(Boolean);
-						const filtered = values.filter((id) => validDataSourceIds.has(id));
+						const filtered = values.filter((id) => dataSourceIds.includes(id));
 						if (filtered.length !== values.length) {
-							changed = true;
 							if (filtered.length > 0) {
-								// @ts-ignore
-								newProperties[propKey] = { ...prop, value: filtered.join(',') };
+								valueEl.textContent = filtered.join(',');
 							} else {
-								// Remove property if no valid datasources remain
-								delete newProperties[propKey];
+								valueEl.textContent = '';
 							}
 						}
 					}
 				}
 			}
+			cleanXml = serialize(dom);
 		}
-		// Recursively clean nested fields if this is a repeating group
-		let newFields = undefined;
-		if (field.fields) {
-			let fieldsChanged = false;
-			newFields = {};
-			for (const [subFieldId, subField] of Object.entries(field.fields)) {
-				const cleaned = cleanField(subField);
-				newFields[subFieldId] = cleaned;
-				if (cleaned !== subField) fieldsChanged = true;
-			}
-			if (!fieldsChanged) newFields = field.fields;
-			else changed = true;
-		}
-		if (changed || (newFields && newFields !== field.fields)) {
-			return {
-				...field,
-				...(newProperties ? { properties: newProperties } : {}),
-				...(newFields ? { fields: newFields } : {})
-			};
-		}
-		return field;
+	} catch (e) {
+		// If XML parsing fails, fallback to original xml (already set to xml at the beginning of the function)
+		console.error('Error parsing XML for cleanup, returning original XML', e);
 	}
-
-	// Clean all top-level fields
-	let fieldsChanged = false;
-	const newFields: any = {};
-	for (const [fieldId, field] of Object.entries(type.fields)) {
-		const cleaned = cleanField(field);
-		newFields[fieldId] = cleaned;
-		if (cleaned !== field) fieldsChanged = true;
-	}
-	if (fieldsChanged) {
-		return {
-			...type,
-			fields: newFields
-		};
-	}
-	return type;
+	return cleanXml;
 }
 
 export default EditTypeView;

--- a/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -1413,7 +1413,7 @@ function cleanupStaleDatasourceValuesFromXml(xml: string, type: ContentType): st
 					const parent = typeEl.parentElement;
 					let valueEl = null;
 					if (parent) {
-						valueEl = parent.querySelector('value');
+						valueEl = parent.querySelector(':scope > value');
 					}
 					if (valueEl && valueEl.textContent) {
 						const values = valueEl.textContent

--- a/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -459,7 +459,9 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 				break;
 			case 'save': {
 				if (!performCurrentFormErrorCheckAndWarning()) break;
-				const latestUpdate = commitOpenFormChanges();
+				let latestUpdate = commitOpenFormChanges();
+				// latestUpdate = cleanupStaleDatasourceValues(latestUpdate);
+				console.log('cleanupStaleDatasourceValues', cleanupStaleDatasourceValues(latestUpdate));
 				dialogContext?.updateSubmittingOrHasPendingChanges({ isSubmitting: true });
 				const typeToSave = latestUpdate ?? type;
 				save(site, typeToSave, configDescriptors).subscribe({
@@ -1383,6 +1385,80 @@ function reorderRepGroupFields(
 			}
 		};
 	}
+}
+
+function cleanupStaleDatasourceValues(type: ContentType) {
+	// Gather all valid datasource IDs
+	const validDataSourceIds = new Set((type.dataSources || []).map((ds) => ds.id));
+
+	// Helper to recursively clean a field (including repeating group fields)
+	function cleanField(field: any): any {
+		let changed = false;
+		const newProperties = field.properties ? { ...field.properties } : undefined;
+		if (newProperties) {
+			for (const [propKey, prop] of Object.entries(newProperties)) {
+				// @ts-ignore
+				if (prop && typeof prop.type === 'string' && prop.type.startsWith('datasource:')) {
+					// @ts-ignore
+					const value = prop.value;
+					if (typeof value === 'string') {
+						const values = value
+							.split(',')
+							.map((v) => v.trim())
+							.filter(Boolean);
+						const filtered = values.filter((id) => validDataSourceIds.has(id));
+						if (filtered.length !== values.length) {
+							changed = true;
+							if (filtered.length > 0) {
+								// @ts-ignore
+								newProperties[propKey] = { ...prop, value: filtered.join(',') };
+							} else {
+								// Remove property if no valid datasources remain
+								delete newProperties[propKey];
+							}
+						}
+					}
+				}
+			}
+		}
+		// Recursively clean nested fields if this is a repeating group
+		let newFields = undefined;
+		if (field.fields) {
+			let fieldsChanged = false;
+			newFields = {};
+			for (const [subFieldId, subField] of Object.entries(field.fields)) {
+				const cleaned = cleanField(subField);
+				newFields[subFieldId] = cleaned;
+				if (cleaned !== subField) fieldsChanged = true;
+			}
+			if (!fieldsChanged) newFields = field.fields;
+			else changed = true;
+		}
+		if (changed || (newFields && newFields !== field.fields)) {
+			return {
+				...field,
+				...(newProperties ? { properties: newProperties } : {}),
+				...(newFields ? { fields: newFields } : {})
+			};
+		}
+		return field;
+	}
+
+	// Clean all top-level fields
+	let fieldsChanged = false;
+	const newFields: any = {};
+	for (const [fieldId, field] of Object.entries(type.fields)) {
+		const cleaned = cleanField(field);
+		newFields[fieldId] = cleaned;
+		if (cleaned !== field) fieldsChanged = true;
+	}
+	if (fieldsChanged) {
+		return {
+			...type,
+			fields: newFields
+		};
+	}
+	return type;
 }
 
 export default EditTypeView;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Saving content types now cleans up stale datasource references in stored form definitions so only currently valid datasource IDs are kept.
  * If configuration parsing or cleanup fails, the original configuration is preserved and an error is logged for diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->