### PR TITLE
[5761] Enhance macro support for populating dates and times in the date time picker

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/controls/DateTimeExpressionInput.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/DateTimeExpressionInput.tsx
@@ -28,8 +28,9 @@ export interface TextProps extends TypeBuilderControl {
 	value: string;
 }
 
-const DATE_TIME_FORMAT_OFFSET = 'now [+ or -] [number] [days | weeks | years | hours | minutes] [optional HH:mm[:ss]]';
-const DATE_TIME_FORMAT_DAY = '{day-of-week} [optional HH:mm[:ss]]';
+const DATE_TIME_FORMAT_OFFSET =
+	'[now] [+ or -] [number] [days | weeks | years | hours | minutes | d | w | y | h | m] [optional HH:mm[:ss]]';
+const DATE_TIME_FORMAT_DAY = '[day-of-week | {day-of-week} | {macro}] [optional HH:mm[:ss]]';
 const DATE_TIME_EXAMPLE =
 	"'now', 'now+5days', 'now-30m', '+2d', '-2w', 'monday', '{friday} 09:00', '{now+2days} 09:30:15'";
 const TIME_FORMAT = 'now[+ or -][number][hours | minutes]';

--- a/ui/app/src/components/ContentTypeManagement/controls/DateTimeExpressionInput.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/DateTimeExpressionInput.tsx
@@ -30,7 +30,8 @@ export interface TextProps extends TypeBuilderControl {
 
 const DATE_TIME_FORMAT_OFFSET = 'now [+ or -] [number] [days | weeks | years | hours | minutes] [optional HH:mm[:ss]]';
 const DATE_TIME_FORMAT_DAY = '{day-of-week} [optional HH:mm[:ss]]';
-const DATE_TIME_EXAMPLE = "'now', 'now+5days', 'now-30minutes', 'now+2days 09:30:15' , '{monday}', '{friday} 09:00'";
+const DATE_TIME_EXAMPLE =
+	"'now', 'now+5days', 'now-30m', '+2d', '-2w', 'monday', '{friday} 09:00', '{now+2days} 09:30:15'";
 const TIME_FORMAT = 'now[+ or -][number][hours | minutes]';
 const TIME_EXAMPLE = "'now', 'now+5hours', 'now-30minutes'";
 

--- a/ui/app/src/components/ContentTypeManagement/controls/DateTimeExpressionInput.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/DateTimeExpressionInput.tsx
@@ -29,8 +29,8 @@ export interface TextProps extends TypeBuilderControl {
 }
 
 const DATE_TIME_FORMAT_OFFSET =
-	'[now] [+ or -] [number] [days | weeks | years | hours | minutes | d | w | y | h | m] [optional HH:mm[:ss]]';
-const DATE_TIME_FORMAT_DAY = '[day-of-week | {day-of-week} | {macro}] [optional HH:mm[:ss]]';
+	'[now] [+ or -] [number] [days | weeks | years | hours | minutes | d | w | y | h | m]';
+const DATE_TIME_FORMAT_DAY = '[day-of-week | {day-of-week}] or {macro} [optional HH:mm[:ss]]';
 const DATE_TIME_EXAMPLE =
 	"'now', 'now+5days', 'now-30m', '+2d', '-2w', 'monday', '{friday} 09:00', '{now+2days} 09:30:15'";
 const TIME_FORMAT = 'now[+ or -][number][hours | minutes]';
@@ -78,6 +78,11 @@ export function DateTimeExpressionInput(props: TextProps) {
 								<Box>
 									<FormattedMessage defaultMessage="e.g." />: {type === 'dateTime' ? DATE_TIME_EXAMPLE : TIME_EXAMPLE}
 								</Box>
+								{type === 'dateTime' && (
+									<Box>
+										<FormattedMessage defaultMessage="When the field disallows past dates, a static time that resolves to a past datetime (e.g. '{now} 00:00') falls back to the current time instead." />
+									</Box>
+								)}
 							</Box>
 						}
 					>

--- a/ui/app/src/components/ContentTypeManagement/controls/DateTimeExpressionInput.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/DateTimeExpressionInput.tsx
@@ -28,8 +28,9 @@ export interface TextProps extends TypeBuilderControl {
 	value: string;
 }
 
-const DATE_TIME_FORMAT = 'now[+ or -][number][days | weeks | years | hours | minutes]';
-const DATE_TIME_EXAMPLE = "'now', 'now+5hours', 'now-30minutes', 'now+10days', 'now-2weeks', 'now+1years'";
+const DATE_TIME_FORMAT_OFFSET = 'now [+ or -] [number] [days | weeks | years | hours | minutes] [optional HH:mm[:ss]]';
+const DATE_TIME_FORMAT_DAY = '{day-of-week} [optional HH:mm[:ss]]';
+const DATE_TIME_EXAMPLE = "'now', 'now+5days', 'now-30minutes', 'now+2days 09:30:15' , '{monday}', '{friday} 09:00'";
 const TIME_FORMAT = 'now[+ or -][number][hours | minutes]';
 const TIME_EXAMPLE = "'now', 'now+5hours', 'now-30minutes'";
 
@@ -61,7 +62,17 @@ export function DateTimeExpressionInput(props: TextProps) {
 								<Box>
 									<FormattedMessage defaultMessage="Date expression to process:" />
 								</Box>
-								<Box>{type === 'dateTime' ? DATE_TIME_FORMAT : TIME_FORMAT}</Box>
+								{type === 'dateTime' ? (
+									<>
+										<Box>{DATE_TIME_FORMAT_OFFSET}</Box>
+										<Box>
+											<FormattedMessage defaultMessage="or" />
+										</Box>
+										<Box>{DATE_TIME_FORMAT_DAY}</Box>
+									</>
+								) : (
+									<Box>{TIME_FORMAT}</Box>
+								)}
 								<Box>
 									<FormattedMessage defaultMessage="e.g." />: {type === 'dateTime' ? DATE_TIME_EXAMPLE : TIME_EXAMPLE}
 								</Box>

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -452,7 +452,9 @@ export function validateTimePopulateExpression(expr: string): boolean {
  * @param expr {string} The populate date expression to validate.
  * @returns true if the expression is valid, false otherwise.
  *
- * Supports: now, now+/-N[days|weeks|years|hours|minutes], day-of-week macros, and {macro} with optional time.
+ * Supports: now, now+/-N[days|weeks|years|hours|minutes], day-of-week names, and {macro} with optional HH:mm[:ss].
+ * A static time suffix is only valid on the {macro} form (e.g. "{friday} 09:00"), not on plain expressions
+ * (e.g. "monday 09:00" or "now+2d 09:00").
  */
 export function validateDatePopulateExpression(expr: string): boolean {
 	if (!expr) return false;
@@ -542,15 +544,21 @@ function setTimeOnDate(date: Date, timeStr: string) {
 }
 
 /**
- * Takes an expression like "now", "now+5days", "now-3weeks", "now+2years", "now-4hours", "now+30minutes"
- * and returns a Date object representing the calculated date. If the expression is invalid, it returns the
- * current date.
+ * Evaluates a populate date/time expression and returns the resulting Date.
+ * If the expression is invalid, returns the current date.
+ *
+ * Supported forms include plain offsets ("now", "now+5days", "+2d"), day-of-week names ("monday"),
+ * and braced macros with an optional static time ("{friday} 09:00", "{now+2days} 09:30:15").
  *
  * @param params {Object} - The parameters for processing the date expression.
- * @param params.expression {string}  - The date expression to process ('now[+ or -][number][days or weeks or years or hours or minutes]'
- * 																			e.g. 'now', 'now+5hours', 'now-30minutes', 'now+10days', 'now-2weeks', 'now+1years').
- * @param params.validatePopulateExpression {Function} - A function to validate the expression. If the expression is invalid, the current date is returned.
- * @param [params.allowPastDate=false] {boolean} - If `false`, sets "now" expression to the end of the current minute. Note: This does not prevent past dates for other expressions (e.g., "now-5days"); the calling control is responsible for that validation.
+ * @param params.expression {string} - The populate expression to evaluate.
+ * @param params.validatePopulateExpression {Function} - Validates the expression; invalid expressions fall back to now.
+ * @param [params.allowPastDate=false] {boolean} - When `false` (the default), avoids populating a datetime in the past:
+ *   - Plain `now` sets seconds to :59 on the current minute.
+ *   - `{macro} HH:mm[:ss]` applies the static time first; if the result is already in the past, falls back to
+ *     the current time with seconds set to :59 (e.g. `{now} 00:00` does not stay at midnight for most of the day).
+ *   - Other past-producing expressions (e.g. "now-5days") are not clamped here; the field control validates those.
+ *   When `true`, the computed datetime is returned as-is, including past static-time results.
  *
  * @returns {Date} The calculated date based on the expression.
  */

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -602,7 +602,7 @@ export function processPopulateExpression({
 		if (normalized === 'now') {
 			if (!allowPastDate) date.setSeconds(59, 0);
 		} else {
-			const match = normalized.match(/^now([+-])(\d+)(d|days|w|weeks|y|years|h|hours|m|minutes)$/);
+			const match = normalized.match(/^(?:now)?([+-])(\d+)(d|days|w|weeks|y|years|h|hours|m|minutes)$/);
 			if (match) {
 				const [, sign, value, unit] = match;
 				const n = parseInt(value, 10) * (sign === '-' ? -1 : 1);

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -564,12 +564,17 @@ export function processPopulateExpression({
 	validatePopulateExpression(expr: string): boolean;
 	allowPastDate?: boolean;
 }): Date {
-	// Match {macro} or {macro} time
-	const macroMatch = expression.match(/^\{([^}]+)\}(?:\s+([0-9]{1,2}:[0-9]{2}(?::[0-9]{2})?))?$/i);
-	if (!macroMatch) return new Date();
+	const trimmed = expression?.trim() ?? '';
+	const macroMatch = trimmed.match(/^\{([^}]+)\}(?:\s+([0-9]{1,2}:[0-9]{2}(?::[0-9]{2})?))?$/i);
+	const macro = (macroMatch ? macroMatch[1] : trimmed).trim();
+	const staticTime = macroMatch?.[2]?.trim() ?? null;
 
-	const macro = macroMatch[1].trim();
-	const staticTime = macroMatch[2]?.trim() ?? null;
+	if (!validatePopulateExpression(trimmed)) {
+		const fallback = new Date();
+		if (!allowPastDate) fallback.setSeconds(59, 0);
+		return fallback;
+	}
+
 	let date = new Date();
 
 	// Day-of-week mapping
@@ -625,8 +630,6 @@ export function processPopulateExpression({
 				}
 			}
 		}
-	} else if (!allowPastDate) {
-		date.setSeconds(59, 0);
 	}
 
 	if (staticTime) setTimeOnDate(date, staticTime);

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -632,6 +632,12 @@ export function processPopulateExpression({
 		}
 	}
 
-	if (staticTime) setTimeOnDate(date, staticTime);
+	if (staticTime) {
+		setTimeOnDate(date, staticTime);
+		if (!allowPastDate && date.getTime() < Date.now()) {
+			date = new Date();
+			date.setSeconds(59, 0);
+		}
+	}
 	return date;
 }

--- a/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
+++ b/ui/app/src/components/FormsEngine/lib/controlHelpers.tsx
@@ -449,13 +449,96 @@ export function validateTimePopulateExpression(expr: string): boolean {
 
 /**
  * Checks if the populate date expression is valid.
- *
  * @param expr {string} The populate date expression to validate.
  * @returns true if the expression is valid, false otherwise.
+ *
+ * Supports: now, now+/-N[days|weeks|years|hours|minutes], day-of-week macros, and {macro} with optional time.
  */
 export function validateDatePopulateExpression(expr: string): boolean {
-	const normalized = expr.replace(/ /g, '');
-	return /^(now|((now)?[+-]\d+(days|weeks|years|hours|minutes)))$/i.test(normalized);
+	if (!expr) return false;
+	const trimmed = expr.trim();
+	const days = [
+		'sunday',
+		'monday',
+		'tuesday',
+		'wednesday',
+		'thursday',
+		'friday',
+		'saturday',
+		'sun',
+		'mon',
+		'tue',
+		'wed',
+		'thu',
+		'fri',
+		'sat'
+	];
+
+	// 1. Check for {macro} or {macro} time
+	const macroMatch = trimmed.match(/^\{([^}]+)\}(?:\s+([0-9]{1,2}:[0-9]{2}(?::[0-9]{2})?))?$/i);
+	if (macroMatch) {
+		const macro = macroMatch[1].trim().toLowerCase();
+		const staticTime = macroMatch[2] ? macroMatch[2].trim() : null;
+
+		// Validate macro (day-of-week or now/now+/-N...)
+		if (
+			days.includes(macro) ||
+			/^(now|((now)?[+-]\d+(d|days|w|weeks|y|years|h|hours|m|minutes)))$/i.test(macro.replace(/ /g, ''))
+		) {
+			// If static time is present, validate format HH:mm or HH:mm:ss
+			if (staticTime) {
+				if (/^([01]?\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/.test(staticTime)) {
+					return true;
+				} else {
+					return false;
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	const lowered = trimmed.toLowerCase();
+	// 2. Day of week macro (plain)
+	if (days.includes(lowered)) return true;
+
+	// 3. now, now+2d, now-3weeks, now+1years, now-4hours, now+30minutes (plain)
+	if (/^(now|((now)?[+-]\d+(d|days|w|weeks|y|years|h|hours|m|minutes)))$/i.test(lowered.replace(/ /g, ''))) return true;
+
+	return false;
+}
+
+/**
+ * Returns a new Date object representing the next occurrence of the specified day of the week after the given date.
+ *
+ * @param date - The reference date from which to calculate the next day of the week.
+ * @param dayOfWeek - The target day of the week as a number (0 = Sunday, 1 = Monday, ..., 6 = Saturday).
+ * @returns A new Date object set to the next occurrence of the specified day of the week.
+ *
+ */
+function getNextDayOfWeek(date: Date, dayOfWeek: number): Date {
+	const result = new Date(date);
+	const current = result.getDay();
+	let delta = dayOfWeek - current;
+	if (delta <= 0) delta += 7;
+	result.setDate(result.getDate() + delta);
+	return result;
+}
+
+/**
+ * Sets the time (hours, minutes, seconds) on a given Date object based on a time string.
+ *
+ * @param date - The Date object to modify.
+ * @param timeStr - The time string in the format "HH:mm" or "HH:mm:ss".
+ * @returns The modified Date object with the specified time set.
+ *
+ */
+function setTimeOnDate(date: Date, timeStr: string) {
+	const parts = timeStr.split(':').map(Number);
+	if (parts.length >= 2) {
+		date.setHours(parts[0], parts[1], parts[2] || 0, 0);
+	}
+	return date;
 }
 
 /**
@@ -481,37 +564,71 @@ export function processPopulateExpression({
 	validatePopulateExpression(expr: string): boolean;
 	allowPastDate?: boolean;
 }): Date {
-	const date = new Date();
-	const daysInWeek = 7;
-	let modifier = 1;
+	// Match {macro} or {macro} time
+	const macroMatch = expression.match(/^\{([^}]+)\}(?:\s+([0-9]{1,2}:[0-9]{2}(?::[0-9]{2})?))?$/i);
+	if (!macroMatch) return new Date();
 
-	const populateDateExp = expression.replace(/ /g, '');
-	const normalized = populateDateExp.toLowerCase();
+	const macro = macroMatch[1].trim();
+	const staticTime = macroMatch[2]?.trim() ?? null;
+	let date = new Date();
 
-	if (validatePopulateExpression(expression)) {
+	// Day-of-week mapping
+	const dayOfWeekMap: Record<string, number> = {
+		sunday: 0,
+		sun: 0,
+		monday: 1,
+		mon: 1,
+		tuesday: 2,
+		tue: 2,
+		wednesday: 3,
+		wed: 3,
+		thursday: 4,
+		thu: 4,
+		friday: 5,
+		fri: 5,
+		saturday: 6,
+		sat: 6
+	};
+	const macroLower = macro.toLowerCase();
+	if (macroLower in dayOfWeekMap) {
+		date = getNextDayOfWeek(date, dayOfWeekMap[macroLower]);
+	} else if (validatePopulateExpression(macro)) {
+		const normalized = macro.replace(/ /g, '').toLowerCase();
 		if (normalized === 'now') {
 			if (!allowPastDate) date.setSeconds(59, 0);
 		} else {
-			const action = normalized.match(/[+-]/)![0];
-			const expValue = parseInt(normalized.match(/\d+/)![0], 10);
-			const type = normalized.match(/(days|weeks|years|hours|minutes)/)![0];
-			if (action === '-') {
-				modifier = modifier * -1;
-			}
-			if (type === 'years') {
-				date.setFullYear(date.getFullYear() + modifier * expValue);
-			} else if (type === 'weeks') {
-				date.setDate(date.getDate() + modifier * expValue * daysInWeek);
-			} else if (type === 'days') {
-				date.setDate(date.getDate() + modifier * expValue);
-			} else if (type === 'hours') {
-				date.setTime(date.getTime() + modifier * (expValue * 3600000));
-			} else if (type === 'minutes') {
-				date.setTime(date.getTime() + modifier * expValue * 60000);
+			const match = normalized.match(/^now([+-])(\d+)(d|days|w|weeks|y|years|h|hours|m|minutes)$/);
+			if (match) {
+				const [, sign, value, unit] = match;
+				const n = parseInt(value, 10) * (sign === '-' ? -1 : 1);
+				switch (unit) {
+					case 'y':
+					case 'years':
+						date.setFullYear(date.getFullYear() + n);
+						break;
+					case 'w':
+					case 'weeks':
+						date.setDate(date.getDate() + n * 7);
+						break;
+					case 'd':
+					case 'days':
+						date.setDate(date.getDate() + n);
+						break;
+					case 'h':
+					case 'hours':
+						date.setTime(date.getTime() + n * 3600000);
+						break;
+					case 'm':
+					case 'minutes':
+						date.setTime(date.getTime() + n * 60000);
+						break;
+				}
 			}
 		}
-	} else {
-		if (!allowPastDate) date.setSeconds(59, 0);
+	} else if (!allowPastDate) {
+		date.setSeconds(59, 0);
 	}
+
+	if (staticTime) setTimeOnDate(date, staticTime);
 	return date;
 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded date macro support in form population expressions: full and abbreviated day-of-week macros, `now` with ± offsets (days/weeks/years/hours/minutes), and optional static time (HH:mm or HH:mm:ss).
* **Bug Fixes**
  * Improved validation and parsing of date/time expressions, with invalid inputs now safely falling back to the current date (with sensible clamping when applicable).
* **Documentation**
  * Refreshed date/time input help text to show separate guidance for offset-style versus day-based formats, plus updated examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->