### PR TITLE
[6601] Data sources should allow content type designer to specify sort and filter defaults where applicable 

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/controlMap.ts
+++ b/ui/app/src/components/ContentTypeManagement/controlMap.ts
@@ -45,7 +45,8 @@ export type DescriptorControlType =
 	| 'date-time-expression-input'
 	| 'rte'
 	| 'delete-dependencies'
-	| 'copy-dependencies';
+	| 'copy-dependencies'
+	| 'sort-dropdown';
 
 const DataSourceMultiSelector = lazy(() => import('./controls/DataSourceMultiSelector'));
 const DataSourceSingleSelector = lazy(() => import('./controls/DataSourceSingleSelector'));
@@ -79,5 +80,6 @@ export const controlMap: Record<DescriptorControlType, ElementType> = {
 	'date-time-expression-input': lazy(() => import('./controls/DateTimeExpressionInput')),
 	rte: lazy(() => import('./controls/RichTextEditor')),
 	'delete-dependencies': lazy(() => import('./controls/DeleteDependencies')),
-	'copy-dependencies': lazy(() => import('./controls/CopyDependencies'))
+	'copy-dependencies': lazy(() => import('./controls/CopyDependencies')),
+	'sort-dropdown': lazy(() => import('./controls/SortDropdown'))
 };

--- a/ui/app/src/components/ContentTypeManagement/controls/SortDropdown.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/SortDropdown.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TypeBuilderControl } from '../utils';
+import FormsEngineField from '../../FormsEngine/components/FormsEngineField';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { useId } from 'react';
+import { defineMessage, useIntl } from 'react-intl';
+import MenuItem from '@mui/material/MenuItem';
+import { getPropertyValue } from '../../FormsEngine/lib/formUtils';
+
+const sortByOptions = [
+	{
+		key: '-AUTO-',
+		value: defineMessage({ defaultMessage: 'Auto' })
+	},
+	{
+		key: '_score',
+		value: defineMessage({ defaultMessage: 'Relevance' })
+	},
+	{
+		key: 'internalName',
+		value: defineMessage({ defaultMessage: 'Name' })
+	}
+];
+const sortOrderOptions = [
+	{
+		key: 'asc',
+		value: defineMessage({ defaultMessage: 'Ascending' })
+	},
+	{
+		key: 'desc',
+		value: defineMessage({ defaultMessage: 'Descending' })
+	}
+];
+
+export interface SortDropdownProps extends TypeBuilderControl {
+	value: string | undefined;
+}
+
+export function SortDropdown(props: SortDropdownProps) {
+	const { field, value, setValue, readonly, autoFocus } = props;
+	const htmlId = useId();
+	const { formatMessage } = useIntl();
+	const type = getPropertyValue(field.properties, 'type', 'sortBy');
+	const options = type === 'sortBy' ? sortByOptions : sortOrderOptions;
+
+	const handleChange = (event: SelectChangeEvent) => {
+		setValue(event.target.value);
+	};
+
+	return (
+		<FormsEngineField field={field} labelId={htmlId}>
+			<Select value={value ?? ''} labelId={htmlId} onChange={handleChange} disabled={readonly} autoFocus={autoFocus}>
+				{options.map((option) => (
+					<MenuItem key={option.key} value={option.key}>
+						{formatMessage(option.value)}
+					</MenuItem>
+				))}
+			</Select>
+		</FormsEngineField>
+	);
+}
+
+export default SortDropdown;

--- a/ui/app/src/components/ContentTypeManagement/controls/SortDropdown.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/SortDropdown.tsx
@@ -38,6 +38,10 @@ const sortByOptions = [
 ];
 const sortOrderOptions = [
 	{
+		key: '',
+		value: defineMessage({ defaultMessage: 'None' })
+	},
+	{
 		key: 'asc',
 		value: defineMessage({ defaultMessage: 'Ascending' })
 	},
@@ -59,7 +63,7 @@ export function SortDropdown(props: SortDropdownProps) {
 	const options = type === 'sortBy' ? sortByOptions : sortOrderOptions;
 
 	const handleChange = (event: SelectChangeEvent) => {
-		setValue(event.target.value);
+		setValue(event.target.value || undefined);
 	};
 
 	return (

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/components.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/components.ts
@@ -35,7 +35,9 @@ export const componentsDataSourceDescriptor: DescriptorContentType = {
 				'baseRepoPath',
 				'baseBrowsePath',
 				'contentTypes',
-				'tags'
+				'tags',
+				'sortBy',
+				'sortOrder'
 			]
 		})
 	],
