### PR TITLE
[5424] Remove delete user, updates to enable/disable users

### DIFF
--- a/ui/app/src/CHANGELOG.md
+++ b/ui/app/src/CHANGELOG.md
@@ -68,6 +68,7 @@
   * [RenameContentDialogContainer] Updated `dependantItems` prop to be of type `LightItem[]`.
   * [RenameItemView] Updated `dependantItems` prop to be of type `LightItem[]`.
   * Removed `CopyDialog` component.
+[UserManagement] Removed delete user functionality. Only `enable`/`disable` users is allowed.
 * [hooks]
   * Removed `useLogicResource` hook.
   * Removed `useSelectorResource` hook.
@@ -120,6 +121,7 @@
   * Updated `dependencies/fetchSimpleDependencies` to use API v2 (`/studio/api/2/dependency/{siteId}/dependencies`)
   * Updated `dependencies/fetchDependant` to use API v2 (`/studio/api/2/dependency/{siteId}/dependent_items`)
   * Removed `content/fetchLegacyItemsTree` service.
+  * Removed `users/trash` service.
 * `PublishingItem` interface changes:
   * `approver` is now `reviewer`, of type Person.
   * `comment` is removed, and now there's `reviewerComment` and `submitterComment`.

--- a/ui/app/src/CHANGELOG.md
+++ b/ui/app/src/CHANGELOG.md
@@ -69,7 +69,7 @@
   * [RenameItemView] Updated `dependantItems` prop to be of type `LightItem[]`.
   * Removed `CopyDialog` component.
   * [TypeList] Added `disableSelected` prop.
-[UserManagement] Removed delete user functionality. Only `enable`/`disable` users is allowed.
+  * [UserManagement] Removed delete user functionality. Only `enable`/`disable` users is allowed.
 * [hooks]
   * Removed `useLogicResource` hook.
   * Removed `useSelectorResource` hook.

--- a/ui/app/src/components/AccountManagement/utils.tsx
+++ b/ui/app/src/components/AccountManagement/utils.tsx
@@ -39,7 +39,8 @@ import {
 	removeCompareVersionDialogViewModes,
 	removeViewVersionDialogViewModes,
 	removeTypeViewCompactMode,
-	removeViewGroupedTypes
+	removeViewGroupedTypes,
+	removeStoredShowDisabledUsers
 } from '../../utils/state';
 
 export const preferencesGroups: Array<{
@@ -140,6 +141,7 @@ export const preferencesGroups: Array<{
 			removeViewVersionDialogViewModes(props.username);
 			removeTypeViewCompactMode(props.username);
 			removeViewGroupedTypes(props.username);
+			removeStoredShowDisabledUsers(props.username);
 		}
 	}
 ];

--- a/ui/app/src/components/EditUserDialog/EditUserDialogContainer.tsx
+++ b/ui/app/src/components/EditUserDialog/EditUserDialogContainer.tsx
@@ -19,7 +19,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import User from '../../models/User';
 import React, { useEffect, useMemo, useState } from 'react';
 import LookupTable from '../../models/LookupTable';
-import { disable, enable, fetchRolesBySite, trash, update } from '../../services/users';
+import { disable, enable, fetchRolesBySite, update } from '../../services/users';
 import { showSystemNotification } from '../../state/actions/system';
 import { EditUserDialogUI } from './EditUserDialogUI';
 import { useSpreadState } from '../../hooks/useSpreadState';
@@ -100,6 +100,7 @@ export function EditUserDialogContainer(props: EditUserDialogContainerProps) {
 							message: formatMessage(translations.userEnabled)
 						})
 					);
+					fnRefs.current.onUserEdited();
 				},
 				error({ response: { response } }) {
 					dispatch(pushErrorDialog({ props: { error: response } }));
@@ -113,6 +114,7 @@ export function EditUserDialogContainer(props: EditUserDialogContainerProps) {
 							message: formatMessage(translations.userDisabled)
 						})
 					);
+					fnRefs.current.onUserEdited();
 				},
 				error({ response: { response } }) {
 					dispatch(pushErrorDialog({ props: { error: response } }));
@@ -151,23 +153,6 @@ export function EditUserDialogContainer(props: EditUserDialogContainerProps) {
 		});
 	};
 
