### PR TITLE
[6601] Data sources should allow content type designer to specify sort and filter defaults where applicable

### DIFF
--- a/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -61,7 +61,7 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 	const site = useActiveSiteId();
 	const { guestBase } = useEnv();
 	const dispatch = useDispatch();
-	const [keyword, setKeyword] = useState('');
+	const [keyword, setKeyword] = useState(initialParametersProp?.keywords ?? '');
 	const [selectedCard, setSelectedCard] = useState<MediaItem>();
 	const [searchParameters, setSearchParameters] = useSpreadState({
 		...initialParameters,

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -305,7 +305,8 @@ export const showSearchDialog = ({
 	path,
 	preselectedPaths = [],
 	contentTypes,
-	onAcceptSelection
+	onAcceptSelection,
+	initialParameters
 }: {
 	path: string;
 	contentTypes?: string[];
@@ -325,6 +326,7 @@ export const showSearchDialog = ({
 				initialParameters: {
 					path,
 					sortBy: 'internalName',
+					...initialParameters,
 					...(contentTypes && { filters: { 'content-type': contentTypes } })
 				},
 				preselectedPaths,

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -310,6 +310,7 @@ export const showSearchDialog = ({
 	path: string;
 	contentTypes?: string[];
 	preselectedPaths?: string[];
+	initialParameters?: SearchProps['initialParameters'];
 	dispatch: ReduxDispatch;
 	onAcceptSelection: SearchProps['onAcceptSelection'];
 }): void => {

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -327,7 +327,12 @@ export const showSearchDialog = ({
 					path,
 					sortBy: 'internalName',
 					...initialParameters,
-					...(contentTypes && { filters: { 'content-type': contentTypes } })
+					...(contentTypes && {
+						filters: {
+							...(initialParameters?.filters ?? {}),
+							'content-type': contentTypes
+						}
+					})
 				},
 				preselectedPaths,
 				onClose: () => dispatch(popDialog({ id })),

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -267,7 +267,8 @@ export const showBrowseFilesDialog = ({
 	path,
 	contentTypes,
 	multiSelect = true,
-	preselectedPaths = []
+	preselectedPaths = [],
+	initialParameters = {}
 }: {
 	path: string;
 	dispatch: ReduxDispatch;
@@ -275,6 +276,7 @@ export const showBrowseFilesDialog = ({
 	contentTypes?: string[];
 	multiSelect?: boolean;
 	preselectedPaths?: string[];
+	initialParameters?: BrowseFilesDialogProps['initialParameters'];
 }): void => {
 	const id = nanoid();
 	dispatch(
@@ -287,6 +289,7 @@ export const showBrowseFilesDialog = ({
 				allowUpload: false,
 				contentTypes: contentTypes ?? [],
 				preselectedPaths,
+				initialParameters,
 				onClose: () => dispatch(popDialog({ id })),
 				onSuccess(items) {
 					dispatch(popDialog({ id }));


### PR DESCRIPTION
Updates in utils for them to support initialParameters (where sorting and filtering can be customized) so it can be used when the datasources work is done

https://github.com/craftercms/craftercms/issues/6601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File browse and search dialogs can now open with pre-filled initial search keywords and accept optional initial parameters, so they launch with relevant search context and caller-supplied defaults/overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/craftercms/studio-ui/pull/4863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->