### PR TITLE
[8221][8222] Accesibility - snack duration,  animations enabling/disabling

### DIFF
--- a/ui/app/src/components/AccountManagement/AccountManagement.tsx
+++ b/ui/app/src/components/AccountManagement/AccountManagement.tsx
@@ -389,7 +389,7 @@ export function AccountManagement(props: AccountManagementProps) {
 						<FormControl sx={{ mt: 2, mb: 1 }}>
 							<Box display="flex" alignItems="center" justifyContent="space-between" mb={1}>
 								<InputLabel htmlFor="snackDuration" shrink sx={{ position: 'static', transform: 'none', mb: 0 }}>
-									<FormattedMessage defaultMessage="Snackbar duration (ms)" />
+									<FormattedMessage defaultMessage="On-screen notification display time (in seconds)" />
 								</InputLabel>
 								<Button
 									variant="text"
@@ -402,11 +402,11 @@ export function AccountManagement(props: AccountManagementProps) {
 							</Box>
 							<NumberField.Root
 								id="snackDuration"
-								value={snackDuration}
-								onValueChange={setSnackDuration}
+								value={snackDuration / 1000} // Display in seconds
+								onValueChange={(value) => setSnackDuration(value * 1000)} // Store in milliseconds
 								min={0}
-								max={60000}
-								step={100}
+								max={60}
+								step={1}
 								format={{ maximumFractionDigits: 0 }}
 							>
 								<NumberField.Group render={<Box display="flex" />}>
@@ -419,6 +419,9 @@ export function AccountManagement(props: AccountManagementProps) {
 									</NumberField.Increment>
 								</NumberField.Group>
 							</NumberField.Root>
+							<FormHelperText sx={{ mt: 1, ml: 0 }}>
+								<FormattedMessage defaultMessage="How long notifications stay visible at on the screen before closing automatically. These appear when you save, publish, or complete other actions. You can dismiss them anytime using their close button." />
+							</FormHelperText>
 						</FormControl>
 
 						<FormControl sx={{ my: 2 }}>

--- a/ui/app/src/components/AccountManagement/AccountManagement.tsx
+++ b/ui/app/src/components/AccountManagement/AccountManagement.tsx
@@ -14,11 +14,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Box from '@mui/material/Box';
-import React, { useEffect, useState } from 'react';
+import Box, { BoxProps } from '@mui/material/Box';
+import React, { forwardRef, useEffect, useId, useState } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import GlobalAppToolbar from '../GlobalAppToolbar';
-import { Typography } from '@mui/material';
+import { Checkbox, FormControlLabel, Typography } from '@mui/material';
 import Paper, { paperClasses } from '@mui/material/Paper';
 import Avatar from '@mui/material/Avatar';
 import Container from '@mui/material/Container';
@@ -47,8 +47,45 @@ import TableBody from '@mui/material/TableBody';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { preferencesGroups } from './utils';
+import { NumberField } from '@base-ui-components/react/number-field';
+import OutlinedInput, { OutlinedInputProps } from '@mui/material/OutlinedInput';
+import AddRounded from '@mui/icons-material/AddRounded';
+import MinusRounded from '@mui/icons-material/RemoveRounded';
 
 import { pushErrorDialog } from '../../utils/system';
+import {
+	getStoredEnableAnimations,
+	getStoredSnackbarDuration,
+	setStoredEnableAnimations,
+	setStoredSnackbarDuration
+} from '../../utils/state';
+
+const decrementButtonSx: BoxProps['sx'] = {
+	borderTopRightRadius: 0,
+	borderBottomRightRadius: 0,
+	boxShadow: 'none',
+	borderRight: 'none'
+};
+
+const incrementButtonSx: BoxProps['sx'] = {
+	borderTopLeftRadius: 0,
+	borderBottomLeftRadius: 0,
+	boxShadow: 'none',
+	borderLeft: 'none'
+};
+
+// MUI OutlinedInput's ref points to the wrapper elements, not to the input. Base UI needs the input directly.
+const OutlinedInputWithRef = forwardRef<HTMLInputElement, OutlinedInputProps>((props, ref) => {
+	const { sx, ...other } = props;
+	return (
+		<OutlinedInput
+			{...other}
+			fullWidth
+			inputRef={ref}
+			sx={{ borderRadius: 0, py: '0px', input: { textAlign: 'center' }, ...sx }}
+		/>
+	);
+});
 
 interface AccountManagementProps {
 	passwordRequirementsMinComplexity?: number;
@@ -65,6 +102,9 @@ const translations = defineMessages({
 	}
 });
 
+export const DEFAULT_SNACKBAR_DURATION = 5000;
+export const DEFAULT_ANIMATIONS_DURATION = 1000; // TODO: check what's the default value for animations duration
+
 export function AccountManagement(props: AccountManagementProps) {
 	const { passwordRequirementsMinComplexity = 4 } = props;
 	const user = useActiveUser();
@@ -80,6 +120,12 @@ export function AccountManagement(props: AccountManagementProps) {
 	const sitesLookup = useSiteLookup();
 	const sitesIds = Object.keys(sitesLookup);
 	const [selectedSite, setSelectedSite] = useState('all');
+	const [snackDuration, setSnackDuration] = useState<number | null>(
+		getStoredSnackbarDuration(user.username) ?? DEFAULT_SNACKBAR_DURATION
+	);
+	const [initialSnackDuration, setInitialSnackDuration] = useState<number | null>(snackDuration);
+	const [enableAnimations, setEnableAnimations] = useState<boolean>(getStoredEnableAnimations(user.username) ?? true);
+	const [initialEnableAnimations, setInitialEnableAnimations] = useState<boolean>(enableAnimations);
 
 	// Retrieve Platform Languages.
 	useEffect(() => {
@@ -139,6 +185,21 @@ export function AccountManagement(props: AccountManagementProps) {
 	const onClearEverything = () => {
 		preferencesGroups.forEach((group) => onClearPreference(group, false));
 		dispatch(showSystemNotification({ message: formatMessage({ defaultMessage: 'Preferences cleared' }) }));
+	};
+
+	const onSaveAccessibility = () => {
+		dispatch(
+			showSystemNotification({
+				message: formatMessage({ defaultMessage: 'Accessibility settings saved' }),
+				options: {
+					autoHideDuration: snackDuration
+				}
+			})
+		);
+		setStoredSnackbarDuration(user.username, snackDuration);
+		setInitialSnackDuration(snackDuration);
+		setStoredEnableAnimations(user.username, enableAnimations);
+		setInitialEnableAnimations(enableAnimations);
 	};
 
 	return (
@@ -318,6 +379,62 @@ export function AccountManagement(props: AccountManagementProps) {
 							</TableBody>
 						</Table>
 					</TableContainer>
+				</Paper>
+				<Paper>
+					<Typography variant="h5">
+						<FormattedMessage defaultMessage="Accessibility" />
+					</Typography>
+					<Box display="flex" flexDirection="column">
+						<FormControl sx={{ mt: 2, mb: 1 }}>
+							<Box display="flex" alignItems="center" justifyContent="space-between" mb={1}>
+								<InputLabel htmlFor="snackDuration" shrink sx={{ position: 'static', transform: 'none', mb: 0 }}>
+									<FormattedMessage defaultMessage="Snackbar duration (ms)" />
+								</InputLabel>
+								<Button
+									variant="text"
+									size="small"
+									disabled={snackDuration === DEFAULT_SNACKBAR_DURATION}
+									onClick={() => setSnackDuration(DEFAULT_SNACKBAR_DURATION)}
+								>
+									<FormattedMessage defaultMessage="Reset to default" />
+								</Button>
+							</Box>
+							<NumberField.Root
+								id="snackDuration"
+								value={snackDuration}
+								onValueChange={setSnackDuration}
+								min={0}
+								step={100}
+								format={{ maximumFractionDigits: 0 }}
+							>
+								<NumberField.Group render={<Box display="flex" />}>
+									<NumberField.Decrement render={<Button variant="outlined" sx={decrementButtonSx} />}>
+										<MinusRounded />
+									</NumberField.Decrement>
+									<NumberField.Input render={<OutlinedInputWithRef />} />
+									<NumberField.Increment render={<Button variant="outlined" sx={incrementButtonSx} />}>
+										<AddRounded />
+									</NumberField.Increment>
+								</NumberField.Group>
+							</NumberField.Root>
+						</FormControl>
+
+						<FormControl sx={{ my: 2 }}>
+							<FormControlLabel
+								control={
+									<Checkbox checked={enableAnimations} onChange={(e) => setEnableAnimations(e.target.checked)} />
+								}
+								label={<FormattedMessage defaultMessage="Enable animations" />}
+							/>
+						</FormControl>
+						<PrimaryButton
+							disabled={initialSnackDuration === snackDuration && initialEnableAnimations === enableAnimations}
+							sx={{ marginLeft: 'auto' }}
+							onClick={() => onSaveAccessibility()}
+						>
+							<FormattedMessage id="words.save" defaultMessage="Save" />
+						</PrimaryButton>
+					</Box>
 				</Paper>
 			</Container>
 

--- a/ui/app/src/components/AccountManagement/AccountManagement.tsx
+++ b/ui/app/src/components/AccountManagement/AccountManagement.tsx
@@ -86,6 +86,7 @@ const OutlinedInputWithRef = forwardRef<HTMLInputElement, OutlinedInputProps>((p
 		/>
 	);
 });
+OutlinedInputWithRef.displayName = 'OutlinedInputWithRef';
 
 interface AccountManagementProps {
 	passwordRequirementsMinComplexity?: number;

--- a/ui/app/src/components/AccountManagement/AccountManagement.tsx
+++ b/ui/app/src/components/AccountManagement/AccountManagement.tsx
@@ -15,7 +15,7 @@
  */
 
 import Box, { BoxProps } from '@mui/material/Box';
-import React, { forwardRef, useEffect, useId, useState } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import GlobalAppToolbar from '../GlobalAppToolbar';
 import { Checkbox, FormControlLabel, Typography } from '@mui/material';
@@ -187,6 +187,7 @@ export function AccountManagement(props: AccountManagementProps) {
 	};
 
 	const onSaveAccessibility = () => {
+		if (snackDuration === null) return;
 		dispatch(
 			showSystemNotification({
 				message: formatMessage({ defaultMessage: 'Accessibility settings saved' }),
@@ -403,6 +404,7 @@ export function AccountManagement(props: AccountManagementProps) {
 								value={snackDuration}
 								onValueChange={setSnackDuration}
 								min={0}
+								max={60000}
 								step={100}
 								format={{ maximumFractionDigits: 0 }}
 							>
@@ -427,7 +429,10 @@ export function AccountManagement(props: AccountManagementProps) {
 							/>
 						</FormControl>
 						<PrimaryButton
-							disabled={initialSnackDuration === snackDuration && initialEnableAnimations === enableAnimations}
+							disabled={
+								snackDuration === null ||
+								(initialSnackDuration === snackDuration && initialEnableAnimations === enableAnimations)
+							}
 							sx={{ marginLeft: 'auto' }}
 							onClick={() => onSaveAccessibility()}
 						>

--- a/ui/app/src/components/AccountManagement/AccountManagement.tsx
+++ b/ui/app/src/components/AccountManagement/AccountManagement.tsx
@@ -103,7 +103,6 @@ const translations = defineMessages({
 });
 
 export const DEFAULT_SNACKBAR_DURATION = 5000;
-export const DEFAULT_ANIMATIONS_DURATION = 1000; // TODO: check what's the default value for animations duration
 
 export function AccountManagement(props: AccountManagementProps) {
 	const { passwordRequirementsMinComplexity = 4 } = props;

--- a/ui/app/src/components/CrafterCMSNextBridge/CrafterCMSNextBridge.tsx
+++ b/ui/app/src/components/CrafterCMSNextBridge/CrafterCMSNextBridge.tsx
@@ -14,17 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
-	ElementType,
-	Fragment,
-	lazy,
-	PropsWithChildren,
-	ReactNode,
-	Suspense,
-	useEffect,
-	useLayoutEffect,
-	useState
-} from 'react';
+import React, { ElementType, Fragment, lazy, PropsWithChildren, ReactNode, Suspense, useLayoutEffect, useState } from 'react';
 import { ThemeOptions } from '@mui/material/styles';
 import { setRequestForgeryToken } from '../../utils/auth';
 import { CrafterCMSStore, getStore } from '../../state/store';
@@ -39,8 +29,7 @@ import LoadingState from '../LoadingState';
 import GlobalStyles from '../GlobalStyles';
 import ErrorState from '../ErrorState/ErrorState';
 import NotistackVariant from '../NotistackVariant';
-import { getStoredSnackbarDuration } from '../../utils/state';
-import { DEFAULT_SNACKBAR_DURATION } from '../AccountManagement';
+import useSnackbarDuration from '../../hooks/useSnackbarDuration';
 const LegacyConcierge = lazy(() => import('../LegacyConcierge/LegacyConcierge'));
 const GlobalDialogManager = lazy(() => import('../GlobalDialogManager/GlobalDialogManager'));
 
@@ -56,7 +45,7 @@ export function CrafterCMSNextBridge(
 ) {
 	const [store, setStore] = useState<CrafterCMSStore>(null);
 	const [storeError, setStoreError] = useState<string>();
-	const [autoHideDuration, setAutoHideDuration] = useState<number>(DEFAULT_SNACKBAR_DURATION);
+	const autoHideDuration = useSnackbarDuration();
 	const {
 		children,
 		themeOptions,
@@ -91,20 +80,6 @@ export function CrafterCMSNextBridge(
 		});
 	}, []);
 
-	useEffect(() => {
-		if (!store) {
-			return;
-		}
-		const user = store.getState().user;
-		if (!user?.username) {
-			return;
-		}
-
-		const storedDuration = getStoredSnackbarDuration(user.username);
-		if (storedDuration != null) {
-			setAutoHideDuration(storedDuration);
-		}
-	}, [store]);
 	return (
 		<CrafterThemeProvider themeOptions={themeOptions}>
 			<I18nProvider>

--- a/ui/app/src/components/CrafterCMSNextBridge/CrafterCMSNextBridge.tsx
+++ b/ui/app/src/components/CrafterCMSNextBridge/CrafterCMSNextBridge.tsx
@@ -21,6 +21,7 @@ import React, {
 	PropsWithChildren,
 	ReactNode,
 	Suspense,
+	useEffect,
 	useLayoutEffect,
 	useState
 } from 'react';
@@ -38,7 +39,8 @@ import LoadingState from '../LoadingState';
 import GlobalStyles from '../GlobalStyles';
 import ErrorState from '../ErrorState/ErrorState';
 import NotistackVariant from '../NotistackVariant';
-
+import { getStoredSnackbarDuration } from '../../utils/state';
+import { DEFAULT_SNACKBAR_DURATION } from '../AccountManagement';
 const LegacyConcierge = lazy(() => import('../LegacyConcierge/LegacyConcierge'));
 const GlobalDialogManager = lazy(() => import('../GlobalDialogManager/GlobalDialogManager'));
 
@@ -54,6 +56,7 @@ export function CrafterCMSNextBridge(
 ) {
 	const [store, setStore] = useState<CrafterCMSStore>(null);
 	const [storeError, setStoreError] = useState<string>();
+	const [autoHideDuration, setAutoHideDuration] = useState<number>(DEFAULT_SNACKBAR_DURATION);
 	const {
 		children,
 		themeOptions,
@@ -67,7 +70,7 @@ export function CrafterCMSNextBridge(
 	const snackbarOrFragmentProps = mountSnackbarProvider
 		? ({
 				maxSnack: 5,
-				autoHideDuration: 5000,
+				autoHideDuration: autoHideDuration,
 				anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
 				action: (id) => <SnackbarCloseButton id={id} />,
 				Components: {
@@ -87,6 +90,21 @@ export function CrafterCMSNextBridge(
 			error: (message) => setStoreError(message)
 		});
 	}, []);
+
+	useEffect(() => {
+		if (!store) {
+			return;
+		}
+		const user = store.getState().user;
+		if (!user?.username) {
+			return;
+		}
+
+		const storedDuration = getStoredSnackbarDuration(user.username);
+		if (storedDuration != null) {
+			setAutoHideDuration(storedDuration);
+		}
+	}, [store]);
 	return (
 		<CrafterThemeProvider themeOptions={themeOptions}>
 			<I18nProvider>

--- a/ui/app/src/components/CrafterThemeProvider/CrafterThemeProvider.tsx
+++ b/ui/app/src/components/CrafterThemeProvider/CrafterThemeProvider.tsx
@@ -37,19 +37,19 @@ muiCache.compat = true;
 export function CrafterThemeProvider(props: CrafterThemeProviderProps) {
 	const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 	const enableAnimations = useEnableAnimations();
-	
+
 	const theme = useMemo(() => {
 		const mode = prefersDarkMode ? 'dark' : 'light';
 		const auxTheme = createTheme({ palette: { mode } });
 		const defaultThemeOptions = createDefaultThemeOptions({ mode });
 		return createTheme({
+			...(props.themeOptions ?? defaultThemeOptions),
 			// Animations: Disable MUI JavaScript/CSS transition helpers
 			...(!enableAnimations && {
 				transitions: {
 					create: () => 'none'
 				}
 			}),
-			...(props.themeOptions ?? defaultThemeOptions),
 			palette: {
 				mode,
 				primary: {
@@ -96,9 +96,9 @@ export function CrafterThemeProvider(props: CrafterThemeProviderProps) {
 					// Animations: Disable interactive ripple effects globally
 					...(!enableAnimations && {
 						defaultProps: {
-							disableRipple: true,
+							disableRipple: true
 						}
-					}),
+					})
 				},
 				MuiInputBase: {
 					styleOverrides: {

--- a/ui/app/src/components/CrafterThemeProvider/CrafterThemeProvider.tsx
+++ b/ui/app/src/components/CrafterThemeProvider/CrafterThemeProvider.tsx
@@ -22,6 +22,7 @@ import palette from '../../styles/palette';
 import { deepmerge } from '@mui/utils';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
+import useEnableAnimations from '../../hooks/useEnableAnimations';
 
 export type CrafterThemeProviderProps = PropsWithChildren<{ themeOptions?: ThemeOptions }>;
 
@@ -35,11 +36,19 @@ muiCache.compat = true;
 
 export function CrafterThemeProvider(props: CrafterThemeProviderProps) {
 	const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+	const enableAnimations = useEnableAnimations();
+	
 	const theme = useMemo(() => {
 		const mode = prefersDarkMode ? 'dark' : 'light';
 		const auxTheme = createTheme({ palette: { mode } });
 		const defaultThemeOptions = createDefaultThemeOptions({ mode });
 		return createTheme({
+			// Animations: Disable MUI JavaScript/CSS transition helpers
+			...(!enableAnimations && {
+				transitions: {
+					create: () => 'none'
+				}
+			}),
 			...(props.themeOptions ?? defaultThemeOptions),
 			palette: {
 				mode,
@@ -83,16 +92,35 @@ export function CrafterThemeProvider(props: CrafterThemeProviderProps) {
 						}
 					}
 				},
+				MuiButtonBase: {
+					// Animations: Disable interactive ripple effects globally
+					...(!enableAnimations && {
+						defaultProps: {
+							disableRipple: true,
+						}
+					}),
+				},
 				MuiInputBase: {
 					styleOverrides: {
 						root: {
 							backgroundColor: auxTheme.palette.background.paper
 						}
 					}
+				},
+				// Animations: Force-disable pure CSS transitions and animations
+				MuiCssBaseline: {
+					...(!enableAnimations && {
+						styleOverrides: {
+							'*, *::before, *::after': {
+								transition: 'none !important',
+								animation: 'none !important'
+							}
+						}
+					})
 				}
 			})
 		});
-	}, [prefersDarkMode, props.themeOptions]);
+	}, [prefersDarkMode, props.themeOptions, enableAnimations]);
 	return (
 		<CacheProvider value={muiCache}>
 			<ThemeProvider theme={theme} children={props.children} />

--- a/ui/app/src/components/LoadingState/LoadingState.tsx
+++ b/ui/app/src/components/LoadingState/LoadingState.tsx
@@ -42,10 +42,6 @@ export type ConditionalLoadingStateProps = LoadingStateProps & PropsWithChildren
 export function LoadingState(props: LoadingStateProps) {
 	const { graphic: Graphic = Gears, classes, revealTimeout = 300, sxs } = props;
 	const [reveal, setReveal] = useState(revealTimeout === 0);
-	// LoadingState is used outside of the StoreProvider, so we need to get the enableAnimations from localStorage.
-	const username = localStorage.getItem('username');
-	const enableAnimations = username ? getStoredEnableAnimations(username) : true;
-
 	useEffect(() => {
 		const timeout = setTimeout(() => {
 			setReveal(true);
@@ -105,12 +101,7 @@ export function LoadingState(props: LoadingStateProps) {
 					...sxs?.graphicRoot
 				}}
 			>
-				<Graphic
-					className={classes?.graphic}
-					sxs={{ root: { width: 120, ...sxs?.graphic } }}
-					{...props.graphicProps}
-					enableAnimations={enableAnimations}
-				/>
+				<Graphic className={classes?.graphic} sxs={{ root: { width: 120, ...sxs?.graphic } }} {...props.graphicProps} />
 			</Box>
 		</Box>
 	);

--- a/ui/app/src/components/LoadingState/LoadingState.tsx
+++ b/ui/app/src/components/LoadingState/LoadingState.tsx
@@ -22,6 +22,7 @@ import Box from '@mui/material/Box';
 import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material/styles';
 import { consolidateSx } from '../../utils/system';
+import { getStoredEnableAnimations } from '../../utils/state';
 
 type LoadingStateClassKey = 'root' | 'title' | 'subtitle' | 'graphic' | 'graphicRoot';
 
@@ -41,6 +42,10 @@ export type ConditionalLoadingStateProps = LoadingStateProps & PropsWithChildren
 export function LoadingState(props: LoadingStateProps) {
 	const { graphic: Graphic = Gears, classes, revealTimeout = 300, sxs } = props;
 	const [reveal, setReveal] = useState(revealTimeout === 0);
+	// LoadingState is used outside of the StoreProvider, so we need to get the enableAnimations from localStorage.
+	const username = localStorage.getItem('username');
+	const enableAnimations = username ? getStoredEnableAnimations(username) : true;
+
 	useEffect(() => {
 		const timeout = setTimeout(() => {
 			setReveal(true);
@@ -100,7 +105,12 @@ export function LoadingState(props: LoadingStateProps) {
 					...sxs?.graphicRoot
 				}}
 			>
-				<Graphic className={classes?.graphic} sxs={{ root: { width: 120, ...sxs?.graphic } }} {...props.graphicProps} />
+				<Graphic
+					className={classes?.graphic}
+					sxs={{ root: { width: 120, ...sxs?.graphic } }}
+					{...props.graphicProps}
+					enableAnimations={enableAnimations}
+				/>
 			</Box>
 		</Box>
 	);

--- a/ui/app/src/components/LoadingState/LoadingState.tsx
+++ b/ui/app/src/components/LoadingState/LoadingState.tsx
@@ -22,7 +22,6 @@ import Box from '@mui/material/Box';
 import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material/styles';
 import { consolidateSx } from '../../utils/system';
-import { getStoredEnableAnimations } from '../../utils/state';
 
 type LoadingStateClassKey = 'root' | 'title' | 'subtitle' | 'graphic' | 'graphicRoot';
 

--- a/ui/app/src/hooks/useEnableAnimations.ts
+++ b/ui/app/src/hooks/useEnableAnimations.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getStoredEnableAnimations, subscribeEnableAnimations } from '../utils/state';
+import { useSyncExternalStore } from 'react';
+
+export function useEnableAnimations(): boolean {
+	// useEnableAnimations is used outside of the StoreProvider, so we need to get the enableAnimations from localStorage.
+	const username = typeof window !== 'undefined' ? localStorage.getItem('username') : null;
+	return useSyncExternalStore(
+		subscribeEnableAnimations,
+		() => getStoredEnableAnimations(username) ?? true,
+		() => true
+	);
+}
+
+export default useEnableAnimations;

--- a/ui/app/src/hooks/useEnableAnimations.ts
+++ b/ui/app/src/hooks/useEnableAnimations.ts
@@ -22,7 +22,7 @@ export function useEnableAnimations(): boolean {
 	const username = typeof window !== 'undefined' ? localStorage.getItem('username') : null;
 	return useSyncExternalStore(
 		subscribeEnableAnimations,
-		() => getStoredEnableAnimations(username) ?? true,
+		() => (username ? (getStoredEnableAnimations(username) ?? true) : true),
 		() => true
 	);
 }

--- a/ui/app/src/hooks/useSnackbarDuration.ts
+++ b/ui/app/src/hooks/useSnackbarDuration.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DEFAULT_SNACKBAR_DURATION } from '../components/AccountManagement';
+import { getStoredSnackbarDuration, subscribeSnackbarDuration } from '../utils/state';
+import { useSyncExternalStore } from 'react';
+
+export function useSnackbarDuration(): number {
+	const username = typeof window !== 'undefined' ? localStorage.getItem('username') : null;
+	return useSyncExternalStore(
+		subscribeSnackbarDuration,
+		() => (username ? (getStoredSnackbarDuration(username) ?? DEFAULT_SNACKBAR_DURATION) : DEFAULT_SNACKBAR_DURATION),
+		() => DEFAULT_SNACKBAR_DURATION
+	);
+}
+
+export default useSnackbarDuration;

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -520,7 +520,7 @@ export function setStoredSnackbarDuration(user: string, value: number) {
 
 export function getStoredSnackbarDuration(user: string): number | null {
 	const value = window.localStorage.getItem(`craftercms.${user}.snackbarDuration`);
-	return value ? parseInt(value) : null;
+	return value ? parseInt(value, 10) : null;
 }
 
 export function removeStoredSnackbarDuration(user: string) {

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -513,3 +513,39 @@ export function getViewGroupedTypes(user: string): boolean {
 export function removeViewGroupedTypes(user: string) {
 	window.localStorage.removeItem(`craftercms.${user}.viewGroupedTypes`);
 }
+
+export function setStoredSnackbarDuration(user: string, value: number) {
+	window.localStorage.setItem(`craftercms.${user}.snackbarDuration`, value.toString());
+}
+
+export function getStoredSnackbarDuration(user: string): number | null {
+	const value = window.localStorage.getItem(`craftercms.${user}.snackbarDuration`);
+	return value ? parseInt(value) : null;
+}
+
+export function removeStoredSnackbarDuration(user: string) {
+	window.localStorage.removeItem(`craftercms.${user}.snackbarDuration`);
+}
+
+const ENABLE_ANIMATIONS_CHANGED = 'craftercms:enableAnimationsChanged';
+export function subscribeEnableAnimations(onStoreChange: () => void) {
+	window.addEventListener(ENABLE_ANIMATIONS_CHANGED, onStoreChange);
+	window.addEventListener('storage', onStoreChange); // other tabs
+	return () => {
+		window.removeEventListener(ENABLE_ANIMATIONS_CHANGED, onStoreChange);
+		window.removeEventListener('storage', onStoreChange);
+	};
+}
+export function setStoredEnableAnimations(user: string, value: boolean) {
+	window.localStorage.setItem(`craftercms.${user}.enableAnimations`, JSON.stringify(value));
+	window.dispatchEvent(new CustomEvent(ENABLE_ANIMATIONS_CHANGED, { detail: { user, value } }));
+}
+
+export function getStoredEnableAnimations(user: string): boolean | null {
+	const value = window.localStorage.getItem(`craftercms.${user}.enableAnimations`);
+	return value ? value === 'true' : null;
+}
+
+export function removeStoredEnableAnimations(user: string) {
+	window.localStorage.removeItem(`craftercms.${user}.enableAnimations`);
+}

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -530,10 +530,16 @@ export function removeStoredSnackbarDuration(user: string) {
 const ENABLE_ANIMATIONS_CHANGED = 'craftercms:enableAnimationsChanged';
 export function subscribeEnableAnimations(onStoreChange: () => void) {
 	window.addEventListener(ENABLE_ANIMATIONS_CHANGED, onStoreChange);
-	window.addEventListener('storage', onStoreChange); // other tabs
+	const storageListener = (e: StorageEvent) => {
+		// Filter by key to avoid listening to other localStorage changes
+		if (e.key?.includes('.enableAnimations')) {
+			onStoreChange();
+		}
+	};
+	window.addEventListener('storage', storageListener);
 	return () => {
 		window.removeEventListener(ENABLE_ANIMATIONS_CHANGED, onStoreChange);
-		window.removeEventListener('storage', onStoreChange);
+		window.removeEventListener('storage', storageListener);
 	};
 }
 export function setStoredEnableAnimations(user: string, value: boolean) {

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -514,8 +514,23 @@ export function removeViewGroupedTypes(user: string) {
 	window.localStorage.removeItem(`craftercms.${user}.viewGroupedTypes`);
 }
 
+const SNACKBAR_DURATION_CHANGED = 'craftercms:snackbarDurationChanged';
+export function subscribeSnackbarDuration(onStoreChange: () => void) {
+	window.addEventListener(SNACKBAR_DURATION_CHANGED, onStoreChange);
+	const storageListener = (e: StorageEvent) => {
+		if (e.key?.includes('.snackbarDuration')) {
+			onStoreChange();
+		}
+	};
+	window.addEventListener('storage', storageListener);
+	return () => {
+		window.removeEventListener(SNACKBAR_DURATION_CHANGED, onStoreChange);
+		window.removeEventListener('storage', storageListener);
+	};
+}
 export function setStoredSnackbarDuration(user: string, value: number) {
 	window.localStorage.setItem(`craftercms.${user}.snackbarDuration`, value.toString());
+	window.dispatchEvent(new CustomEvent(SNACKBAR_DURATION_CHANGED, { detail: { user, value } }));
 }
 
 export function getStoredSnackbarDuration(user: string): number | null {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8221
https://github.com/craftercms/craftercms/issues/8222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accessibility section in Account Management: set snackbar auto-hide duration, reset to default, toggle animations, and save changes.
  * Saving shows a confirmation notification using the chosen duration; settings persist per user and apply across sessions.

* **Improvements**
  * Animation and snackbar duration preferences are applied app-wide (including notifications) and synchronized across tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->