### PR TITLE
[7830] "Allow Duplicates" option for node-selector not properly honored by Experience Builder drag and drop

### DIFF
--- a/ui/app/src/components/FormsEngine/controls/NodeSelector.tsx
+++ b/ui/app/src/components/FormsEngine/controls/NodeSelector.tsx
@@ -303,7 +303,7 @@ function NodeSelector(props: NodeSelectorProps) {
 					dispatch,
 					path: processPath(pickerChoice.path),
 					contentTypes: pickerChoice.allowedContentTypes,
-					preselectedPaths: value.map((item) => item.key).filter(Boolean),
+					preselectedPaths: allowDuplicates ? [] : value.map((item) => item.key).filter(Boolean),
 					onSuccess(items: MediaItem | MediaItem[]) {
 						const newNodeSelectorItems = [];
 						asArray(items).forEach((item) => {

--- a/ui/guest/src/contentController.ts
+++ b/ui/guest/src/contentController.ts
@@ -260,7 +260,9 @@ function updateHierarchyMapIndexesFromCollection(collection: string[]) {
 		collection.forEach(
 			isSimpleIndex
 				? (id, index) => {
-						modelHierarchyMap[id].parentContainerFieldIndex = String(index);
+						if (modelHierarchyMap[id]) {
+							modelHierarchyMap[id].parentContainerFieldIndex = String(index);
+						}
 					}
 				: (id, index) => {
 						const current = modelHierarchyMap[id].parentContainerFieldIndex as string;

--- a/ui/guest/src/contentController.ts
+++ b/ui/guest/src/contentController.ts
@@ -255,7 +255,11 @@ function collectReferrers(modelId) {
 
 function updateHierarchyMapIndexesFromCollection(collection: string[]) {
 	if (collection.length) {
-		const isSimpleIndex = isSimple(modelHierarchyMap[collection[0]].parentContainerFieldIndex);
+		const firstEntry = modelHierarchyMap[collection[0]];
+		if (!firstEntry) {
+			return;
+		}
+		const isSimpleIndex = isSimple(firstEntry.parentContainerFieldIndex);
 		// 1. Update item being sorted and items getting displaced because of that sort
 		collection.forEach(
 			isSimpleIndex
@@ -265,8 +269,10 @@ function updateHierarchyMapIndexesFromCollection(collection: string[]) {
 						}
 					}
 				: (id, index) => {
-						const current = modelHierarchyMap[id].parentContainerFieldIndex as string;
-						modelHierarchyMap[id].parentContainerFieldIndex = `${removeLastPiece(current)}.${index}`;
+						const entry = modelHierarchyMap[id];
+						if (!entry) return;
+						const current = entry.parentContainerFieldIndex as string;
+						entry.parentContainerFieldIndex = `${removeLastPiece(current)}.${index}`;
 					}
 		);
 	}

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -644,7 +644,7 @@ const reducer = createReducer(initialState, {
 						contentItemsByPath: getCachedContentItems(),
 						parentModelId: getParentModelId(record.modelId, getCachedModels(), modelHierarchyMap)
 					}) ||
-					(!allowDuplicates && hierarchyMap[record.modelId]?.children.includes(instanceId))
+					(!allowDuplicates && hierarchyMap[record.modelId]?.children?.includes(instanceId))
 				);
 			},
 			// This action type ensures we're working with existing 'shared' components

--- a/ui/guest/src/store/reducers/root.ts
+++ b/ui/guest/src/store/reducers/root.ts
@@ -90,6 +90,7 @@ import { getParentModelId } from '../../utils/ice';
 import { getCachedModels, getCachedContentItems, modelHierarchyMap } from '../../contentController';
 import { isEditActionAvailable } from '../../utils/util';
 import type { BuiltInControlType } from '@craftercms/studio-ui/components/FormsEngine/lib/controlMap';
+import { ContentTypeFieldValidations } from '@craftercms/studio-ui';
 
 type CaseReducer<S = GuestState, A extends GuestStandardAction = GuestStandardAction> = Reducer<S, A>;
 
@@ -633,13 +634,17 @@ const reducer = createReducer(initialState, {
 		const dropTargets = getContentTypeDropTargets(
 			instance.craftercms.contentTypeId,
 			(record: ICERecord, hierarchyMap: ModelHierarchyMap) => {
+				const { field: { validations = [] } = {} } = getReferentialEntries(record);
+				const allowDuplicates = (validations as ContentTypeFieldValidations)?.allowDuplicates?.value ?? false;
+
 				return (
 					!isEditActionAvailable({
 						record,
 						models: getCachedModels(),
 						contentItemsByPath: getCachedContentItems(),
 						parentModelId: getParentModelId(record.modelId, getCachedModels(), modelHierarchyMap)
-					}) || hierarchyMap[record.modelId]?.children.includes(instanceId)
+					}) ||
+					(!allowDuplicates && hierarchyMap[record.modelId]?.children.includes(instanceId))
 				);
 			},
 			// This action type ensures we're working with existing 'shared' components


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Enforced duplicate-item validation across selection workflows so items cannot be duplicated when disallowed.
- Prevented errors when updating item hierarchies by guarding against missing or undefined entries.
- Adjusted preselection behavior so initial selections respect the allow-duplicates setting, avoiding unintended preselected items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->