### PR TITLE
[7472] Replace the term dependency with reference throughout the product 

### DIFF
--- a/ui/app/src/components/ContentTypeManagement/controls/CopyDependencies.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/CopyDependencies.tsx
@@ -85,7 +85,7 @@ export function CopyDependencies(props: CopyDependenciesProps) {
 						/>
 					</Box>
 					<Box display="flex" alignItems="center">
-						<Tooltip title={<FormattedMessage defaultMessage="Remove Dependency" />}>
+						<Tooltip title={<FormattedMessage defaultMessage="Remove Reference" />}>
 							<IconButton onClick={() => removeDependency(index)}>
 								<RemoveCircleOutlineRoundedIcon />
 							</IconButton>
@@ -94,7 +94,7 @@ export function CopyDependencies(props: CopyDependenciesProps) {
 				</Card>
 			))}
 			<Box display="flex" justifyContent="center">
-				<Tooltip title={<FormattedMessage defaultMessage="Add Dependency" />}>
+				<Tooltip title={<FormattedMessage defaultMessage="Add Reference" />}>
 					<IconButton onClick={() => addDependency()}>
 						<AddCircleOutlineRoundedIcon />
 					</IconButton>

--- a/ui/app/src/components/ContentTypeManagement/controls/DeleteDependencies.tsx
+++ b/ui/app/src/components/ContentTypeManagement/controls/DeleteDependencies.tsx
@@ -92,9 +92,9 @@ export function DeleteDependencies(props: DeleteDependenciesProps) {
 						/>
 					</Box>
 					<Box display="flex" alignItems="center">
-						<Tooltip title={<FormattedMessage defaultMessage="Remove Dependency" />}>
+						<Tooltip title={<FormattedMessage defaultMessage="Remove Reference" />}>
 							<IconButton
-								aria-label={formatMessage({ defaultMessage: 'Remove Dependency' })}
+								aria-label={formatMessage({ defaultMessage: 'Remove Reference' })}
 								onClick={() => removeDependency(index)}
 							>
 								<RemoveCircleOutlineRoundedIcon />
@@ -104,8 +104,8 @@ export function DeleteDependencies(props: DeleteDependenciesProps) {
 				</Card>
 			))}
 			<Box display="flex" justifyContent="center">
-				<Tooltip title={<FormattedMessage defaultMessage="Add Dependency" />}>
-					<IconButton aria-label={formatMessage({ defaultMessage: 'Add Dependency' })} onClick={() => addDependency()}>
+				<Tooltip title={<FormattedMessage defaultMessage="Add Reference" />}>
+					<IconButton aria-label={formatMessage({ defaultMessage: 'Add Reference' })} onClick={() => addDependency()}>
 						<AddCircleOutlineRoundedIcon />
 					</IconButton>
 				</Tooltip>

