### PR TITLE
[8397] Remove viewPackages action from packageItems default set of actions

### DIFF
--- a/ui/app/src/utils/itemActions.ts
+++ b/ui/app/src/utils/itemActions.ts
@@ -379,7 +379,7 @@ export function generateSingleItemOptions(
 	) {
 		sectionC.push(menuOptions.publish);
 	}
-	if (isInActiveWorkflow(item)) {
+	if (isInActiveWorkflow(item) && actionsToInclude.viewPackages) {
 		sectionC.push(menuOptions.viewPackages);
 	}
 	// endregion


### PR DESCRIPTION
Validate view packages action against actionsToInclude (actionsToInclude is set to 'all actions' if no override is set)

https://github.com/craftercms/craftercms/issues/8397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the “View packages” context-menu option could appear even when it was explicitly excluded by the available action filter.
  * The menu now respects the selected action set more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->