### PR TITLE
[8708] Improve Insert Control dialog usability

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/components/PickControlDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickControlDialog.tsx
@@ -46,8 +46,7 @@ export const systemFieldsIds: BuiltInControlType[] = [
 	'page-nav-order',
 	'locale-selector',
 	'expired-date',
-	'forcehttps',
-	'uuid'
+	'forcehttps'
 ];
 
 export function PickControlDialog(props: PickControlDialogProps) {

--- a/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
@@ -95,6 +95,7 @@ export function PickFieldDialogBody(props: PickFieldDialogBodyProps) {
 				{selectedView === 0 ? (
 					<SelectField
 						configLookup={configLookup}
+						typesCurrentList={typesCurrentList}
 						typesFullList={typesFullList}
 						selectedField={selectedField}
 						setSelectedField={onSelectField}
@@ -219,10 +220,12 @@ export function SelectField(props: {
 	setSelectedField: (field: PartialContentType) => void;
 	systemFieldsIds?: PickFieldDialogProps['systemFieldsIds'];
 	systemFieldsTitle?: PickFieldDialogProps['systemFieldsTitle'];
+	typesCurrentList?: PickFieldDialogProps['typesCurrentList'];
 }) {
 	const {
 		configLookup,
 		typesFullList,
+		typesCurrentList,
 		selectedField,
 		setSelectedField,
 		systemFieldsIds = [],
@@ -230,6 +233,7 @@ export function SelectField(props: {
 	} = props;
 	const [searchTerm, setSearchTerm] = useState('');
 	const { formatMessage } = useIntl();
+	const currentTypeIds = new Set((typesCurrentList ?? []).map((item) => item.id));
 
 	const basicFields = typesFullList
 		.map((type) => applyTranslations(type, formatMessage))
@@ -237,8 +241,17 @@ export function SelectField(props: {
 			(type) =>
 				(type.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
 					type.description.toLowerCase().includes(searchTerm.toLowerCase())) &&
-				systemFieldsIds.includes(type.id)
+				systemFieldsIds.includes(type.id) &&
+				// Type is not in 'currentTypeIds'
+				!currentTypeIds.has(type.id) &&
+				// If type is file-name and `currentTypeIds` has auto-filename, or
+				// type is auto-filename and `currentTypeIds` has file-name, then filter out
+				!(
+					(type.id === 'file-name' && currentTypeIds.has('auto-filename')) ||
+					(type.id === 'auto-filename' && currentTypeIds.has('file-name'))
+				)
 		);
+
 	const filteredFields = typesFullList
 		.map((type) => applyTranslations(type, formatMessage))
 		.filter(
@@ -255,6 +268,20 @@ export function SelectField(props: {
 	return (
 		<>
 			<SearchBar keyword={searchTerm} onChange={handleSearchChange} autoFocus={true} />
+			<Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', mt: 2 }}>
+				{filteredFields.map((field, index) => (
+					<ListItemButton key={index} onClick={() => setSelectedField(field)} selected={selectedField?.id === field.id}>
+						<ListItemIcon>
+							{configLookup?.[field.id]?.icon?.id ? (
+								<SystemIcon icon={configLookup[field.id].icon} />
+							) : (
+								<ComponentIcon />
+							)}
+						</ListItemIcon>
+						<ListItemText primary={field.name} secondary={field.description} />
+					</ListItemButton>
+				))}
+			</Box>
 			{basicFields.length > 0 && (
 				<>
 					<FormControl sx={{ mt: 2 }}>
@@ -281,20 +308,6 @@ export function SelectField(props: {
 					{filteredFields.length > 0 && <Divider />}
 				</>
 			)}
-			<Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', mt: 2 }}>
-				{filteredFields.map((field, index) => (
-					<ListItemButton key={index} onClick={() => setSelectedField(field)} selected={selectedField?.id === field.id}>
-						<ListItemIcon>
-							{configLookup?.[field.id]?.icon?.id ? (
-								<SystemIcon icon={configLookup[field.id].icon} />
-							) : (
-								<ComponentIcon />
-							)}
-						</ListItemIcon>
-						<ListItemText primary={field.name} secondary={field.description} />
-					</ListItemButton>
-				))}
-			</Box>
 		</>
 	);
 }

--- a/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
@@ -226,7 +226,7 @@ export function SelectField(props: {
 	const {
 		configLookup,
 		typesFullList,
-		currentFieldTypes,
+		currentFieldTypes = [],
 		selectedField,
 		setSelectedField,
 		systemFieldsIds = [],

--- a/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
+++ b/ui/app/src/components/ContentTypeManagement/components/PickFieldDialog.tsx
@@ -57,11 +57,12 @@ export interface PickFieldDialogProps extends EnhancedDialogProps {
 export interface PickFieldDialogBodyProps extends Omit<PickFieldDialogProps, 'title'> {}
 
 export function PickFieldDialogBody(props: PickFieldDialogBodyProps) {
-	const { configLookup, typesFullList, typesCurrentList, onInsert, onClose, systemFieldsTitle, systemFieldsIds } =
+	const { configLookup, typesFullList, typesCurrentList, onInsert, onClose, systemFieldsTitle, systemFieldsIds, type } =
 		props;
 	const [selectedField, setSelectedField] = useState<PartialContentType>(undefined);
 	const [selectedView, setSelectedView] = useState<number>(0);
 	const [position, setPosition] = useState<number>(typesCurrentList?.length ?? 0);
+	const currentFieldTypes = Object.values(type.fields ?? {}).map((field) => field.type);
 
 	const onSecondaryAction = (e: React.MouseEvent) => {
 		if (selectedView === 0) {
@@ -95,7 +96,7 @@ export function PickFieldDialogBody(props: PickFieldDialogBodyProps) {
 				{selectedView === 0 ? (
 					<SelectField
 						configLookup={configLookup}
-						typesCurrentList={typesCurrentList}
+						currentFieldTypes={currentFieldTypes}
 						typesFullList={typesFullList}
 						selectedField={selectedField}
 						setSelectedField={onSelectField}
@@ -220,12 +221,12 @@ export function SelectField(props: {
 	setSelectedField: (field: PartialContentType) => void;
 	systemFieldsIds?: PickFieldDialogProps['systemFieldsIds'];
 	systemFieldsTitle?: PickFieldDialogProps['systemFieldsTitle'];
-	typesCurrentList?: PickFieldDialogProps['typesCurrentList'];
+	currentFieldTypes?: string[];
 }) {
 	const {
 		configLookup,
 		typesFullList,
-		typesCurrentList,
+		currentFieldTypes,
 		selectedField,
 		setSelectedField,
 		systemFieldsIds = [],
@@ -233,7 +234,6 @@ export function SelectField(props: {
 	} = props;
 	const [searchTerm, setSearchTerm] = useState('');
 	const { formatMessage } = useIntl();
-	const currentTypeIds = new Set((typesCurrentList ?? []).map((item) => item.id));
 
 	const basicFields = typesFullList
 		.map((type) => applyTranslations(type, formatMessage))
@@ -243,12 +243,12 @@ export function SelectField(props: {
 					type.description.toLowerCase().includes(searchTerm.toLowerCase())) &&
 				systemFieldsIds.includes(type.id) &&
 				// Type is not in 'currentTypeIds'
-				!currentTypeIds.has(type.id) &&
+				!currentFieldTypes.includes(type.id) &&
 				// If type is file-name and `currentTypeIds` has auto-filename, or
 				// type is auto-filename and `currentTypeIds` has file-name, then filter out
 				!(
-					(type.id === 'file-name' && currentTypeIds.has('auto-filename')) ||
-					(type.id === 'auto-filename' && currentTypeIds.has('file-name'))
+					(type.id === 'file-name' && currentFieldTypes.includes('auto-filename')) ||
+					(type.id === 'auto-filename' && currentFieldTypes.includes('file-name'))
 				)
 		);
 
@@ -268,7 +268,7 @@ export function SelectField(props: {
 	return (
 		<>
 			<SearchBar keyword={searchTerm} onChange={handleSearchChange} autoFocus={true} />
-			<Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', mt: 2 }}>
+			<Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', mt: 1, mb: 2 }}>
 				{filteredFields.map((field, index) => (
 					<ListItemButton key={index} onClick={() => setSelectedField(field)} selected={selectedField?.id === field.id}>
 						<ListItemIcon>
@@ -284,10 +284,11 @@ export function SelectField(props: {
 			</Box>
 			{basicFields.length > 0 && (
 				<>
+					<Divider />
 					<FormControl sx={{ mt: 2 }}>
 						<FormLabel id="fieldSectionRadioGroupLabel">{systemFieldsTitle}</FormLabel>
 					</FormControl>
-					<Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', mt: 1, mb: 2 }}>
+					<Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', mt: 2 }}>
 						{basicFields.map((field, index) => (
 							<ListItemButton
 								key={index}
@@ -305,7 +306,6 @@ export function SelectField(props: {
 							</ListItemButton>
 						))}
 					</Box>
-					{filteredFields.length > 0 && <Divider />}
 				</>
 			)}
 		</>


### PR DESCRIPTION
- Move system types under the other fields types.
- Don't show system fields that are already used (you can't have multiples of these)
- Move UUID (a generic control) to the generic list of controls.

https://github.com/craftercms/craftercms/issues/8708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate field type assignments and conflicting file-name/auto-filename combinations in the field picker.
  * Adjusted the field selection layout so filtered fields consistently appear before system fields for clearer choices.
  * Removed UUID from the list of available control types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->