--- a/ui/app/src/components/ContentTypeManagement/descriptors/controls/commonDescriptors.ts
+++ b/ui/app/src/components/ContentTypeManagement/descriptors/controls/commonDescriptors.ts
@@ -290,7 +290,7 @@ export const typeBasicDetailsDescriptor: DescriptorContentType = {
 		'delete-dependencies': {
 			id: 'delete-dependencies',
 			type: 'delete-dependencies',
-			name: defineMessage({ defaultMessage: 'Delete Dependencies' }),
+			name: defineMessage({ defaultMessage: 'Delete References' }),
 			description: '',
 			helpText: '',
 			defaultValue: { 'delete-dependency': [] },
@@ -299,7 +299,7 @@ export const typeBasicDetailsDescriptor: DescriptorContentType = {
 		'copy-dependencies': {
 			id: 'copy-dependencies',
 			type: 'copy-dependencies',
-			name: defineMessage({ defaultMessage: 'Copy Dependencies' }),
+			name: defineMessage({ defaultMessage: 'Copy References' }),
 			description: '',
 			helpText: '',
 			defaultValue: { 'copy-dependency': [] },

--- a/ui/app/src/components/CreateFileDialog/translations.ts
+++ b/ui/app/src/components/CreateFileDialog/translations.ts
@@ -25,7 +25,6 @@ export const translations = defineMessages({
 		defaultMessage: 'File "{fileName}" doesn\'t comply with project policies: {detail}'
 	},
 	fetchingDependentItems: {
-		id: 'renameAssetDialog.fetchingDependentItems',
-		defaultMessage: 'Fetching dependent items'
+		defaultMessage: 'Fetching items that reference the selected item'
 	}
 });

--- a/ui/app/src/components/DeleteContentTypeDialog/DeleteContentTypeDialogBody.tsx
+++ b/ui/app/src/components/DeleteContentTypeDialog/DeleteContentTypeDialogBody.tsx
@@ -82,10 +82,7 @@ export function DeleteContentTypeDialogBody(props: DeleteContentTypeDialogBodyPr
 				) : (
 					<>
 						<Alert variant="outlined" severity="warning" sx={{ marginBottom: '1em' }} icon={false}>
-							<FormattedMessage
-								id="deleteContentTypeDialog.reviewDependenciesMessage"
-								defaultMessage="Please review and confirm all of content type dependencies that will be deleted."
-							/>
+							<FormattedMessage defaultMessage="Please review and confirm all content type references that will be deleted." />
 						</Alert>
 						<ContentTypeUsageReport
 							entries={entriesWithItems}
@@ -97,8 +94,7 @@ export function DeleteContentTypeDialogBody(props: DeleteContentTypeDialogBodyPr
 						/>
 						<Alert severity="warning" sx={{ marginBottom: '.5em' }}>
 							<FormattedMessage
-								id="deleteContentTypeDialog.typeConfirmPassword"
-								defaultMessage={`Type the word "<b>{password}</b>" to confirm the deletion of "{name}" and all it's dependencies.`}
+								defaultMessage={`Type the word "<b>{password}</b>" to confirm the deletion of "{name}" and all its references.`}
 								values={{
 									password,
 									name: contentType.name,

--- a/ui/app/src/components/DeleteDialog/DeleteDialog.tsx
+++ b/ui/app/src/components/DeleteDialog/DeleteDialog.tsx
@@ -27,10 +27,7 @@ export function DeleteDialog(props: DeleteDialogProps) {
 			title={<FormattedMessage id="deleteDialog.title" defaultMessage="Delete" />}
 			dialogHeaderProps={{
 				subtitle: (
-					<FormattedMessage
-						id="deleteDialog.subtitle"
-						defaultMessage="Selected items will be deleted along with their child items. Please review dependent items before deleting as these will end-up with broken link references."
-					/>
+					<FormattedMessage defaultMessage="Selected items will be deleted along with their child items. Please review items that reference the selected item before deleting as these will end up with broken link references." />
 				)
 			}}
 			isSubmitting={isSubmitting}

--- a/ui/app/src/components/DeleteDialog/DeleteDialogUIBody.tsx
+++ b/ui/app/src/components/DeleteDialog/DeleteDialogUIBody.tsx
@@ -71,7 +71,8 @@ export function DeleteDialogUIBody(props: DeleteDialogContentUIProps) {
 						<ListItemText
 							primary={
 								<Typography variant="subtitle1" component="span">
-									<FormattedMessage id="deleteDialog.dependentItems" defaultMessage="Dependent Items" />
+									<FormattedMessage defaultMessage="Items that reference the selected item" />
+
 									{` • `}
 									<FormattedMessage id="deleteDialog.brokenItems" defaultMessage="Will have broken references" />
 								</Typography>
@@ -128,7 +129,7 @@ export function DeleteDialogUIBody(props: DeleteDialogContentUIProps) {
 						>
 							<InfoIcon color="action" fontSize="small" />
 							<Typography variant="caption">
-								<FormattedMessage id="deleteDialog.emptyDependentItems" defaultMessage="No dependent items" />
+								<FormattedMessage defaultMessage="No items that reference the selected item" />
 							</Typography>
 						</Box>
 					)}

--- a/ui/app/src/components/DeletePluginDialog/UninstallPluginDialogBody.tsx
+++ b/ui/app/src/components/DeletePluginDialog/UninstallPluginDialogBody.tsx
@@ -82,8 +82,7 @@ export function UninstallPluginDialogBody(props: UninstallPluginDialogBodyProps)
 					<>
 						<Alert variant="outlined" severity="warning" icon={false}>
 							<FormattedMessage
-								id="uninstallPluginDialog.reviewDependenciesMessage"
-								defaultMessage={'Please review the dependant items of "{pluginId}"'}
+								defaultMessage={'Please review the items that reference the plugin "{pluginId}"'}
 								values={{
 									pluginId
 								}}

--- a/ui/app/src/components/DependenciesDialog/DependenciesDialog.tsx
+++ b/ui/app/src/components/DependenciesDialog/DependenciesDialog.tsx
@@ -23,10 +23,7 @@ import { FormattedMessage } from 'react-intl';
 export function DependenciesDialog(props: DependenciesDialogProps) {
 	const { item, dependenciesShown, rootPath, ...rest } = props;
 	return (
-		<EnhancedDialog
-			title={<FormattedMessage id="dependenciesDialog.title" defaultMessage="Content Item Dependencies" />}
-			{...rest}
-		>
+		<EnhancedDialog title={<FormattedMessage defaultMessage="Content Item References" />} {...rest}>
 			<DependenciesDialogContainer item={item} rootPath={rootPath} dependenciesShown={dependenciesShown} />
 		</EnhancedDialog>
 	);

--- a/ui/app/src/components/DependenciesDialog/DependenciesDialogUI.tsx
+++ b/ui/app/src/components/DependenciesDialog/DependenciesDialogUI.tsx
@@ -93,13 +93,10 @@ export function DependenciesDialogUI(props: DependenciesDialogUIProps) {
 							}}
 						>
 							<MenuItem value="depends-on-me">
-								<FormattedMessage id="dependenciesDialog.dependsOnMe" defaultMessage="Dependencies of selected item" />
+								<FormattedMessage defaultMessage="References of selected item" />
 							</MenuItem>
 							<MenuItem value="depends-on">
-								<FormattedMessage
-									id="dependenciesDialog.dependsOn"
-									defaultMessage="Items that depend on selected item"
-								/>
+								<FormattedMessage defaultMessage="Items that are referenced by the selected item" />
 							</MenuItem>
 						</Select>
 					</FormControl>
@@ -115,14 +112,14 @@ export function DependenciesDialogUI(props: DependenciesDialogUIProps) {
 						title={
 							dependenciesShown === 'depends-on-me' ? (
 								<FormattedMessage
-									id="dependenciesDialog.emptyDependantsMessage"
-									defaultMessage={'"{itemName}" has no dependencies'}
+									// id="dependenciesDialog.emptyDependantsMessage"
+									defaultMessage={'"{itemName}" has no references'}
 									values={{ itemName: item?.label }}
 								/>
 							) : (
 								<FormattedMessage
-									id="dependenciesDialog.emptyDependenciesMessage"
-									defaultMessage={'Nothing depends on "{itemName}"'}
+									// id="dependenciesDialog.emptyDependenciesMessage"
+									defaultMessage={'Nothing is referenced by "{itemName}"'}
 									values={{ itemName: item?.label }}
 								/>
 							)
@@ -167,7 +164,7 @@ export function DependenciesDialogUI(props: DependenciesDialogUIProps) {
 										handleContextMenuClose();
 									}}
 								>
-									<FormattedMessage id="dependenciesDialog.dependencies" defaultMessage="Dependencies" />
+									<FormattedMessage id="dependenciesDialog.references" defaultMessage="References" />
 								</MenuItem>
 							)}
 							<MenuItem

--- a/ui/app/src/components/DependenciesDialog/DependenciesDialogUI.tsx
+++ b/ui/app/src/components/DependenciesDialog/DependenciesDialogUI.tsx
@@ -112,13 +112,11 @@ export function DependenciesDialogUI(props: DependenciesDialogUIProps) {
 						title={
 							dependenciesShown === 'depends-on-me' ? (
 								<FormattedMessage
-									// id="dependenciesDialog.emptyDependantsMessage"
 									defaultMessage={'"{itemName}" has no references'}
 									values={{ itemName: item?.label }}
 								/>
 							) : (
 								<FormattedMessage
-									// id="dependenciesDialog.emptyDependenciesMessage"
 									defaultMessage={'Nothing is referenced by "{itemName}"'}
 									values={{ itemName: item?.label }}
 								/>

--- a/ui/app/src/components/DependenciesDialog/utils.tsx
+++ b/ui/app/src/components/DependenciesDialog/utils.tsx
@@ -79,7 +79,7 @@ export const dialogInitialState = {
 
 export const assetsTypes = {
 	'all-deps': {
-		label: <FormattedMessage id="dependenciesDialog.allDeps" defaultMessage="Show all dependencies" />,
+		label: <FormattedMessage defaultMessage="Show all references" />,
 		filter: () => true
 	},
 	'content-items': {

--- a/ui/app/src/components/DependencySelection/DependencySelection.tsx
+++ b/ui/app/src/components/DependencySelection/DependencySelection.tsx
@@ -63,23 +63,19 @@ export function DependencySelection(props: DependencySelectionProps) {
 				{nnou(dependencies) && (
 					<>
 						<SelectionList
-							title={<FormattedMessage id="publishDialog.hardDependencies" defaultMessage="Hard Dependencies" />}
+							title={<FormattedMessage defaultMessage="References of mandatory submission" />}
 							subtitle={
 								<FormattedMessage id="publishDialog.submissionMandatory" defaultMessage="Submission Mandatory" />
 							}
-							emptyMessage={
-								<FormattedMessage id="publishDialog.emptyHardDependencies" defaultMessage="No hard dependencies" />
-							}
+							emptyMessage={<FormattedMessage defaultMessage="No references of mandatory submission" />}
 							paths={dependencies.hardDependencies ?? []}
 							displayItemTitle={false}
 							disabled={disabled}
 						/>
 						<SelectionList
-							title={<FormattedMessage id="publishDialog.softDependencies" defaultMessage="Soft Dependencies" />}
+							title={<FormattedMessage defaultMessage="References of optional submission" />}
 							subtitle={<FormattedMessage id="publishDialog.submissionOptional" defaultMessage="Submission Optional" />}
-							emptyMessage={
-								<FormattedMessage id="publishDialog.emptySoftDependencies" defaultMessage="No soft dependencies" />
-							}
+							emptyMessage={<FormattedMessage defaultMessage="No references of optional submission" />}
 							paths={dependencies.softDependencies ?? []}
 							onItemClicked={onItemClicked}
 							onSelectAllClicked={onSelectAllSoftClicked}

--- a/ui/app/src/components/ItemActionsMenu/translations.ts
+++ b/ui/app/src/components/ItemActionsMenu/translations.ts
@@ -73,9 +73,9 @@ export const translations = defineMessages({
 		id: 'words.history',
 		defaultMessage: 'History'
 	},
-	dependencies: {
-		id: 'words.dependencies',
-		defaultMessage: 'Dependencies'
+	references: {
+		id: 'words.references',
+		defaultMessage: 'References'
 	},
 	translation: {
 		id: 'words.translation',

--- a/ui/app/src/components/PublishOnDemandWidget/PublishOnDemandWidget.tsx
+++ b/ui/app/src/components/PublishOnDemandWidget/PublishOnDemandWidget.tsx
@@ -54,9 +54,8 @@ import { extractErrorPayload } from '../../utils/ajax';
 
 const messages = defineMessages({
 	publishStudioWarning: {
-		id: 'publishingDashboard.warning',
 		defaultMessage:
-			"This will force publish all items that match the pattern requested including their dependencies, and it may take a long time depending on the number of items. Please make sure that all modified items (including potentially someone's work in progress) are ready to be published before continuing."
+			"This will force publish all items that match the pattern requested including their references, and it may take a long time depending on the number of items. Please make sure that all modified items (including potentially someone's work in progress) are ready to be published before continuing."
 	},
 	warningLabel: {
 		id: 'words.warning',

--- a/ui/app/src/components/RenameDialogBody/RenameItemView.tsx
+++ b/ui/app/src/components/RenameDialogBody/RenameItemView.tsx
@@ -90,7 +90,7 @@ export function RenameItemView(props: RenameItemViewProps) {
 
 	return fetchingDependantItems ? (
 		<LoadingState
-			title={<FormattedMessage defaultMessage="Fetching dependent items" />}
+			title={<FormattedMessage defaultMessage="Fetching items that reference the selected item" />}
 			sxs={{ title: { marginTop: 0 } }}
 		/>
 	) : dependantItems ? (
@@ -123,7 +123,7 @@ export function RenameItemView(props: RenameItemViewProps) {
 			{dependantItems?.length > 0 ? (
 				<>
 					<Typography variant="subtitle2" sx={{ mt: 1, mb: 1 }}>
-						<FormattedMessage id="renameAsset.dependentItems" defaultMessage="Dependent Items" />
+						<FormattedMessage defaultMessage="Items that reference the selected item" />
 					</Typography>
 					<DependenciesList
 						dependencies={dependantItems}
@@ -174,7 +174,10 @@ export function RenameItemView(props: RenameItemViewProps) {
 							mr: 1
 						}}
 					/>
-					<FormattedMessage id="renameAsset.noDependentItems" defaultMessage="No dependent items" />
+					<FormattedMessage
+						id="renameAsset.noDependentItems"
+						defaultMessage="No items that reference the selected item"
+					/>
 				</Typography>
 			)}
 		</>

--- a/ui/app/src/components/SiteConfigurationManagement/translations.ts
+++ b/ui/app/src/components/SiteConfigurationManagement/translations.ts
@@ -248,13 +248,11 @@ export const translations = defineMessages({
 		defaultMessage: 'Engine URL Rewrite Configuration (XML Style) - Live'
 	},
 	confTabDependencyResolverConf: {
-		id: 'siteConfigurationManagement.confTabDependencyResolverConf',
-		defaultMessage: 'Dependency Resolver Configuration'
+		defaultMessage: 'Reference Resolver Configuration'
 	},
 	confTabDependencyResolverConfDesc: {
-		id: 'siteConfigurationManagement.confTabDependencyResolverConfDesc',
 		defaultMessage:
-			'This file configures what file paths Crafter considers a dependency and how they should be extracted.'
+			'This file configures what file paths Crafter considers a reference and how they should be extracted.'
 	},
 	confTabAWSProfiles: { id: 'siteConfigurationManagement.confTabAWSProfiles', defaultMessage: 'AWS Profiles' },
 	confTabAWSProfilesDesc: {

--- a/ui/app/src/env/i18n-legacy.ts
+++ b/ui/app/src/env/i18n-legacy.ts
@@ -264,8 +264,7 @@ export const contentTypesMessages = defineMessages({
 		defaultMessage: '"{tool}" tool not found.'
 	},
 	dependsOn: {
-		id: 'contentType.dependsOn',
-		defaultMessage: 'This property depends on "{dependency}"'
+		defaultMessage: 'This property references "{dependency}"'
 	},
 	minValueError: {
 		id: 'contentType.minSizeError',

--- a/ui/app/src/utils/itemActions.ts
+++ b/ui/app/src/utils/itemActions.ts
@@ -190,7 +190,7 @@ const unparsedMenuOptions: Record<AllItemActions, ContextMenuOptionDescriptor<Al
 	},
 	dependencies: {
 		id: 'dependencies',
-		label: translations.dependencies
+		label: translations.references
 	},
 	editController: {
 		id: 'editController',


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated terminology throughout the UI to consistently use “references” instead of “dependencies.”
  * Refreshed tooltip, aria-label, and button copy (e.g., add/remove reference wording).
  * Adjusted dialog and menu text for dependency/reference views, including titles, empty states, and warning/subtitle messaging.
  * Updated related internationalized strings so messages like “dependent items” now read as “items that reference the selected item,” improving consistency across rename, delete, uninstall, and publish flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->