-	const onDelete = (username: string) => {
-		trash(username).subscribe({
-			next() {
-				onClose(null, null);
-				dispatch(
-					showSystemNotification({
-						message: formatMessage(translations.userDeleted)
-					})
-				);
-				fnRefs.current.onUserEdited();
-			},
-			error({ response: { response } }) {
-				dispatch(pushErrorDialog({ props: { error: response } }));
-			}
-		});
-	};
-
 	const onCloseResetPasswordDialog = () => {
 		setOpenResetPassword(false);
 	};
@@ -198,10 +183,10 @@ export function EditUserDialogContainer(props: EditUserDialogContainerProps) {
 		setSubmitOk(
 			Boolean(
 				user.firstName.trim() &&
-					!validateFieldMinLength('firstName', user.firstName) &&
-					user.lastName.trim() &&
-					!validateFieldMinLength('lastName', user.lastName) &&
-					!isInvalidEmail(user.email)
+				!validateFieldMinLength('firstName', user.firstName) &&
+				user.lastName.trim() &&
+				!validateFieldMinLength('lastName', user.lastName) &&
+				!isInvalidEmail(user.email)
 			)
 		);
 	}, [user, refs]);
@@ -223,7 +208,6 @@ export function EditUserDialogContainer(props: EditUserDialogContainerProps) {
 			passwordRequirementsMinComplexity={passwordRequirementsMinComplexity}
 			onSave={onSave}
 			onCloseButtonClick={(e) => onClose(e, null)}
-			onDelete={onDelete}
 			onCloseResetPasswordDialog={onCloseResetPasswordDialog}
 			onInputChange={onInputChange}
 			onEnableChange={onEnableChange}

--- a/ui/app/src/components/EditUserDialog/EditUserDialogContainer.tsx
+++ b/ui/app/src/components/EditUserDialog/EditUserDialogContainer.tsx
@@ -32,10 +32,6 @@ import { pushErrorDialog } from '../../utils/system';
 import { useEnhancedDialogContext } from '../EnhancedDialog';
 
 const translations = defineMessages({
-	userDeleted: {
-		id: 'userInfoDialog.userDeleted',
-		defaultMessage: 'User deleted successfully'
-	},
 	userUpdated: {
 		id: 'userInfoDialog.userUpdated',
 		defaultMessage: 'User updated successfully'

--- a/ui/app/src/components/EditUserDialog/EditUserDialogUI.tsx
+++ b/ui/app/src/components/EditUserDialog/EditUserDialogUI.tsx
@@ -61,18 +61,6 @@ const translations = defineMessages({
 		id: 'words.roles',
 		defaultMessage: 'Roles'
 	},
-	confirmHelperText: {
-		id: 'userInfoDialog.helperText',
-		defaultMessage: 'Delete user "{username}"?'
-	},
-	confirmOk: {
-		id: 'words.yes',
-		defaultMessage: 'Yes'
-	},
-	confirmCancel: {
-		id: 'words.no',
-		defaultMessage: 'No'
-	},
 	invalidMinLength: {
 		id: 'userInfoDialog.invalidMinLength',
 		defaultMessage: 'Min {length} characters'

--- a/ui/app/src/components/EditUserDialog/EditUserDialogUI.tsx
+++ b/ui/app/src/components/EditUserDialog/EditUserDialogUI.tsx
@@ -95,7 +95,6 @@ export function EditUserDialogUI(props: EditUserDialogUIProps) {
 		passwordRequirementsMinComplexity,
 		onSave,
 		onCloseButtonClick,
-		onDelete,
 		onCloseResetPasswordDialog,
 		onInputChange,
 		onEnableChange,
@@ -130,18 +129,6 @@ export function EditUserDialogUI(props: EditUserDialogUIProps) {
 									<PasswordRoundedIcon />
 								</IconButton>
 							</Tooltip>
-							<ConfirmDropdown
-								cancelText={formatMessage(translations.confirmCancel)}
-								confirmText={formatMessage(translations.confirmOk)}
-								confirmHelperText={formatMessage(translations.confirmHelperText, {
-									username: user.username
-								})}
-								iconTooltip={<FormattedMessage id="userInfoDialog.deleteUser" defaultMessage="Delete user" />}
-								icon={DeleteRoundedIcon}
-								onConfirm={() => {
-									onDelete(user.username);
-								}}
-							/>
 						</>
 					) : (
 						<Chip

--- a/ui/app/src/components/EditUserDialog/EditUserDialogUI.tsx
+++ b/ui/app/src/components/EditUserDialog/EditUserDialogUI.tsx
@@ -20,8 +20,6 @@ import Typography from '@mui/material/Typography';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import PasswordRoundedIcon from '@mui/icons-material/VpnKeyRounded';
-import ConfirmDropdown from '../ConfirmDropdown';
-import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import Divider from '@mui/material/Divider';
 import DialogBody from '../DialogBody/DialogBody';

--- a/ui/app/src/components/EditUserDialog/utils.ts
+++ b/ui/app/src/components/EditUserDialog/utils.ts
@@ -30,8 +30,7 @@ export interface EditUserDialogProps extends EditUserBaseProps, EnhancedDialogPr
 }
 
 export interface EditUserDialogContainerProps
-	extends EditUserBaseProps,
-		Pick<EditUserDialogProps, 'onClose' | 'isSubmitting' | 'onUserEdited' | 'open'> {}
+	extends EditUserBaseProps, Pick<EditUserDialogProps, 'onClose' | 'isSubmitting' | 'onUserEdited' | 'open'> {}
 
 export interface EditUserDialogUIProps {
 	user: User;
@@ -48,6 +47,5 @@ export interface EditUserDialogUIProps {
 	onSave(): void;
 	onCloseButtonClick?(e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void;
 	onCloseResetPasswordDialog(): void;
-	onDelete(username: string): void;
 	onResetPassword(value: boolean): void;
 }

--- a/ui/app/src/components/UserManagement/UserManagement.tsx
+++ b/ui/app/src/components/UserManagement/UserManagement.tsx
@@ -54,9 +54,9 @@ export function UserManagement(props: UserManagementProps) {
 	const searchInpuRef = useRef(undefined);
 
 	const fetchUsers = useCallback(
-		(keyword = '', _offset = offset) => {
+		(searchKeyword = keyword, _offset = offset, _showDisabled = showDisabled) => {
 			setFetching(true);
-			return fetchAll({ limit, offset: _offset, keyword, showDisabled }).subscribe({
+			return fetchAll({ limit, offset: _offset, keyword: searchKeyword, showDisabled: _showDisabled }).subscribe({
 				next(users) {
 					setUsers(users);
 					setError(null);
@@ -129,7 +129,6 @@ export function UserManagement(props: UserManagementProps) {
 		setShowDisabled(checked);
 		setStoredShowDisabledUsers(user.username, checked);
 		setOffset(0);
-		fetchUsers(keyword, 0);
 	};
 
 	return (

--- a/ui/app/src/components/UserManagement/UserManagement.tsx
+++ b/ui/app/src/components/UserManagement/UserManagement.tsx
@@ -33,6 +33,8 @@ import { useEnhancedDialogState } from '../../hooks/useEnhancedDialogState';
 import { useWithPendingChangesCloseRequest } from '../../hooks/useWithPendingChangesCloseRequest';
 import { ApiResponseErrorState } from '../ApiResponseErrorState';
 import { EmptyState } from '../EmptyState';
+import { useActiveUser } from '../../hooks/useActiveUser';
+import { getStoredShowDisabledUsers, setStoredShowDisabledUsers } from '../../utils/state';
 
 export interface UserManagementProps {
 	passwordRequirementsMinComplexity?: number;
@@ -47,12 +49,15 @@ export function UserManagement(props: UserManagementProps) {
 	const [error, setError] = useState<ApiResponse | null>(null);
 	const [viewUser, setViewUser] = useState<User | null>(null);
 	const [keyword, setKeyword] = useState('');
+	const user = useActiveUser();
+	const [showDisabled, setShowDisabled] = useState(getStoredShowDisabledUsers(user.username));
+	const showDisabledRef = useRef(showDisabled);
 	const searchInpuRef = useRef(undefined);
 
 	const fetchUsers = useCallback(
 		(keyword = '', _offset = offset) => {
 			setFetching(true);
-			return fetchAll({ limit, offset: _offset, keyword }).subscribe({
+			return fetchAll({ limit, offset: _offset, keyword, showDisabled: showDisabledRef.current }).subscribe({
 				next(users) {
 					setUsers(users);
 					setError(null);
@@ -121,6 +126,14 @@ export function UserManagement(props: UserManagementProps) {
 		onSearch$.next(keyword);
 	}
 
+	const onShowDisabledChange = (checked: boolean) => {
+		showDisabledRef.current = checked;
+		setShowDisabled(checked);
+		setStoredShowDisabledUsers(user.username, checked);
+		setOffset(0);
+		fetchUsers(keyword, 0);
+	};
+
 	return (
 		<Paper elevation={0}>
 			<GlobalAppToolbar
@@ -165,6 +178,8 @@ export function UserManagement(props: UserManagementProps) {
 						onRowClicked={onRowClicked}
 						onPageChange={onPageChange}
 						onRowsPerPageChange={onRowsPerPageChange}
+						showDisabled={showDisabled}
+						onShowDisabledChange={onShowDisabledChange}
 					/>
 				) : (
 					<EmptyState title={<FormattedMessage id="usersGrid.emptyStateMessage" defaultMessage="No Users Found" />} />

--- a/ui/app/src/components/UserManagement/UserManagement.tsx
+++ b/ui/app/src/components/UserManagement/UserManagement.tsx
@@ -51,13 +51,12 @@ export function UserManagement(props: UserManagementProps) {
 	const [keyword, setKeyword] = useState('');
 	const user = useActiveUser();
 	const [showDisabled, setShowDisabled] = useState(getStoredShowDisabledUsers(user.username));
-	const showDisabledRef = useRef(showDisabled);
 	const searchInpuRef = useRef(undefined);
 
 	const fetchUsers = useCallback(
 		(keyword = '', _offset = offset) => {
 			setFetching(true);
-			return fetchAll({ limit, offset: _offset, keyword, showDisabled: showDisabledRef.current }).subscribe({
+			return fetchAll({ limit, offset: _offset, keyword, showDisabled }).subscribe({
 				next(users) {
 					setUsers(users);
 					setError(null);
@@ -69,7 +68,7 @@ export function UserManagement(props: UserManagementProps) {
 				}
 			});
 		},
-		[limit, offset]
+		[limit, offset, showDisabled]
 	);
 
 	useEffect(() => {
@@ -127,7 +126,6 @@ export function UserManagement(props: UserManagementProps) {
 	}
 
 	const onShowDisabledChange = (checked: boolean) => {
-		showDisabledRef.current = checked;
 		setShowDisabled(checked);
 		setStoredShowDisabledUsers(user.username, checked);
 		setOffset(0);

--- a/ui/app/src/components/UsersGrid/UsersGridUI.tsx
+++ b/ui/app/src/components/UsersGrid/UsersGridUI.tsx
@@ -102,10 +102,10 @@ export function UsersGridUI(props: UsersGridUIProps) {
 										{user.username}
 									</Typography>
 								</GlobalAppGridCell>
-								<GlobalAppGridCell align="left" className="width60">
+								<GlobalAppGridCell align="left" className="width40">
 									{user.email}
 								</GlobalAppGridCell>
-								<GlobalAppGridCell align="right" className="width60">
+								<GlobalAppGridCell align="right" className="width20">
 									{!user.enabled && <Chip label={<FormattedMessage defaultMessage="Disabled" />} size="small" />}
 								</GlobalAppGridCell>
 							</GlobalAppGridRow>

--- a/ui/app/src/components/UsersGrid/UsersGridUI.tsx
+++ b/ui/app/src/components/UsersGrid/UsersGridUI.tsx
@@ -28,16 +28,21 @@ import Pagination from '../Pagination';
 import GlobalAppGridRow from '../GlobalAppGridRow';
 import GlobalAppGridCell from '../GlobalAppGridCell';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
 export interface UsersGridUIProps {
 	users: PagedArray<User>;
 	onRowClicked(user: User): void;
 	onPageChange(page: number): void;
 	onRowsPerPageChange?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+	showDisabled: boolean;
+	onShowDisabledChange(checked: boolean): void;
 }
 
 export function UsersGridUI(props: UsersGridUIProps) {
-	const { users, onRowClicked, onPageChange, onRowsPerPageChange } = props;
+	const { users, onRowClicked, onPageChange, onRowsPerPageChange, showDisabled, onShowDisabledChange } = props;
 	return (
 		<Box display="flex" flexDirection="column">
 			<TableContainer>
@@ -57,15 +62,31 @@ export function UsersGridUI(props: UsersGridUIProps) {
 									<FormattedMessage id="words.username" defaultMessage="Username" />
 								</Typography>
 							</GlobalAppGridCell>
-							<GlobalAppGridCell align="left" className="width60">
+							<GlobalAppGridCell align="left" className="width40">
 								<Typography variant="subtitle2">
 									<FormattedMessage id="words.email" defaultMessage="E-mail" />
 								</Typography>
 							</GlobalAppGridCell>
+							<GlobalAppGridCell align="right" className="width20">
+								<FormControlLabel
+									control={
+										<Checkbox
+											size="small"
+											checked={showDisabled}
+											onChange={(e) => onShowDisabledChange(e.target.checked)}
+										/>
+									}
+									label={
+										<Typography variant="subtitle2">
+											<FormattedMessage defaultMessage="Show disabled users" />
+										</Typography>
+									}
+								/>
+							</GlobalAppGridCell>
 						</GlobalAppGridRow>
 					</TableHead>
 					<TableBody>
-						{users?.map((user, i) => (
+						{users?.map((user) => (
 							<GlobalAppGridRow key={user.id} onClick={() => onRowClicked(user)}>
 								<GlobalAppGridCell align="center" className="avatar">
 									<Avatar sx={{ margin: '0 auto' }}>
@@ -83,6 +104,9 @@ export function UsersGridUI(props: UsersGridUIProps) {
 								</GlobalAppGridCell>
 								<GlobalAppGridCell align="left" className="width60">
 									{user.email}
+								</GlobalAppGridCell>
+								<GlobalAppGridCell align="right" className="width60">
+									{!user.enabled && <Chip label={<FormattedMessage defaultMessage="Disabled" />} size="small" />}
 								</GlobalAppGridCell>
 							</GlobalAppGridRow>
 						))}

--- a/ui/app/src/components/UsersGrid/UsersGridUI.tsx
+++ b/ui/app/src/components/UsersGrid/UsersGridUI.tsx
@@ -81,6 +81,7 @@ export function UsersGridUI(props: UsersGridUIProps) {
 											<FormattedMessage defaultMessage="Show disabled users" />
 										</Typography>
 									}
+									labelPlacement="start"
 								/>
 							</GlobalAppGridCell>
 						</GlobalAppGridRow>

--- a/ui/app/src/services/users.ts
+++ b/ui/app/src/services/users.ts
@@ -45,11 +45,9 @@ export function update(user: Partial<User>): Observable<User> {
 	return patchJSON(`/studio/api/2/users`, user).pipe(map((response) => response?.response?.user));
 }
 
-export function trash(username: string): Observable<true> {
-	return del(`/studio/api/2/users?username=${encodeURIComponent(username)}`).pipe(map(() => true));
-}
-
-export function fetchAll(options?: Partial<PaginationOptions & { keyword?: string }>): Observable<PagedArray<User>> {
+export function fetchAll(
+	options?: Partial<PaginationOptions & { keyword?: string; showDisabled?: boolean }>
+): Observable<PagedArray<User>> {
 	const mergedOptions = {
 		limit: 100,
 		offset: 0,

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -520,7 +520,7 @@ export function setStoredShowDisabledUsers(user: string, value: boolean) {
 
 export function getStoredShowDisabledUsers(user: string): boolean {
 	const value = window.localStorage.getItem(`craftercms.${user}.showDisabledUsers`);
-	return value ? value === 'true' : null;
+	return value ? value === 'true' : false;
 }
 
 export function removeStoredShowDisabledUsers(user: string) {

--- a/ui/app/src/utils/state.ts
+++ b/ui/app/src/utils/state.ts
@@ -513,3 +513,16 @@ export function getViewGroupedTypes(user: string): boolean {
 export function removeViewGroupedTypes(user: string) {
 	window.localStorage.removeItem(`craftercms.${user}.viewGroupedTypes`);
 }
+
+export function setStoredShowDisabledUsers(user: string, value: boolean) {
+	window.localStorage.setItem(`craftercms.${user}.showDisabledUsers`, JSON.stringify(value));
+}
+
+export function getStoredShowDisabledUsers(user: string): boolean {
+	const value = window.localStorage.getItem(`craftercms.${user}.showDisabledUsers`);
+	return value ? value === 'true' : null;
+}
+
+export function removeStoredShowDisabledUsers(user: string) {
+	window.localStorage.removeItem(`craftercms.${user}.showDisabledUsers`);
+}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “show disabled users” toggle to user management, with a per-user saved preference and automatic list refresh (including pagination reset).
  * User grid now includes an email column and shows a “Disabled” indicator for disabled accounts.
* **Improvements**
  * Removed delete-user functionality from the edit user dialog; the workflow now supports password reset instead.
  * Deleted-user related backend support was removed from services, and stored disabled-user preference cleanup was added.
* **Documentation**
  * Updated changelog formatting and added new 5.0.0 release-note entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->