### PR TITLE
[8656] Item manager in Type Builder's form failing to save

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/utils.ts
+++ b/ui/app/src/components/ContentTypeManagement/utils.ts
@@ -273,7 +273,9 @@ export function reverseTypeFieldValuesObject(
 				properties[property] = { ...mergedProperties[property] };
 				// Serialize field properties
 				const serializer = valueSerializersLookup[fieldDescriptor.type];
-				properties[property].value = serializer ? serializer(null, values[property]) : (values[property] as never);
+				properties[property].value = serializer
+					? serializer(fieldDescriptor, values[property])
+					: (values[property] as never);
 			}
 		} else if (property === 'validations') {
 			fieldWithReversedValues.validations = { ...field.validations };

--- a/ui/app/src/components/FormsEngine/lib/valueSerializers.ts
+++ b/ui/app/src/components/FormsEngine/lib/valueSerializers.ts
@@ -143,7 +143,7 @@ type XmlNuancedArrayFormat<T = unknown> = {
 };
 
 function prepareString(field: ContentTypeField, value: string): string {
-	const escapeContent = (field.properties?.escapeContent?.value as boolean) ?? false;
+	const escapeContent = (field?.properties?.escapeContent?.value as boolean) ?? false;
 	return nnou(value) && escapeContent ? escapeXml(value as string) : value;
 }
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of field property serialization in content type management to correctly pass field descriptors.
  * Enhanced string value processing with defensive programming to prevent runtime errors when field properties are undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->