### PR TITLE
[8571] Disable staging target on initial publish

### DIFF
--- a/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -119,12 +119,14 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 			if (publishingTargets?.length && target === '') {
 				// If we haven't found a target by this point, we wish to default the dialog to
 				// staging (as long as that target is enabled in the system, which is checked next).
-				target = publishingTargets.find((target) => target.name === 'staging')?.name ?? publishingTargets[0].name;
+				target = published
+					? (publishingTargets.find((target) => target.name === 'staging')?.name ?? publishingTargets[0].name)
+					: publishingTargets[0].name;
 			}
 		}
 
 		return target;
-	}, [publishingTargets, mainItems]);
+	}, [publishingTargets, mainItems, published]);
 	const commentMaxLength = useSelector<GlobalState, number>(
 		(state) => state.uiConfig.publishing.submissionCommentMaxLength
 	);

--- a/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -121,7 +121,7 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 				// staging (as long as that target is enabled in the system, which is checked next).
 				target = published
 					? (publishingTargets.find((target) => target.name === 'staging')?.name ?? publishingTargets[0].name)
-					: publishingTargets[0].name;
+					: (publishingTargets.find((target) => target.name !== 'staging')?.name ?? '');
 			}
 		}
 

--- a/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -118,7 +118,7 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 			// If there aren't any available target (or they haven't loaded), dialog should not have a selected target.
 			if (publishingTargets?.length && target === '') {
 				// If we haven't found a target by this point, we wish to default the dialog to
-				// staging (as long as that target is enabled in the system, which is checked next).
+				// staging (as long as that target is enabled in the system and it's not the first publish), which is checked next.
 				target = published
 					? (publishingTargets.find((target) => target.name === 'staging')?.name ?? publishingTargets[0].name)
 					: (publishingTargets.find((target) => target.name !== 'staging')?.name ?? '');

--- a/ui/app/src/components/PublishDialog/PublishDialogForm.tsx
+++ b/ui/app/src/components/PublishDialog/PublishDialogForm.tsx
@@ -315,7 +315,11 @@ export function PublishDialogForm(props: PublishDialogFormProps) {
 								>
 									<Box component="span">
 										<FormControlLabel
-											disabled={disabled || (target.name === 'staging' && isPromote)}
+											disabled={
+												disabled ||
+												(target.name === 'staging' && isPromote) ||
+												(target.name === 'staging' && !published)
+											}
 											value={target.name}
 											control={
 												<Radio
@@ -323,7 +327,17 @@ export function PublishDialogForm(props: PublishDialogFormProps) {
 													sx={{ padding: '4px', marginLeft: '5px', marginRight: '5px', ...sxs?.radioInput }}
 												/>
 											}
-											label={messages[target.name] ? formatMessage(messages[target.name]) : capitalize(target.name)}
+											label={
+												messages[target.name] ? (
+													target.name === 'staging' && !published ? (
+														<FormattedMessage defaultMessage="Staging (disabled on first publish)" />
+													) : (
+														formatMessage(messages[target.name])
+													)
+												) : (
+													capitalize(target.name)
+												)
+											}
 											slotProps={{
 												typography: {
 													sx: { fontSize: '14px', ...sxs?.formInputs }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the publishing target is chosen when opening the publish dialog, so first-time publishing now defaults to the most appropriate available target.
  * Updated target availability rules to better reflect publish vs. promote flows.
  * Clarified the staging option label when it can’t be selected on first publish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->