### PR TITLE
Rollback @prettier/plugin-xml to version 3.3.0

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -70,7 +70,7 @@
 		"@mui/x-data-grid": "^8.27.5",
 		"@mui/x-date-pickers": "^8.27.2",
 		"@mui/x-tree-view": "^8.27.2",
-		"@prettier/plugin-xml": "3.4.2",
+		"@prettier/plugin-xml": "3.3.0",
 		"@reduxjs/toolkit": "^2.11.2",
 		"@stomp/stompjs": "^7.3.0",
 		"@tinymce/tinymce-react": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,7 +1672,7 @@ __metadata:
     "@mui/x-data-grid": "npm:^8.27.5"
     "@mui/x-date-pickers": "npm:^8.27.2"
     "@mui/x-tree-view": "npm:^8.27.2"
-    "@prettier/plugin-xml": "npm:3.4.2"
+    "@prettier/plugin-xml": "npm:3.3.0"
     "@reduxjs/toolkit": "npm:^2.11.2"
     "@rollup/plugin-swc": "npm:^0.4.0"
     "@stomp/stompjs": "npm:^7.3.0"
@@ -3246,6 +3246,17 @@ __metadata:
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: 10/ddd16090cde777aaf102940f05d0274602079a95ad9805bd20bc55dcc7c3a2ba1b99dd5c73e5cc2753c3d31250ca52a67d58059459d7d27debb983a9f552936c
+  languageName: node
+  linkType: hard
+
+"@prettier/plugin-xml@npm:3.3.0":
+  version: 3.3.0
+  resolution: "@prettier/plugin-xml@npm:3.3.0"
+  dependencies:
+    "@xml-tools/parser": "npm:^1.0.11"
+  peerDependencies:
+    prettier: ^3.0.0
+  checksum: 10/0f33b044af7d7a79fdf73a4754aed56f73efbf200be24efa40ef5f52b849243ddfe5a27ec3f1ad7ffdc21b6b0015319509a37cd365f6f52466df41c0eeec3b4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See https://github.com/prettier/plugin-xml/issues/784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->