### PR TITLE
[8454] Improve the "More Items" alignment in the side bar 

### DIFF
--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
@@ -161,31 +161,49 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
 		));
 		children.length < totalByPath[path] &&
 			propsForTreeItem.children.push(
-				<Box
-					component="section"
+				<TreeItem
 					key="more"
+					itemId={`${path}::__more__`}
+					label={
+						<Button
+							color="primary"
+							size="small"
+							onClick={(event) => {
+								event.stopPropagation();
+								onMoreClick(path);
+							}}
+						>
+							<FormattedMessage
+								id="pathNavigatorTree.moreLinkLabel"
+								defaultMessage="{count, plural, one {...{count} more item} other {...{count} more items}}"
+								values={{ count: totalByPath[path] - children.length }}
+							/>
+						</Button>
+					}
 					sx={{
-						color: (theme) => theme.palette.text.primary,
-						display: 'flex',
-						alignItems: 'center',
-						minHeight: '23.5px',
-						marginLeft: '10px'
+						[`& > .${treeItemClasses.content}`]: {
+							pt: 0,
+							pb: 0,
+							pr: 0,
+							alignItems: 'center',
+							minHeight: '23.5px',
+							cursor: 'default',
+							'&:hover': {
+								background: 'none'
+							}
+						},
+						[`& .${treeItemClasses.label}`]: {
+							paddingLeft: 0
+						},
+						[`& .${treeItemClasses.iconContainer}`]: {
+							width: '26px',
+							marginRight: 0
+						},
+						[`& .${treeItemClasses.focused}`]: {
+							background: 'none !important'
+						}
 					}}
-				>
-					<Button
-						color="primary"
-						size="small"
-						onClick={() => {
-							onMoreClick(path);
-						}}
-					>
-						<FormattedMessage
-							id="pathNavigatorTree.moreLinkLabel"
-							defaultMessage="{count, plural, one {...{count} more item} other {...{count} more items}}"
-							values={{ count: totalByPath[path] - children.length }}
-						/>
-					</Button>
-				</Box>
+				/>
 			);
 	} else if (totalByPath[path] > 0 && !childrenByParentPath[path]?.length) {
 		// If totalByPath at the current path is greater than 0, but there are no children in childrenByParentPath for the current path,

--- a/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
+++ b/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
@@ -198,9 +198,6 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
 						[`& .${treeItemClasses.iconContainer}`]: {
 							width: '26px',
 							marginRight: 0
-						},
-						[`& .${treeItemClasses.focused}`]: {
-							background: 'none !important'
 						}
 					}}
 				/>


### PR DESCRIPTION
Updated the 'N more items' entry of the tree to be a `TreeItem` instead of a `Box` so it gets indented properly with the rest of items.

https://github.com/craftercms/craftercms/issues/8454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “more” entry in the path navigator tree so it behaves like a proper tree item, making it easier to interact with and navigate.
  * Updated click handling to avoid unintended tree selection or expansion when loading additional items.
  * Refined tree item spacing, hover, focus, and label styling for a more consistent and polished sidebar experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->