### PR TITLE
[8419] Improve Change Type dialog/flow

### DIFF
--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialog.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialog.tsx
@@ -19,21 +19,33 @@ import { FormattedMessage } from 'react-intl';
 import EnhancedDialog from '../EnhancedDialog';
 import { ChangeContentTypeDialogProps } from './utils';
 import ChangeContentTypeDialogContainer from './ChangeContentTypeDialogContainer';
+import useFetchAllowedTypesForPath from '../../hooks/useFetchAllowedTypesForPath';
+import { getNormalizedFolderPathForApi1GetTypes } from '../../utils/contentType';
 
 export function ChangeContentTypeDialog(props: ChangeContentTypeDialogProps) {
 	const { item, onContentTypeSelected, initialCompact, ...rest } = props;
+	const { contentTypes, isFetching } = useFetchAllowedTypesForPath(
+		getNormalizedFolderPathForApi1GetTypes(item),
+		// Filter only compatible types, and filter out current type.
+		(types) => types.filter((type) => type.type === item.systemType && item.contentTypeId != type.id)
+	);
+
 	return (
 		<EnhancedDialog
-			maxWidth="lg"
+			maxWidth={contentTypes?.length ? 'lg' : 'xs'}
 			dialogHeaderProps={{
 				title: <FormattedMessage defaultMessage="Change Content Type" />,
-				subtitle: <FormattedMessage defaultMessage="The item can only be changed to the types below." />
+				subtitle: contentTypes?.length ? (
+					<FormattedMessage defaultMessage="The item can only be changed to the types below." />
+				) : undefined
 			}}
 			{...rest}
 		>
 			<ChangeContentTypeDialogContainer
 				item={item}
 				initialCompact={initialCompact}
+				contentTypes={contentTypes}
+				isFetching={isFetching}
 				onContentTypeSelected={onContentTypeSelected}
 				onClose={props.onClose}
 			/>

--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialog.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialog.tsx
@@ -46,7 +46,7 @@ export function ChangeContentTypeDialog(props: ChangeContentTypeDialogProps) {
 				item={item}
 				initialCompact={initialCompact}
 				contentTypes={contentTypes}
-				isFetching={true}
+				isFetching={isFetching}
 				onContentTypeSelected={onContentTypeSelected}
 				onClose={props.onClose}
 			/>

--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialog.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialog.tsx
@@ -32,12 +32,13 @@ export function ChangeContentTypeDialog(props: ChangeContentTypeDialogProps) {
 
 	return (
 		<EnhancedDialog
-			maxWidth={contentTypes?.length ? 'lg' : 'xs'}
+			maxWidth={isFetching || contentTypes?.length ? 'lg' : 'xs'}
 			dialogHeaderProps={{
 				title: <FormattedMessage defaultMessage="Change Content Type" />,
-				subtitle: contentTypes?.length ? (
-					<FormattedMessage defaultMessage="The item can only be changed to the types below." />
-				) : undefined
+				subtitle:
+					isFetching || contentTypes?.length ? (
+						<FormattedMessage defaultMessage="The item can only be changed to the types below." />
+					) : undefined
 			}}
 			{...rest}
 		>
@@ -45,7 +46,7 @@ export function ChangeContentTypeDialog(props: ChangeContentTypeDialogProps) {
 				item={item}
 				initialCompact={initialCompact}
 				contentTypes={contentTypes}
-				isFetching={isFetching}
+				isFetching={true}
 				onContentTypeSelected={onContentTypeSelected}
 				onClose={props.onClose}
 			/>

--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
@@ -19,12 +19,10 @@ import React from 'react';
 import DialogBody from '../DialogBody/DialogBody';
 import { FormattedMessage, useIntl } from 'react-intl';
 import SelectTypeView from '../ContentTypeManagement/components/SelectTypeView';
-import { getNormalizedFolderPathForApi1GetTypes } from '../../utils/contentType';
 import { TypeListProps } from '../ContentTypeManagement/components/TypeList';
 import ItemDisplay from '../ItemDisplay';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import useFetchAllowedTypesForPath from '../../hooks/useFetchAllowedTypesForPath';
 import { ObjectTypeOption } from '../ContentTypeFilter';
 import { DialogFooter } from '../DialogFooter';
 import SecondaryButton from '../SecondaryButton';
@@ -33,7 +31,6 @@ import { useDispatch } from 'react-redux';
 import { nanoid } from 'nanoid';
 import { pushConfirmDialog } from '../../utils/system';
 import { popDialog } from '../../state/actions/dialogStack';
-import Alert from '@mui/material/Alert';
 
 export function ChangeContentTypeDialogContainer(props: ChangeContentTypeDialogContainerProps) {
 	const { item, onContentTypeSelected, initialCompact = false, onClose, contentTypes, isFetching } = props;

--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
@@ -99,19 +99,13 @@ export function ChangeContentTypeDialogContainer(props: ChangeContentTypeDialogC
 						}}
 					/>
 				) : (
-					<>
-						<EmptyState
-							title={<FormattedMessage defaultMessage="No available content types." />}
-							subtitle={
-								<FormattedMessage defaultMessage="There are no compatible content types available for this item." />
-							}
-							sxs={{ root: { height: '100%' } }}
-						/>
-						{/* <Alert severity="info">
-							<FormattedMessage defaultMessage="No available content types." />
-							<FormattedMessage defaultMessage="There are no available content types for this item." />
-						</Alert> */}
-					</>
+					<EmptyState
+						title={<FormattedMessage defaultMessage="No available content types." />}
+						subtitle={
+							<FormattedMessage defaultMessage="There are no compatible content types available for this item." />
+						}
+						sxs={{ root: { height: '100%' } }}
+					/>
 				)}
 			</DialogBody>
 			<DialogFooter>

--- a/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
+++ b/ui/app/src/components/ChangeContentTypeDialog/ChangeContentTypeDialogContainer.tsx
@@ -33,9 +33,10 @@ import { useDispatch } from 'react-redux';
 import { nanoid } from 'nanoid';
 import { pushConfirmDialog } from '../../utils/system';
 import { popDialog } from '../../state/actions/dialogStack';
+import Alert from '@mui/material/Alert';
 
 export function ChangeContentTypeDialogContainer(props: ChangeContentTypeDialogContainerProps) {
-	const { item, onContentTypeSelected, initialCompact = false, onClose } = props;
+	const { item, onContentTypeSelected, initialCompact = false, onClose, contentTypes, isFetching } = props;
 	const dispatch = useDispatch();
 	const { formatMessage } = useIntl();
 
@@ -62,17 +63,14 @@ export function ChangeContentTypeDialogContainer(props: ChangeContentTypeDialogC
 		);
 	};
 
-	const { contentTypes, isFetching } = useFetchAllowedTypesForPath(
-		getNormalizedFolderPathForApi1GetTypes(item),
-		// Filter only compatible types, and filter out current type.
-		(types) => types.filter((type) => type.type === item.systemType && item.contentTypeId != type.id)
-	);
 	// Show the select type view if there are content types to show, or if it's still loading (to show the skeleton). Otherwise, show the empty state.
 	const showSelectTpeView = contentTypes?.length || isFetching;
 
 	return (
 		<>
-			<DialogBody sx={{ minHeight: 670, justifyContent: showSelectTpeView ? 'start' : 'center' }}>
+			<DialogBody
+				sx={{ minHeight: contentTypes?.length ? 670 : 300, justifyContent: showSelectTpeView ? 'start' : 'center' }}
+			>
 				{showSelectTpeView ? (
 					<SelectTypeView
 						initialCompact={initialCompact}
@@ -101,15 +99,28 @@ export function ChangeContentTypeDialogContainer(props: ChangeContentTypeDialogC
 						}}
 					/>
 				) : (
-					<EmptyState
-						title={<FormattedMessage defaultMessage="No types available for the item." />}
-						sxs={{ root: { height: '100%' } }}
-					/>
+					<>
+						<EmptyState
+							title={<FormattedMessage defaultMessage="No available content types." />}
+							subtitle={
+								<FormattedMessage defaultMessage="There are no compatible content types available for this item." />
+							}
+							sxs={{ root: { height: '100%' } }}
+						/>
+						{/* <Alert severity="info">
+							<FormattedMessage defaultMessage="No available content types." />
+							<FormattedMessage defaultMessage="There are no available content types for this item." />
+						</Alert> */}
+					</>
 				)}
 			</DialogBody>
 			<DialogFooter>
 				<SecondaryButton onClick={(e) => onClose(e, null)}>
-					<FormattedMessage defaultMessage="Cancel" />
+					{contentTypes?.length ? (
+						<FormattedMessage defaultMessage="Cancel" />
+					) : (
+						<FormattedMessage defaultMessage="Close" />
+					)}
 				</SecondaryButton>
 			</DialogFooter>
 		</>

--- a/ui/app/src/components/ChangeContentTypeDialog/utils.ts
+++ b/ui/app/src/components/ChangeContentTypeDialog/utils.ts
@@ -24,8 +24,6 @@ import { ContentType } from '../../models';
 export interface ChangeContentTypeDialogBaseProps {
 	item: ContentItem;
 	initialCompact: boolean;
-	contentTypes?: ContentType[];
-	isFetching: boolean;
 }
 
 export interface ChangeContentTypeDialogProps extends ChangeContentTypeDialogBaseProps, EnhancedDialogProps {
@@ -39,4 +37,7 @@ export interface ChangeContentTypeDialogStateProps extends ChangeContentTypeDial
 }
 
 export interface ChangeContentTypeDialogContainerProps
-	extends ChangeContentTypeDialogBaseProps, Pick<ChangeContentTypeDialogProps, 'onContentTypeSelected' | 'onClose'> {}
+	extends ChangeContentTypeDialogBaseProps, Pick<ChangeContentTypeDialogProps, 'onContentTypeSelected' | 'onClose'> {
+	contentTypes?: ContentType[];
+	isFetching: boolean;
+}

--- a/ui/app/src/components/ChangeContentTypeDialog/utils.ts
+++ b/ui/app/src/components/ChangeContentTypeDialog/utils.ts
@@ -24,7 +24,7 @@ import { ContentType } from '../../models';
 export interface ChangeContentTypeDialogBaseProps {
 	item: ContentItem;
 	initialCompact: boolean;
-	contentTypes: ContentType[];
+	contentTypes?: ContentType[];
 	isFetching: boolean;
 }
 

--- a/ui/app/src/components/ChangeContentTypeDialog/utils.ts
+++ b/ui/app/src/components/ChangeContentTypeDialog/utils.ts
@@ -19,10 +19,13 @@ import StandardAction from '../../models/StandardAction';
 import { EnhancedDialogState } from '../../hooks/useEnhancedDialogState';
 import { EnhancedDialogProps } from '../EnhancedDialog';
 import { NewContentDialogProps } from '../NewContentDialog/utils';
+import { ContentType } from '../../models';
 
 export interface ChangeContentTypeDialogBaseProps {
 	item: ContentItem;
 	initialCompact: boolean;
+	contentTypes: ContentType[];
+	isFetching: boolean;
 }
 
 export interface ChangeContentTypeDialogProps extends ChangeContentTypeDialogBaseProps, EnhancedDialogProps {


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The change-content-type dialog now retrieves and displays only compatible content types for the selected item path.
  * The dialog layout adapts dynamically while loading and based on whether compatible types are available (including responsive sizing and conditional subtitles).

* **Bug Fixes**
  * Improved empty-state behavior when no compatible types exist, with clearer messaging and updated primary action labeling (Cancel vs Close).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->