### PR TITLE
[8723] Handle errors when trying to paste an item in an invalid location for its content type

### DIFF
--- a/ui/app/src/components/ErrorState/ErrorState.tsx
+++ b/ui/app/src/components/ErrorState/ErrorState.tsx
@@ -93,7 +93,7 @@ export function ErrorState(props: ErrorStateProps) {
 					sx={{
 						textAlign: 'center',
 						marginBottom: (theme) => theme.spacing(1),
-						wordBreak: 'break-all',
+						wordBreak: 'break-word',
 						...sxs?.message
 					}}
 					children={message}

--- a/ui/app/src/state/epics/content.ts
+++ b/ui/app/src/state/epics/content.ts
@@ -441,7 +441,7 @@ const content: CrafterCMSEpic[] = [
 							() => unblockUI(),
 							(error) => {
 								const responseCode = error.response?.code;
-								if (responseCode === 1001) {
+								if (responseCode === 56001) {
 									const item = state.content.itemsByPath[state.content.clipboard.sourcePath];
 									const sourceContentType = item?.contentTypeId;
 									return pushErrorDialog({

--- a/ui/app/src/state/epics/content.ts
+++ b/ui/app/src/state/epics/content.ts
@@ -439,7 +439,37 @@ const content: CrafterCMSEpic[] = [
 						map(() => batchActions([unblockUI(), clearClipboard(), showPasteItemSuccessNotification()])),
 						catchAjaxError(
 							() => unblockUI(),
-							(error) => pushErrorDialog({ props: { error: error.response } })
+							(error) => {
+								const responseCode = error.response.code;
+								if (responseCode === 56001) {
+									const item = state.content.itemsByPath[state.content.clipboard.sourcePath];
+									const sourceContentType = item?.contentTypeId;
+									return pushErrorDialog({
+										props: {
+											error: {
+												message: getIntl().formatMessage(
+													{ defaultMessage: 'Cannot copy "{sourceLabel}" to "{targetPath}".' },
+													{
+														sourceLabel: item?.label ?? state.content.clipboard.sourcePath,
+														targetPath: payload.path
+													}
+												),
+												remedialAction: getIntl().formatMessage(
+													{
+														defaultMessage:
+															'Content type "{contentType}" of the source item is not allowed in the target location.'
+													},
+													{
+														contentType: sourceContentType
+													}
+												)
+											}
+										}
+									});
+								} else {
+									return pushErrorDialog({ props: { error: error.response } });
+								}
+							}
 						)
 					)
 				)

--- a/ui/app/src/state/epics/content.ts
+++ b/ui/app/src/state/epics/content.ts
@@ -42,7 +42,7 @@ import {
 	reloadContentItem,
 	unlockItem
 } from '../actions/content';
-import { catchAjaxError } from '../../utils/ajax';
+import { catchAjaxError, extractErrorPayload } from '../../utils/ajax';
 import {
 	duplicate,
 	fetchContentItem as fetchContentItemService,
@@ -440,8 +440,8 @@ const content: CrafterCMSEpic[] = [
 						catchAjaxError(
 							() => unblockUI(),
 							(error) => {
-								const responseCode = error.response.code;
-								if (responseCode === 56001) {
+								const responseCode = error.response?.code;
+								if (responseCode === 1001) {
 									const item = state.content.itemsByPath[state.content.clipboard.sourcePath];
 									const sourceContentType = item?.contentTypeId;
 									return pushErrorDialog({
@@ -454,20 +454,22 @@ const content: CrafterCMSEpic[] = [
 														targetPath: payload.path
 													}
 												),
-												remedialAction: getIntl().formatMessage(
-													{
-														defaultMessage:
-															'Content type "{contentType}" of the source item is not allowed in the target location.'
-													},
-													{
-														contentType: sourceContentType
-													}
-												)
+												remedialAction: sourceContentType
+													? getIntl().formatMessage(
+															{
+																defaultMessage:
+																	'Content type "{contentType}" of the source item is not allowed in the target location.'
+															},
+															{
+																contentType: sourceContentType
+															}
+														)
+													: undefined
 											}
 										}
 									});
 								} else {
-									return pushErrorDialog({ props: { error: error.response } });
+									return pushErrorDialog({ props: { error: extractErrorPayload(error as AjaxError) } });
 								}
 							}
 						)

--- a/ui/app/src/state/epics/content.ts
+++ b/ui/app/src/state/epics/content.ts
@@ -42,7 +42,7 @@ import {
 	reloadContentItem,
 	unlockItem
 } from '../actions/content';
-import { catchAjaxError, extractErrorPayload } from '../../utils/ajax';
+import { catchAjaxError } from '../../utils/ajax';
 import {
 	duplicate,
 	fetchContentItem as fetchContentItemService,

--- a/ui/app/src/state/epics/content.ts
+++ b/ui/app/src/state/epics/content.ts
@@ -42,7 +42,7 @@ import {
 	reloadContentItem,
 	unlockItem
 } from '../actions/content';
-import { catchAjaxError } from '../../utils/ajax';
+import { catchAjaxError, extractErrorPayload } from '../../utils/ajax';
 import {
 	duplicate,
 	fetchContentItem as fetchContentItemService,

--- a/ui/app/src/state/epics/mappedDialogs.ts
+++ b/ui/app/src/state/epics/mappedDialogs.ts
@@ -131,7 +131,6 @@ const dialogsMap = {
 	[showRenameAssetDialog.type]: 'craftercms.components.RenameAssetDialog',
 	[showDeleteDialog.type]: 'craftercms.components.DeleteDialog',
 	[showEditDialog.type]: 'craftercms.components.LegacyFormDialog',
-	[blockUI.type]: 'craftercms.components.UIBlocker',
 	[showFolderMoveAlertDialog.type]: 'craftercms.components.FolderMoveAlertDialog'
 };
 
@@ -274,29 +273,6 @@ const showDialogsEpics: CrafterCMSEpic[] = [
 			})
 		),
 	// endregion
-
-	// region UIBlocker
-	(action$, state$) =>
-		action$.pipe(
-			ofType(blockUI.type),
-			withLatestFrom(state$),
-			map(([{ payload, type }]) => {
-				return pushDialog({
-					id: blockUI.type,
-					component: dialogsMap[type],
-					props: payload
-				});
-			})
-		),
-	(action$, state$) =>
-		action$.pipe(
-			ofType(unblockUI.type),
-			withLatestFrom(state$),
-			map(() => {
-				return popDialog({ id: blockUI.type });
-			})
-		)
-	// end region
 ] as CrafterCMSEpic[];
 
 export default showDialogsEpics;

--- a/ui/app/src/state/epics/mappedDialogs.ts
+++ b/ui/app/src/state/epics/mappedDialogs.ts
@@ -99,7 +99,6 @@ import { generateDialogId } from '../../utils/dialogs';
 import { updatePublishingStatus } from '../actions/publishingStatus';
 import { DialogStackItem, StandardAction } from '../../models';
 import { createCallback, type EnhancedDialogProps } from '../../components';
-import { blockUI, unblockUI } from '../actions/system';
 import { NEVER } from 'rxjs';
 
 const dialogsMap = {


### PR DESCRIPTION
The error handler was correct, but the block/unblock UI actions were added to the new dialogs system, so the showing/removal wasn't working as expected in this scenario (and probably others).

Added error handling for this scenario, for the error message to be clear to the user.

This PR https://github.com/craftercms/studio/pull/3956 is needed for the error code handling to work properly.

https://github.com/craftercms/craftercms/issues/8723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Improved how error messages wrap by adjusting text-breaking behavior for longer or unbroken content.

* **Bug Fixes**
  * Enhanced clipboard error handling by displaying a more specific, destination-clarifying message for a particular error code, with an improved fallback for other errors.

* **Refactor**
  * Removed the UI-blocking dialog flow and its related dialog-mapping/state handling to streamline dialog management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->