### PR TITLE
[8574] Modeling tool allows user to use . in the content type name

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/components/CreateTypeDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/CreateTypeDialog.tsx
@@ -226,7 +226,14 @@ function transformId(value: string): string {
 }
 
 function suggestTypeId(label: string): string {
-	let camelized = camelize(label.replace(/\s/g, '-'));
+	// Replace spaces with underscore, remove illegal characters.
+	let sanitized = label.replace(/\s/g, '_').replace(/[^_0-9A-Za-z]/g, '');
+	// Ensure the first character is a letter or underscore
+	if (sanitized !== '' && !/^[_A-Za-z]/.test(sanitized)) {
+		sanitized = `_${sanitized}`;
+	}
+
+	let camelized = camelize(sanitized.replace(/\s/g, '-'));
 	camelized = camelized.charAt(0).toLowerCase() + camelized.substring(1);
 	return transformId(camelized);
 }

--- a/ui/app/src/components/ContentTypeManagement/components/CreateTypeDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/CreateTypeDialog.tsx
@@ -226,12 +226,10 @@ function transformId(value: string): string {
 }
 
 function suggestTypeId(label: string): string {
-	// Replace spaces with underscore, remove illegal characters.
-	let sanitized = label.replace(/\s/g, '_').replace(/[^_0-9A-Za-z]/g, '');
-	// Ensure the first character is a letter or underscore
-	if (sanitized !== '' && !/^[_A-Za-z]/.test(sanitized)) {
-		sanitized = `_${sanitized}`;
-	}
+	// Replace spaces with hyphens so camelize() can produce camelCase.
+	let sanitized = label.replace(/\s/g, '-').replace(/[^-A-Za-z0-9]/g, '');
+	// Strip any leading hyphens/digits so the result starts with a letter.
+	sanitized = sanitized.replace(/^[-0-9]+/, '');
 
 	let camelized = camelize(sanitized);
 	camelized = camelized.charAt(0).toLowerCase() + camelized.substring(1);

--- a/ui/app/src/components/ContentTypeManagement/components/CreateTypeDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/CreateTypeDialog.tsx
@@ -233,7 +233,7 @@ function suggestTypeId(label: string): string {
 		sanitized = `_${sanitized}`;
 	}
 
-	let camelized = camelize(sanitized.replace(/\s/g, '-'));
+	let camelized = camelize(sanitized);
 	camelized = camelized.charAt(0).toLowerCase() + camelized.substring(1);
 	return transformId(camelized);
 }

--- a/ui/app/src/components/ContentTypeManagement/components/CreateTypeDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/CreateTypeDialog.tsx
@@ -228,8 +228,10 @@ function transformId(value: string): string {
 function suggestTypeId(label: string): string {
 	// Replace spaces with hyphens so camelize() can produce camelCase.
 	let sanitized = label.replace(/\s/g, '-').replace(/[^-A-Za-z0-9]/g, '');
-	// Strip any leading hyphens/digits so the result starts with a letter.
-	sanitized = sanitized.replace(/^[-0-9]+/, '');
+	// Ensure the first character is a letter or underscore
+	if (sanitized !== '' && !/^[_A-Za-z]/.test(sanitized)) {
+		sanitized = `_${sanitized}`;
+	}
 
 	let camelized = camelize(sanitized);
 	camelized = camelized.charAt(0).toLowerCase() + camelized.substring(1);

--- a/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
@@ -140,7 +140,12 @@ export function Variable(props: VariableProps) {
 }
 
 const cleanVariable = (value) => {
-	return value.replace(/-/g, '_').replace(/[^A-Za-z0-9-_]/g, '');
+	let sanitized = value.replace(/-/g, '_').replace(/[^A-Za-z0-9-_]/g, '');
+	// Ensure the first character is a letter or underscore
+	if (sanitized !== '' && !/^[_A-Za-z]/.test(sanitized)) {
+		sanitized = `_${sanitized}`;
+	}
+	return sanitized;
 };
 
 const getValueWithSuffix = (value: string, suffix: string, supportedSuffixes: SuffixesType[]): string => {

--- a/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/Variable.tsx
@@ -140,7 +140,7 @@ export function Variable(props: VariableProps) {
 }
 
 const cleanVariable = (value) => {
-	let sanitized = value.replace(/-/g, '_').replace(/[^A-Za-z0-9-_]/g, '');
+	let sanitized = value.replace(/-/g, '_').replace(/[^A-Za-z0-9_]/g, '');
 	// Ensure the first character is a letter or underscore
 	if (sanitized !== '' && !/^[_A-Za-z]/.test(sanitized)) {
 		sanitized = `_${sanitized}`;


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic identifier generation for new content types: labels with spaces, leading hyphens/digits, or special characters are now sanitized and normalized before forming the final identifier, reducing invalid or unexpected IDs.
  * Tightened variable name sanitization: generated variable names are validated to start with a letter or underscore and contain only allowed characters, preventing malformed names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/craftercms/studio-ui/pull/4858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->