### PR TITLE
[8595] Improve error handling in CreateSiteDialog, rename 'key' to 'private_key'

### DIFF
--- a/ui/app/src/components/CreateSiteDialog/CreateSiteDialog.tsx
+++ b/ui/app/src/components/CreateSiteDialog/CreateSiteDialog.tsx
@@ -48,7 +48,7 @@ const siteInitialState: SiteState = {
 	expanded: {
 		basic: false,
 		token: false,
-		key: false
+		private_key: false
 	},
 	showIncompatible: true,
 	gitBranch: '',

--- a/ui/app/src/components/CreateSiteDialog/CreateSiteDialogContainer.tsx
+++ b/ui/app/src/components/CreateSiteDialog/CreateSiteDialogContainer.tsx
@@ -789,7 +789,10 @@ export function CreateSiteDialogContainer(props: CreateSiteDialogContainerProps)
 							)}
 						</DialogBody>
 					) : apiState.error ? (
-						<ApiResponseErrorState sxs={{ root: { height: '100%' } }} error={apiState.errorResponse} />
+						<ApiResponseErrorState
+							sxs={{ root: { height: '100%' } }}
+							error={extractErrorPayload(apiState.errorResponse)}
+						/>
 					) : (
 						<Box sx={{ position: 'relative', padding: 16, flexGrow: 1 }}>
 							<LoadingState />

--- a/ui/app/src/components/CreateSiteDialog/CreateSiteDialogContainer.tsx
+++ b/ui/app/src/components/CreateSiteDialog/CreateSiteDialogContainer.tsx
@@ -59,6 +59,7 @@ import GitFilled from '../../icons/GitFilled';
 import { previewSwitch } from '../../services/security';
 import { keyframes } from '@emotion/react';
 import { fadeIn } from 'react-animations';
+import { extractErrorPayload } from '../../utils/ajax';
 
 interface SearchState {
 	searchKey: string;
@@ -627,7 +628,7 @@ export function CreateSiteDialogContainer(props: CreateSiteDialogContainerProps)
 				(apiState.errorResponse && (
 					<ApiResponseErrorState
 						sxs={{ root: { height: '100%' } }}
-						error={apiState.errorResponse}
+						error={extractErrorPayload(apiState.errorResponse)}
 						onButtonClick={handleErrorBack}
 					/>
 				)) ||

--- a/ui/app/src/components/CreateSiteDialog/CreateSiteDialogContainer.tsx
+++ b/ui/app/src/components/CreateSiteDialog/CreateSiteDialogContainer.tsx
@@ -205,7 +205,7 @@ export function CreateSiteDialogContainer(props: CreateSiteDialogContainerProps)
 			if (type === 'token') {
 				map['repoToken'] = !site.repoToken;
 			}
-			if (type === 'key') {
+			if (type === 'private_key') {
 				map['repoKey'] = !site.repoKey;
 			}
 		}
@@ -368,7 +368,7 @@ export function CreateSiteDialogContainer(props: CreateSiteDialogContainerProps)
 			if (!site.repoUrl) return false;
 			else if (site.repoAuthentication === 'basic' && (!site.repoUsername || !site.repoPassword)) return false;
 			else if (site.repoAuthentication === 'token' && !site.repoToken) return false;
-			else return !(site.repoAuthentication === 'key' && !site.repoKey);
+			else return !(site.repoAuthentication === 'private_key' && !site.repoKey);
 		} else {
 			return checkAdditionalFields();
 		}
@@ -426,7 +426,7 @@ export function CreateSiteDialogContainer(props: CreateSiteDialogContainerProps)
 				if (site.repoAuthentication === 'token') {
 					authentication.token = site.repoToken;
 				}
-				if (site.repoAuthentication === 'key') {
+				if (site.repoAuthentication === 'private_key') {
 					authentication.privateKey = site.repoKey;
 				}
 

--- a/ui/app/src/components/GitAuthForm/GitAuthForm.tsx
+++ b/ui/app/src/components/GitAuthForm/GitAuthForm.tsx
@@ -185,7 +185,7 @@ function AuthFields(props: AuthFieldsProps) {
 					}}
 				/>
 			)}
-			{type === 'key' && (
+			{type === 'private_key' && (
 				<TextField
 					id="repoKey"
 					name="repoKey"
@@ -258,11 +258,11 @@ export function GitAuthForm(props: GitAuthFormProps) {
 					<AuthFields inputs={inputs} handleInputChange={handleInputChange} />
 				</Collapse>
 				<FormControlLabel
-					value="key"
-					control={<Radio onChange={() => viewAuth('key')} />}
+					value="private_key"
+					control={<Radio onChange={() => viewAuth('private_key')} />}
 					label={<FormattedMessage id="gitForm.privateKey" defaultMessage="Private Key" />}
 				/>
-				<Collapse in={inputs.expanded.key} timeout={300} unmountOnExit>
+				<Collapse in={inputs.expanded.private_key} timeout={300} unmountOnExit>
 					<AuthFields inputs={inputs} handleInputChange={handleInputChange} />
 				</Collapse>
 			</RadioGroup>

--- a/ui/app/src/components/NewRemoteRepositoryDialog/NewRemoteRepositoryDialogContainer.tsx
+++ b/ui/app/src/components/NewRemoteRepositoryDialog/NewRemoteRepositoryDialogContainer.tsx
@@ -48,7 +48,7 @@ export function NewRemoteRepositoryDialogContainer(props: NewRemoteRepositoryDia
 					? { remoteUsername: inputs.repoUsername, remotePassword: inputs.repoPassword }
 					: inputs.repoAuthentication === 'token'
 						? { remoteToken: inputs.repoToken }
-						: inputs.repoAuthentication === 'key'
+						: inputs.repoAuthentication === 'private_key'
 							? { remotePrivateKey: inputs.repoKey }
 							: {})
 			}).subscribe({

--- a/ui/app/src/components/NewRemoteRepositoryDialog/utils.ts
+++ b/ui/app/src/components/NewRemoteRepositoryDialog/utils.ts
@@ -44,7 +44,7 @@ export const inputsInitialState: Partial<SiteState> & { remoteName: string; remo
 	expanded: {
 		basic: false,
 		token: false,
-		key: false
+		private_key: false
 	},
 	repoAuthentication: 'none',
 	repoUsername: '',

--- a/ui/app/src/models/Site.ts
+++ b/ui/app/src/models/Site.ts
@@ -45,7 +45,7 @@ export interface SiteState extends SiteBaseState {
 	useRemote: boolean;
 	createAsOrphan: boolean;
 	repoUrl: string;
-	repoAuthentication: 'none' | 'basic' | 'token' | 'key';
+	repoAuthentication: 'none' | 'basic' | 'token' | 'private_key';
 	repoRemoteBranch: string;
 	sandboxBranch: string;
 	repoRemoteName: string;
@@ -60,7 +60,7 @@ export interface SiteState extends SiteBaseState {
 	expanded: {
 		basic: boolean;
 		token: boolean;
-		key: boolean;
+		private_key: boolean;
 	};
 	showIncompatible: boolean;
 


### PR DESCRIPTION
- Improved error handling
- Rename 'key' to 'private_key' in repository authentication logic according to API spec 

https://github.com/craftercms/craftercms/issues/8595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling to ensure more consistent and properly formatted error displays when creating a new site.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/craftercms/studio-ui/pull/4861)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->