@@ -95,6 +97,26 @@ export const componentsDataSourceDescriptor: DescriptorContentType = {
 			name: defineMessage({ defaultMessage: 'Tags' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
+		},
+		sortBy: {
+			id: 'sortBy',
+			type: 'sort-dropdown',
+			name: defineMessage({ defaultMessage: 'Sort By' }),
+			defaultValue: '-AUTO-',
+			validations: immutableEmptyObject,
+			properties: {
+				type: { name: 'type', type: 'string', value: 'sortBy' }
+			}
+		},
+		sortOrder: {
+			id: 'sortOrder',
+			type: 'sort-dropdown',
+			name: defineMessage({ defaultMessage: 'Sort Order' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject,
+			properties: {
+				type: { name: 'type', type: 'string', value: 'sortOrder' }
+			}
 		}
 	}
 };

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgRepositoryUpload.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/imgRepositoryUpload.ts
@@ -27,7 +27,7 @@ export const imgRepositoryUploadDataSourceDescriptor: DescriptorContentType = {
 		createVirtualSection({
 			id: 'properties',
 			title: defineMessage({ defaultMessage: 'Options' }),
-			fields: ['repoPath', 'useSearch']
+			fields: ['repoPath', 'useSearch', 'sortBy', 'sortOrder']
 		})
 	],
 	fields: {
@@ -47,6 +47,26 @@ export const imgRepositoryUploadDataSourceDescriptor: DescriptorContentType = {
 			name: defineMessage({ defaultMessage: 'Use Search' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
+		},
+		sortBy: {
+			id: 'sortBy',
+			type: 'sort-dropdown',
+			name: defineMessage({ defaultMessage: 'Sort By' }),
+			defaultValue: '-AUTO-',
+			validations: immutableEmptyObject,
+			properties: {
+				type: { name: 'type', type: 'string', value: 'sortBy' }
+			}
+		},
+		sortOrder: {
+			id: 'sortOrder',
+			type: 'sort-dropdown',
+			name: defineMessage({ defaultMessage: 'Sort Order' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject,
+			properties: {
+				type: { name: 'type', type: 'string', value: 'sortOrder' }
+			}
 		}
 	}
 };

--- a/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoBrowseRepo.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/videoBrowseRepo.ts
@@ -27,7 +27,7 @@ export const videoBrowseRepoDataSourceDescriptor: DescriptorContentType = {
 		createVirtualSection({
 			id: 'properties',
 			title: defineMessage({ defaultMessage: 'Options' }),
-			fields: ['repoPath', 'useSearch']
+			fields: ['repoPath', 'useSearch', 'sortBy', 'sortOrder']
 		})
 	],
 	fields: {
@@ -46,6 +46,26 @@ export const videoBrowseRepoDataSourceDescriptor: DescriptorContentType = {
 			name: defineMessage({ defaultMessage: 'Use Search' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
+		},
+		sortBy: {
+			id: 'sortBy',
+			type: 'sort-dropdown',
+			name: defineMessage({ defaultMessage: 'Sort By' }),
+			defaultValue: '-AUTO-',
+			validations: immutableEmptyObject,
+			properties: {
+				type: { name: 'type', type: 'string', value: 'sortBy' }
+			}
+		},
+		sortOrder: {
+			id: 'sortOrder',
+			type: 'sort-dropdown',
+			name: defineMessage({ defaultMessage: 'Sort Order' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject,
+			properties: {
+				type: { name: 'type', type: 'string', value: 'sortOrder' }
+			}
 		}
 	}
 };

--- a/ui/app/src/components/FormsEngine/controls/ImagePicker.tsx
+++ b/ui/app/src/components/FormsEngine/controls/ImagePicker.tsx
@@ -205,6 +205,10 @@ export function ImagePicker(props: ImagePickerProps) {
 					path: processPath(choice.path),
 					multiSelect: false,
 					preselectedPaths: value ? [value] : [],
+					initialParameters: {
+						sortBy: choice.options?.sortBy,
+						sortOrder: choice.options?.sortOrder
+					},
 					onSuccess(imageData: MediaItem) {
 						// Check if the image meets restrictions
 						validateImageRestrictions(imageData.path, restrictions).then((meetsRestrictions) => {
@@ -232,6 +236,10 @@ export function ImagePicker(props: ImagePickerProps) {
 					dispatch,
 					path: ensureSingleSlash(`${processPath(choice.path)}/.+`),
 					preselectedPaths: value ? [value] : [],
+					initialParameters: {
+						sortBy: choice.options?.sortBy,
+						sortOrder: choice.options?.sortOrder
+					},
 					onAcceptSelection(images) {
 						validateImageRestrictions(images[0], restrictions).then((meetsRestrictions) => {
 							if (!meetsRestrictions) {

--- a/ui/app/src/components/FormsEngine/controls/NodeSelector.tsx
+++ b/ui/app/src/components/FormsEngine/controls/NodeSelector.tsx
@@ -140,6 +140,10 @@ export interface AllowedPathsData {
 	path: string;
 	title: string;
 	allowedContentTypes?: string[];
+	options?: {
+		sortBy?: string;
+		sortOrder?: 'asc' | 'desc';
+	};
 }
 
 type ContentCreationStrategy = 'embedded' | 'shared';
@@ -304,6 +308,10 @@ function NodeSelector(props: NodeSelectorProps) {
 					path: processPath(pickerChoice.path),
 					contentTypes: pickerChoice.allowedContentTypes,
 					preselectedPaths: allowDuplicates ? [] : value.map((item) => item.key).filter(Boolean),
+					initialParameters: {
+						sortBy: pickerChoice.options?.sortBy,
+						sortOrder: pickerChoice.options?.sortOrder
+					},
 					onSuccess(items: MediaItem | MediaItem[]) {
 						const newNodeSelectorItems = [];
 						asArray(items).forEach((item) => {
@@ -331,6 +339,10 @@ function NodeSelector(props: NodeSelectorProps) {
 					path: ensureSingleSlash(`${processPath(pickerChoice.path)}/.+`),
 					contentTypes: pickerChoice.allowedContentTypes,
 					preselectedPaths: value.map((item) => item.key).filter(Boolean),
+					initialParameters: {
+						sortBy: pickerChoice.options?.sortBy,
+						sortOrder: pickerChoice.options?.sortOrder
+					},
 					onAcceptSelection(paths, items) {
 						const newNodeSelectorItems = [];
 						items?.forEach((item) => {

--- a/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedImagePickerData.ts
+++ b/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedImagePickerData.ts
@@ -42,7 +42,7 @@ export function useConsolidatedImagePickerData(dataSources: DataSource[]): Conso
 					if (!path) break;
 					const sortOptions = {
 						sortBy: ds.properties?.['sortBy'],
-						sortOrder: ds.properties['sortOrder']
+						sortOrder: ds.properties?.['sortOrder']
 					};
 					if (ds.properties.useSearch) {
 						allowedSearchPaths.push({

--- a/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedImagePickerData.ts
+++ b/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedImagePickerData.ts
@@ -40,15 +40,21 @@ export function useConsolidatedImagePickerData(dataSources: DataSource[]): Conso
 				case 'img-repository-upload': {
 					const path = ds.properties.repoPath || ds.properties.path;
 					if (!path) break;
+					const sortOptions = {
+						sortBy: ds.properties?.['sortBy'],
+						sortOrder: ds.properties['sortOrder']
+					};
 					if (ds.properties.useSearch) {
 						allowedSearchPaths.push({
 							title: ds.title,
-							path
+							path,
+							options: sortOptions
 						});
 					} else {
 						allowedBrowsePaths.push({
 							title: ds.title,
-							path
+							path,
+							options: sortOptions
 						});
 					}
 					break;

--- a/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedImagePickerData.ts
+++ b/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedImagePickerData.ts
@@ -41,8 +41,8 @@ export function useConsolidatedImagePickerData(dataSources: DataSource[]): Conso
 					const path = ds.properties.repoPath || ds.properties.path;
 					if (!path) break;
 					const sortOptions = {
-						sortBy: ds.properties?.['sortBy'],
-						sortOrder: ds.properties?.['sortOrder']
+						sortBy: ds.properties?.['sortBy'] as string | undefined,
+						sortOrder: ds.properties?.['sortOrder'] as 'asc' | 'desc' | undefined
 					};
 					if (ds.properties.useSearch) {
 						allowedSearchPaths.push({

--- a/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedItemPickerData.ts
+++ b/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedItemPickerData.ts
@@ -65,18 +65,24 @@ export function useConsolidatedItemPickerData(dataSources: DataSource[]): Consol
 							allowedSharedExisingTypes.push(contentTypeId);
 						}
 					});
+					const sortOptions = {
+						sortBy: ds.properties?.['sortBy'],
+						sortOrder: ds.properties?.['sortOrder']
+					};
 					if (ds.properties.enableBrowse) {
 						allowedBrowsePaths.push({
 							title: ds.title,
 							path: ds.properties.baseBrowsePath,
-							allowedContentTypes: allowedSharedExisingTypes
+							allowedContentTypes: allowedSharedExisingTypes,
+							options: sortOptions
 						});
 					}
 					if (ds.properties.enableSearch) {
 						allowedSearchPaths.push({
 							title: ds.title,
 							path: ds.properties.baseBrowsePath,
-							allowedContentTypes: allowedSharedExisingTypes
+							allowedContentTypes: allowedSharedExisingTypes,
+							options: sortOptions
 						});
 					}
 					break;

--- a/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedItemPickerData.ts
+++ b/ui/app/src/components/FormsEngine/dataSourceHooks/useConsolidatedItemPickerData.ts
@@ -66,8 +66,8 @@ export function useConsolidatedItemPickerData(dataSources: DataSource[]): Consol
 						}
 					});
 					const sortOptions = {
-						sortBy: ds.properties?.['sortBy'],
-						sortOrder: ds.properties?.['sortOrder']
+						sortBy: ds.properties?.['sortBy'] as string | undefined,
+						sortOrder: ds.properties?.['sortOrder'] as 'asc' | 'desc' | undefined
 					};
 					if (ds.properties.enableBrowse) {
 						allowedBrowsePaths.push({

--- a/ui/app/src/components/FormsEngine/lib/valueRetrievers.ts
+++ b/ui/app/src/components/FormsEngine/lib/valueRetrievers.ts
@@ -88,7 +88,8 @@ export const valueRetrieverLookup: Record<BuiltInControlType | DescriptorControl
 	'input-link': textFieldExtractor,
 	'input-phone': textFieldExtractor,
 	'delete-dependencies': null,
-	'copy-dependencies': null
+	'copy-dependencies': null,
+	'sort-dropdown': textFieldExtractor
 };
 
 /**

--- a/ui/app/src/components/FormsEngine/lib/valueSerializers.ts
+++ b/ui/app/src/components/FormsEngine/lib/valueSerializers.ts
@@ -98,7 +98,8 @@ export const valueSerializersLookup: Record<BuiltInControlType | DescriptorContr
 	'input-link': undefined,
 	'input-phone': undefined,
 	'delete-dependencies': (field, value) => (value == null ? undefined : prepareObject(field, value as object)),
-	'copy-dependencies': (field, value) => (value == null ? undefined : prepareObject(field, value as object))
+	'copy-dependencies': (field, value) => (value == null ? undefined : prepareObject(field, value as object)),
+	'sort-dropdown': undefined
 };
 
 /**


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sort field and order settings to component, image and video data source configurations with a new sort dropdown control.
  * Picker dialogs (image/item/node) now receive and apply initial sort preferences, improving browse/search ordering.
  * Sort dropdown supports localization, readonly disablement and autofocus.

* **Bug Fixes / Improvements**
  * Form value handling extended so sort selections are preserved when saving and serializing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->