### PR TITLE
[7231] Validate uploading files existence

### DIFF
--- a/ui/app/src/components/SingleFileUpload/SingleFileUpload.tsx
+++ b/ui/app/src/components/SingleFileUpload/SingleFileUpload.tsx
@@ -22,6 +22,7 @@ import 'uppy/dist/uppy.css';
 import '@uppy/progress-bar/dist/style.css';
 import { getGlobalHeaders } from '../../utils/ajax';
 import { validateActionPolicy } from '../../services/sites';
+import { checkPathExistence } from '../../services/content';
 import ConfirmDialog from '../ConfirmDialog/ConfirmDialog';
 import type { Body, Meta, UppyFile } from '@uppy/utils/lib/UppyFile';
 import { useDispatch } from 'react-redux';
@@ -60,6 +61,10 @@ const messages = defineMessages({
 	},
 	policyError: {
 		defaultMessage: 'File "{fileName}" doesn\'t comply with project policies: {detail}'
+	},
+	overwriteConfirm: {
+		id: 'fileUpload.overwriteConfirm',
+		defaultMessage: 'A file named "{fileName}" already exists at this location. Do you want to overwrite it?'
 	}
 });
 
@@ -133,7 +138,7 @@ export function SingleFileUpload(props: SingleFileUploadProps) {
 	const { upload } = useSiteUIConfig();
 	const [confirm, setConfirm] = useState<{
 		body: string;
-		error?: boolean;
+		type: 'policy' | 'overwrite' | 'error';
 	}>(null);
 	const [error, setError] = useState(null);
 	fileRef.current = file;
@@ -191,6 +196,33 @@ export function SingleFileUpload(props: SingleFileUploadProps) {
 			}),
 		[fileTypes, customFileName, path]
 	);
+
+	const confirmUpload = () => {
+		// When uploading large files to aws/s3, something causes requests to fail and get retried n times before finally stating it failed; despite the file seemingly actually getting uploaded.
+		// This setTimeout avoids that issue. The mechanism of failure or why this avoids it is unknown.
+		setTimeout(() => uppy.upload(), 50);
+		setDescription(`${formatMessage(messages.uploadingFile)}:`);
+		onUploadStart?.();
+	};
+
+	const checkExistenceAndUpload = (targetPath: string, fileName: string) => {
+		checkPathExistence(site, targetPath).subscribe({
+			next: (exists) => {
+				if (exists) {
+					setConfirm({
+						type: 'overwrite',
+						body: formatMessage(messages.overwriteConfirm, { fileName })
+					});
+				} else {
+					confirmUpload();
+				}
+			},
+			error: ({ response }) => {
+				setDisableInput(false);
+				dispatch(pushErrorDialog({ props: { error: response?.response } }));
+			}
+		});
+	};
 
 	const retryUpload = () => {
 		setError(null);
@@ -291,6 +323,7 @@ export function SingleFileUpload(props: SingleFileUploadProps) {
 								// Modified value is expected to be a path.
 								const modifiedName = modifiedValue.match(/[^/]+$/)?.[0] ?? modifiedValue;
 								setConfirm({
+									type: 'policy',
 									body: formatMessage(
 										{
 											defaultMessage:
@@ -301,15 +334,11 @@ export function SingleFileUpload(props: SingleFileUploadProps) {
 								});
 								setSuggestedName(modifiedName);
 							} else {
-								// When uploading large files to aws/s3, something causes requests to fail and get retried n times before finally stating it failed; despite the file seemingly actually getting uploaded.
-								// This setTimeout avoids that issue. The mechanism of failure or why this avoids it is unknown.
-								setTimeout(() => uppy.upload(), 50);
-								setDescription(`${formatMessage(messages.uploadingFile)}:`);
-								onUploadStart?.();
+								checkExistenceAndUpload(ensureSingleSlash(`${path}/${fileName}`), fileName);
 							}
 						} else {
 							setConfirm({
-								error: true,
+								type: 'error',
 								body: formatMessage(messages.policyError, { fileName: file.name, detail: message })
 							});
 						}
@@ -342,17 +371,21 @@ export function SingleFileUpload(props: SingleFileUploadProps) {
 	}, [onUploadStart, formatMessage, path, site, uppy, dispatch, onFileAddedProp]);
 
 	const onConfirm = () => {
-		uppy.upload();
-		setSuggestedName(null);
-		setDescription(`${formatMessage(messages.uploadingFile)}:`);
-		onUploadStart?.();
-		setConfirm(null);
+		if (confirm?.type === 'policy') {
+			const name = suggestedName ?? file.name;
+			setConfirm(null);
+			checkExistenceAndUpload(ensureSingleSlash(`${path}/${name}`), name);
+		} else if (confirm?.type === 'overwrite') {
+			setConfirm(null);
+			confirmUpload();
+		}
 	};
 
 	const onConfirmCancel = () => {
 		document.querySelector('.uppy-FileInput-btn')?.removeAttribute('disabled');
 		uppy.removeFile(file.id);
 		setFile(null);
+		setSuggestedName(null);
 		setConfirm(null);
 		setDescription(formatMessage(messages.selectFileMessage));
 		setDisableInput(false);
@@ -455,8 +488,8 @@ export function SingleFileUpload(props: SingleFileUploadProps) {
 			<ConfirmDialog
 				open={Boolean(confirm)}
 				body={confirm?.body}
-				onOk={confirm?.error ? onConfirmCancel : onConfirm}
-				onCancel={confirm?.error ? null : onConfirmCancel}
+				onOk={confirm?.type === 'error' ? onConfirmCancel : onConfirm}
+				onCancel={confirm?.type === 'error' ? null : onConfirmCancel}
 				disableEnforceFocus={true}
 			/>
 		</>

--- a/ui/app/src/components/UploadDialog/UploadDialogContainer.tsx
+++ b/ui/app/src/components/UploadDialog/UploadDialogContainer.tsx
@@ -23,7 +23,7 @@ import { translations } from './translations';
 import { getBulkUploadUrl } from '../../services/content';
 import { getGlobalHeaders } from '../../utils/ajax';
 import { useUnmount } from '../../hooks/useUnmount';
-import { Button, IconButton } from '@mui/material';
+import { IconButton } from '@mui/material';
 import CloseIconRounded from '@mui/icons-material/CloseRounded';
 import DialogBody from '../DialogBody/DialogBody';
 import UppyDashboard from '../UppyDashboard';
@@ -170,7 +170,6 @@ export function UploadDialogContainer(props: UploadDialogContainerProps) {
 
 	return (
 		<>
-			<Button style={{ display: 'none' }}>test</Button>
 			<IconButton style={{ display: 'none' }} size="large" aria-label={formatMessage({ defaultMessage: 'Close' })}>
 				<CloseIconRounded />
 			</IconButton>

--- a/ui/app/src/components/UppyDashboard/UppyDashboard.tsx
+++ b/ui/app/src/components/UppyDashboard/UppyDashboard.tsx
@@ -22,6 +22,7 @@ import { validateActionPolicy } from '../../services/sites';
 import { checkPathExistence } from '../../services/content';
 import { defineMessages, useIntl } from 'react-intl';
 import { showSystemNotification } from '../../state/actions/system';
+import { pushErrorDialog } from '../../utils/system';
 import { useDispatch } from 'react-redux';
 import { alpha } from '@mui/material';
 import { Subject } from 'rxjs';
@@ -32,6 +33,7 @@ import { UppyDashboardProps } from './UppyDashboardProps';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import Box from '@mui/material/Box';
 import type { DashboardOptions } from 'uppy';
+import { extractErrorPayload } from '../../utils/ajax';
 
 const translations = defineMessages({
 	cancelPending: {
@@ -177,6 +179,9 @@ export function UppyDashboard(props: UppyDashboardProps) {
 			proudlyDisplayPoweredByUppy: false,
 			validateActionPolicy,
 			checkPathExistence,
+			onPathExistenceError: (err) => {
+				dispatch(pushErrorDialog({ props: { error: extractErrorPayload(err) } }));
+			},
 			onPendingChanges: function () {
 				functionsRef.current.onPendingChanges.apply(null, arguments);
 			},

--- a/ui/app/src/components/UppyDashboard/UppyDashboard.tsx
+++ b/ui/app/src/components/UppyDashboard/UppyDashboard.tsx
@@ -107,7 +107,7 @@ const translations = defineMessages({
 	},
 	fileOverwriteRequired: {
 		id: 'uppyDashboard.fileOverwriteRequired',
-		defaultMessage: 'A file named "{fileName}" already exists. Confirm to overwrite it, or remove it from the queue.'
+		defaultMessage: 'A file named "{fileName}" already exists. Do you want to overwrite it?'
 	},
 	confirmOverwrite: {
 		id: 'uppyDashboard.confirmOverwrite',

--- a/ui/app/src/components/UppyDashboard/UppyDashboard.tsx
+++ b/ui/app/src/components/UppyDashboard/UppyDashboard.tsx
@@ -19,6 +19,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 
 import palette from '../../styles/palette';
 import { validateActionPolicy } from '../../services/sites';
+import { checkPathExistence } from '../../services/content';
 import { defineMessages, useIntl } from 'react-intl';
 import { showSystemNotification } from '../../state/actions/system';
 import { useDispatch } from 'react-redux';
@@ -100,6 +101,18 @@ const translations = defineMessages({
 	projectPoliciesNoComply: {
 		defaultMessage: 'File "{fileName}" doesn\'t comply with project policies: {detail}'
 	},
+	fileAlreadyExists: {
+		id: 'uppyDashboard.fileAlreadyExists',
+		defaultMessage: 'A file with the name "{fileName}" already exists at this location.'
+	},
+	fileOverwriteRequired: {
+		id: 'uppyDashboard.fileOverwriteRequired',
+		defaultMessage: 'A file named "{fileName}" already exists. Confirm to overwrite it, or remove it from the queue.'
+	},
+	confirmOverwrite: {
+		id: 'uppyDashboard.confirmOverwrite',
+		defaultMessage: 'Overwrite and upload'
+	},
 	proceed: {
 		defaultMessage: 'Start Uploads'
 	},
@@ -163,6 +176,7 @@ export function UppyDashboard(props: UppyDashboardProps) {
 			singleFileFullScreen: false,
 			proudlyDisplayPoweredByUppy: false,
 			validateActionPolicy,
+			checkPathExistence,
 			onPendingChanges: function () {
 				functionsRef.current.onPendingChanges.apply(null, arguments);
 			},
@@ -186,6 +200,7 @@ export function UppyDashboard(props: UppyDashboardProps) {
 					rejectAll: formatMessage(translations.rejectAll),
 					validating: formatMessage(translations.validating),
 					validateAndRetry: formatMessage(translations.validateAndRetry),
+					confirmOverwrite: formatMessage(translations.confirmOverwrite),
 					removeFile: formatMessage(translations.removeFile),
 					back: formatMessage(translations.back),
 					addingMoreFiles: formatMessage(translations.addingMoreFiles),
@@ -218,6 +233,12 @@ export function UppyDashboard(props: UppyDashboardProps) {
 				},
 				projectPoliciesNoComply: (fileName, detail) => {
 					return formatMessage(translations.projectPoliciesNoComply, { fileName, detail });
+				},
+				fileAlreadyExists: (fileName) => {
+					return formatMessage(translations.fileAlreadyExists, { fileName });
+				},
+				fileOverwriteRequired: (fileName) => {
+					return formatMessage(translations.fileOverwriteRequired, { fileName });
 				}
 			},
 			onMaxActiveUploadsReached: () => {

--- a/ui/app/src/components/UppyDashboard/UppyDashboard.tsx
+++ b/ui/app/src/components/UppyDashboard/UppyDashboard.tsx
@@ -129,6 +129,10 @@ const translations = defineMessages({
 	},
 	dropPasteBoth: {
 		defaultMessage: 'Drop files here, {browseFiles} or {browseFolders}'
+	},
+	pathExistenceCheckFailed: {
+		id: 'uppyDashboard.pathExistenceCheckFailed',
+		defaultMessage: 'Unable to verify whether the file already exists'
 	}
 });
 
@@ -220,7 +224,8 @@ export function UppyDashboard(props: UppyDashboardProps) {
 						// These values are for uppy's mechanism to replace the placeholders with links
 						browseFiles: '%{browseFiles}',
 						browseFolders: '%{browseFolders}'
-					})
+					}),
+					pathExistenceCheckFailed: formatMessage(translations.pathExistenceCheckFailed)
 				},
 				pluralize: (n: number) => (n === 1 ? 0 : 1)
 			},

--- a/ui/uppy/src/components/Dashboard.jsx
+++ b/ui/uppy/src/components/Dashboard.jsx
@@ -169,6 +169,7 @@ export default function Dashboard(props) {
 							externalMessages={props.externalMessages}
 							validateFilesPolicy={props.validateFilesPolicy}
 							validateAndRetry={props.validateAndRetry}
+							confirmOverwrite={props.confirmOverwrite}
 						/>
 					) : (
 						<div

--- a/ui/uppy/src/components/FileItem/Buttons/index.jsx
+++ b/ui/uppy/src/components/FileItem/Buttons/index.jsx
@@ -74,14 +74,14 @@ function CopyLinkButton({ file, uppy, i18n }) {
 	);
 }
 
-function AcceptSuggestedNameIcon({ i18n, onClick }) {
+function ConfirmActionIcon({ i18n, onClick, labelKey }) {
 	return (
 		<button
 			className="uppy-dashboard-button-base uppy-dashboard-icon-button edgeEnd"
 			tabIndex="0"
 			type="button"
-			aria-label={i18n('validateAndRetry')}
-			title={i18n('validateAndRetry')}
+			aria-label={i18n(labelKey)}
+			title={i18n(labelKey)}
 			onClick={() => onClick()}
 		>
 			<svg className="uppy-dashboard-svg-icon" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
@@ -103,7 +103,8 @@ export default function Buttons(props) {
 		i18n,
 		toggleFileCard,
 		openFileEditor,
-		validateAndRetry
+		validateAndRetry,
+		confirmOverwrite
 	} = props;
 	const editAction = () => {
 		if (metaFields && metaFields.length > 0) {
@@ -125,7 +126,10 @@ export default function Buttons(props) {
 			/>
 			{showRemoveButton ? <RemoveButton i18n={i18n} file={file} onClick={() => uppy.removeFile(file.id)} /> : null}
 			{file.meta.validating === false && file.meta.allowed && file.meta.suggestedName && (
-				<AcceptSuggestedNameIcon i18n={i18n} onClick={() => validateAndRetry(file.id)} />
+				<ConfirmActionIcon i18n={i18n} labelKey="validateAndRetry" onClick={() => validateAndRetry(file.id)} />
+			)}
+			{file.meta.validating === false && file.meta.overwriteRequired && (
+				<ConfirmActionIcon i18n={i18n} labelKey="confirmOverwrite" onClick={() => confirmOverwrite(file.id)} />
 			)}
 			{showLinkToFileUploadResult && file.uploadURL ? <CopyLinkButton file={file} uppy={uppy} i18n={i18n} /> : null}
 		</div>

--- a/ui/uppy/src/components/FileItem/Buttons/index.jsx
+++ b/ui/uppy/src/components/FileItem/Buttons/index.jsx
@@ -125,9 +125,13 @@ export default function Buttons(props) {
 				onClick={editAction}
 			/>
 			{showRemoveButton ? <RemoveButton i18n={i18n} file={file} onClick={() => uppy.removeFile(file.id)} /> : null}
-			{file.meta.validating === false && file.meta.allowed && file.meta.suggestedName && (
-				<ConfirmActionIcon i18n={i18n} labelKey="validateAndRetry" onClick={() => validateAndRetry(file.id)} />
-			)}
+
+			{file.meta.validating === false &&
+				file.meta.allowed &&
+				file.meta.suggestedName &&
+				!file.meta.overwriteRequired && (
+					<ConfirmActionIcon i18n={i18n} labelKey="validateAndRetry" onClick={() => validateAndRetry(file.id)} />
+				)}
 			{file.meta.validating === false && file.meta.overwriteRequired && (
 				<ConfirmActionIcon i18n={i18n} labelKey="confirmOverwrite" onClick={() => confirmOverwrite(file.id)} />
 			)}

--- a/ui/uppy/src/components/FileItem/FileInfo/index.jsx
+++ b/ui/uppy/src/components/FileItem/FileInfo/index.jsx
@@ -101,6 +101,9 @@ const warningIcon = () => (
 		aria-hidden="true"
 		tabIndex="-1"
 		title="WarningRounded"
+		data-ga-event-category="material-icons"
+		data-ga-event-action="click"
+		data-ga-event-label="WarningRounded"
 	>
 		<path d="M4.47 21h15.06c1.54 0 2.5-1.67 1.73-3L13.73 4.99c-.77-1.33-2.69-1.33-3.46 0L2.74 18c-.77 1.33.19 3 1.73 3zM12 14c-.55 0-1-.45-1-1v-2c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z"></path>
 	</svg>

--- a/ui/uppy/src/components/FileItem/FileInfo/index.jsx
+++ b/ui/uppy/src/components/FileItem/FileInfo/index.jsx
@@ -58,7 +58,7 @@ const renderFileName = (props) => {
 					<span className="item-name-valid">{truncateString(suggestedName, maxNameLength)}</span>
 				</span>
 			)}
-				</div>
+		</div>
 	);
 };
 
@@ -93,6 +93,26 @@ const renderFileType = (props) =>
 const renderFileSize = (props) =>
 	props.file.size && <div className="uppy-Dashboard-Item-statusSize">{prettierBytes(props.file.size)}</div>;
 
+const warningIcon = () => (
+	<svg
+		className="warning-icon"
+		focusable="false"
+		viewBox="0 0 24 24"
+		aria-hidden="true"
+		tabIndex="-1"
+		title="WarningRounded"
+	>
+		<path d="M4.47 21h15.06c1.54 0 2.5-1.67 1.73-3L13.73 4.99c-.77-1.33-2.69-1.33-3.46 0L2.74 18c-.77 1.33.19 3 1.73 3zM12 14c-.55 0-1-.45-1-1v-2c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z"></path>
+	</svg>
+);
+
+const renderOverwriteWarning = (props) => (
+	<div class="uppy-dashboard-site-policy-warning">
+		{warningIcon()}
+		{props.externalMessages.fileOverwriteRequired(props.file.meta.name)}
+	</div>
+);
+
 const renderPolicyWarning = (props) => {
 	const file = props.file;
 	const allowed = file.meta.allowed;
@@ -100,19 +120,7 @@ const renderPolicyWarning = (props) => {
 	return allowed ? (
 		<div class="uppy-dashboard-site-policy-warning">
 			{' '}
-			<svg
-				className="warning-icon"
-				focusable="false"
-				viewBox="0 0 24 24"
-				aria-hidden="true"
-				tabIndex="-1"
-				title="WarningRounded"
-				data-ga-event-category="material-icons"
-				data-ga-event-action="click"
-				data-ga-event-label="WarningRounded"
-			>
-				<path d="M4.47 21h15.06c1.54 0 2.5-1.67 1.73-3L13.73 4.99c-.77-1.33-2.69-1.33-3.46 0L2.74 18c-.77 1.33.19 3 1.73 3zM12 14c-.55 0-1-.45-1-1v-2c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z"></path>
-			</svg>
+			{warningIcon()}
 			{props.externalMessages.projectPoliciesChangeRequired(file.name, file.meta.suggestedName)}
 		</div>
 	) : (
@@ -173,7 +181,8 @@ export default function FileInfo(props) {
 	return (
 		<div className="uppy-Dashboard-Item-fileInfo" data-uppy-file-source={file.source}>
 			<div className="uppy-Dashboard-Item-fileName" style={{ display: 'block' }}>
-			{(props.file.meta.suggestedName || props.file.meta.allowed === false) && renderPolicyWarning(props)}
+				{props.file.meta.overwriteRequired && renderOverwriteWarning(props)}
+				{(props.file.meta.suggestedName || props.file.meta.allowed === false) && renderPolicyWarning(props)}
 				{renderFileName({
 					file,
 					isSingleFile,

--- a/ui/uppy/src/components/FileItem/index.jsx
+++ b/ui/uppy/src/components/FileItem/index.jsx
@@ -119,6 +119,7 @@ export default class FileItem extends Component {
 						uppy={this.props.uppy}
 						i18n={this.props.i18n}
 						validateAndRetry={this.props.validateAndRetry}
+						confirmOverwrite={this.props.confirmOverwrite}
 					/>
 				</div>
 			</div>

--- a/ui/uppy/src/components/FileList.jsx
+++ b/ui/uppy/src/components/FileList.jsx
@@ -45,7 +45,8 @@ export default function FileList({
 	containerHeight,
 	externalMessages,
 	validateFilesPolicy,
-	validateAndRetry
+	validateAndRetry,
+	confirmOverwrite
 }) {
 	// It's not great that this is hardcoded!
 	// It's ESPECIALLY not great that this is checking against `itemsPerRow`!
@@ -107,6 +108,7 @@ export default function FileList({
 					file={files[fileID]}
 					validateFilesPolicy={validateFilesPolicy}
 					validateAndRetry={validateAndRetry}
+					confirmOverwrite={confirmOverwrite}
 				/>
 			))}
 		</div>

--- a/ui/uppy/src/plugins/Dashboard.jsx
+++ b/ui/uppy/src/plugins/Dashboard.jsx
@@ -154,7 +154,7 @@ export class Dashboard extends UppyDashboard {
 			if (file.progress.uploadComplete) {
 				completeFiles++;
 			}
-			if (file.meta.allowed === false || file.meta.suggestedName) {
+			if (file.meta.allowed === false || file.meta.suggestedName || file.meta.overwriteRequired) {
 				invalidFiles++;
 			}
 		});
@@ -170,11 +170,60 @@ export class Dashboard extends UppyDashboard {
 		}
 	};
 
+	// craftercms/uppy - check path existence custom code
+	checkPathAndUpload = (fileId, path, invalidFiles, { onUploadStarted, onComplete } = {}) => {
+		const complete = () => onComplete?.();
+
+		const startUpload = () => {
+			this.uppy.retryUpload(fileId);
+			onUploadStarted?.();
+			complete();
+		};
+
+		if (!this.opts.checkPathExistence) {
+			startUpload();
+			return;
+		}
+
+		this.opts.checkPathExistence(this.opts.site, path).subscribe({
+			next: (exists) => {
+				if (exists) {
+					invalidFiles[fileId] = true;
+					this.uppy.setFileMeta(fileId, {
+						allowed: true,
+						overwriteRequired: true
+					});
+					this.setPluginState({ invalidFiles: { ...invalidFiles } });
+					complete();
+				} else {
+					startUpload();
+				}
+			},
+			error: () => {
+				startUpload();
+			}
+		});
+	};
+
 	// craftercms/uppy - site policy custom code
 	validateFilesPolicy = (files) => {
 		if (files.length === 0) return;
 		const fileIdLookup = {};
-		const invalidFiles = this.getPluginState().invalidFiles;
+		const invalidFiles = { ...this.getPluginState().invalidFiles };
+		let uploading = false;
+		let pendingExistenceChecks = 0;
+
+		const finalizeExistenceChecks = () => {
+			this.opts.onPendingChanges(uploading);
+			this.setPluginState({ invalidFiles });
+		};
+
+		const onExistenceCheckComplete = () => {
+			pendingExistenceChecks--;
+			if (pendingExistenceChecks === 0) {
+				finalizeExistenceChecks();
+			}
+		};
 
 		this.opts
 			.validateActionPolicy(
@@ -192,7 +241,6 @@ export class Dashboard extends UppyDashboard {
 				})
 			)
 			.subscribe((response) => {
-				let uploading = false;
 				response.forEach(({ allowed, modifiedValue, target, message }) => {
 					let fileId = fileIdLookup[target];
 					this.uppy.setFileMeta(fileId, {
@@ -202,16 +250,25 @@ export class Dashboard extends UppyDashboard {
 						...(modifiedValue && { suggestedName: modifiedValue.replace(/^.*[\\\/]/, '') })
 					});
 					if (allowed && modifiedValue === null) {
-						this.uppy.retryUpload(fileId);
-						uploading = true;
+						if (this.opts.checkPathExistence) {
+							pendingExistenceChecks++;
+							this.checkPathAndUpload(fileId, target, invalidFiles, {
+								onUploadStarted: () => {
+									uploading = true;
+								},
+								onComplete: onExistenceCheckComplete
+							});
+						} else {
+							this.uppy.retryUpload(fileId);
+							uploading = true;
+						}
 					} else {
 						invalidFiles[fileId] = true;
 					}
 				});
-				this.opts.onPendingChanges(uploading);
-				this.setPluginState({
-					invalidFiles: invalidFiles
-				});
+				if (pendingExistenceChecks === 0) {
+					finalizeExistenceChecks();
+				}
 			});
 	};
 
@@ -229,7 +286,16 @@ export class Dashboard extends UppyDashboard {
 			name: suggestedName,
 			path
 		});
+		this.checkPathAndUpload(fileID, path, invalidFiles);
+	};
+
+	confirmOverwrite = (fileID) => {
+		const invalidFiles = { ...this.getPluginState().invalidFiles };
+		invalidFiles[fileID] = false;
+		this.setPluginState({ invalidFiles });
+		this.uppy.setFileMeta(fileID, { overwriteRequired: null });
 		this.uppy.retryUpload(fileID);
+		this.opts.onPendingChanges(true);
 	};
 
 	validateAndRemove = (fileID) => {
@@ -275,14 +341,21 @@ export class Dashboard extends UppyDashboard {
 	};
 
 	confirmAll = () => {
-		const files = this.uppy.getFiles();
 		const invalidFiles = { ...this.getPluginState().invalidFiles };
+		let uploading = false;
 		Object.keys(invalidFiles).forEach((fileID) => {
 			if (invalidFiles[fileID]) {
 				invalidFiles[fileID] = false;
 				const file = this.uppy.getFile(fileID);
-				const suggestedName = this.uppy.getFile(fileID).meta.suggestedName;
-				if (file.meta.allowed) {
+				if (!file) {
+					return;
+				}
+				if (file.meta.overwriteRequired) {
+					this.uppy.setFileMeta(fileID, { overwriteRequired: null });
+					this.uppy.retryUpload(fileID);
+					uploading = true;
+				} else if (file.meta.allowed) {
+					const suggestedName = file.meta.suggestedName;
 					const initialPath = file.meta.path;
 					const basePath = initialPath.substring(0, initialPath.lastIndexOf('/'));
 					const path = `${basePath}/${suggestedName}`;
@@ -292,13 +365,16 @@ export class Dashboard extends UppyDashboard {
 						name: suggestedName,
 						path
 					});
-					this.uppy.retryUpload(fileID);
+					this.checkPathAndUpload(fileID, path, invalidFiles);
 				} else {
 					this.uppy.removeFile(fileID);
 				}
 			}
 		});
 		this.setPluginState({ invalidFiles });
+		if (uploading) {
+			this.opts.onPendingChanges(true);
+		}
 	};
 
 	#generateLargeThumbnailIfSingleFile = () => {
@@ -537,6 +613,7 @@ export class Dashboard extends UppyDashboard {
 			cancelPending: this.cancelPending,
 			clearCompleted: this.clearCompleted,
 			validateAndRetry: this.validateAndRetry,
+			confirmOverwrite: this.confirmOverwrite,
 			rejectAll: this.rejectAll,
 			confirmAll: this.confirmAll,
 			invalidFiles: pluginState.invalidFiles ?? {},

--- a/ui/uppy/src/plugins/Dashboard.jsx
+++ b/ui/uppy/src/plugins/Dashboard.jsx
@@ -205,7 +205,7 @@ export class Dashboard extends UppyDashboard {
 					err?.response?.response?.message ??
 					(typeof err?.response?.response === 'string' ? err.response.response : null) ??
 					err?.message ??
-					'Unable to verify whether the file already exists';
+					this.i18n('pathExistenceCheckFailed');
 				this.uppy.setFileMeta(fileId, {
 					allowed: false,
 					message: detail

--- a/ui/uppy/src/plugins/Dashboard.jsx
+++ b/ui/uppy/src/plugins/Dashboard.jsx
@@ -286,7 +286,11 @@ export class Dashboard extends UppyDashboard {
 			name: suggestedName,
 			path
 		});
-		this.checkPathAndUpload(fileID, path, invalidFiles);
+		this.checkPathAndUpload(fileID, path, invalidFiles, {
+			onUploadStarted: () => {
+				this.opts.onPendingChanges(true);
+			}
+		});
 	};
 
 	confirmOverwrite = (fileID) => {
@@ -365,7 +369,12 @@ export class Dashboard extends UppyDashboard {
 						name: suggestedName,
 						path
 					});
-					this.checkPathAndUpload(fileID, path, invalidFiles);
+					this.checkPathAndUpload(fileID, path, invalidFiles, {
+						onUploadStarted: () => {
+							uploading = true;
+							this.opts.onPendingChanges(true);
+						}
+					});
 				} else {
 					this.uppy.removeFile(fileID);
 				}

--- a/ui/uppy/src/plugins/Dashboard.jsx
+++ b/ui/uppy/src/plugins/Dashboard.jsx
@@ -224,8 +224,11 @@ export class Dashboard extends UppyDashboard {
 		const invalidFiles = { ...this.getPluginState().invalidFiles };
 		let uploading = false;
 		let pendingExistenceChecks = 0;
+		let finalized = false;
 
 		const finalizeExistenceChecks = () => {
+			if (finalized) return;
+			finalized = true;
 			this.opts.onPendingChanges(uploading);
 			this.setPluginState({ invalidFiles });
 		};
@@ -363,11 +366,18 @@ export class Dashboard extends UppyDashboard {
 		const invalidFiles = { ...this.getPluginState().invalidFiles };
 		let uploading = false;
 		let pendingPathChecks = 0;
+		let finalized = false;
+
+		const finalizePathChecks = () => {
+			if (finalized) return;
+			finalized = true;
+			if (uploading) this.opts.onPendingChanges(true);
+		};
 
 		const onPathCheckComplete = () => {
 			pendingPathChecks--;
 			if (pendingPathChecks === 0) {
-				if (uploading) this.opts.onPendingChanges(true);
+				finalizePathChecks();
 			}
 		};
 
@@ -407,7 +417,7 @@ export class Dashboard extends UppyDashboard {
 		});
 		this.setPluginState({ invalidFiles });
 		if (pendingPathChecks === 0) {
-			if (uploading) this.opts.onPendingChanges(true);
+			finalizePathChecks();
 		}
 	};
 

--- a/ui/uppy/src/plugins/Dashboard.jsx
+++ b/ui/uppy/src/plugins/Dashboard.jsx
@@ -199,8 +199,20 @@ export class Dashboard extends UppyDashboard {
 					startUpload();
 				}
 			},
-			error: () => {
-				startUpload();
+			error: (err) => {
+				invalidFiles[fileId] = true;
+				const detail =
+					err?.response?.response?.message ??
+					(typeof err?.response?.response === 'string' ? err.response.response : null) ??
+					err?.message ??
+					'Unable to verify whether the file already exists';
+				this.uppy.setFileMeta(fileId, {
+					allowed: false,
+					message: detail
+				});
+				this.setPluginState({ invalidFiles: { ...invalidFiles } });
+				this.opts.onPathExistenceError?.(err);
+				complete();
 			}
 		});
 	};
@@ -241,6 +253,10 @@ export class Dashboard extends UppyDashboard {
 				})
 			)
 			.subscribe((response) => {
+				pendingExistenceChecks = response.filter(
+					({ allowed, modifiedValue }) => allowed && modifiedValue === null && this.opts.checkPathExistence
+				).length;
+
 				response.forEach(({ allowed, modifiedValue, target, message }) => {
 					let fileId = fileIdLookup[target];
 					this.uppy.setFileMeta(fileId, {
@@ -251,7 +267,6 @@ export class Dashboard extends UppyDashboard {
 					});
 					if (allowed && modifiedValue === null) {
 						if (this.opts.checkPathExistence) {
-							pendingExistenceChecks++;
 							this.checkPathAndUpload(fileId, target, invalidFiles, {
 								onUploadStarted: () => {
 									uploading = true;
@@ -347,6 +362,15 @@ export class Dashboard extends UppyDashboard {
 	confirmAll = () => {
 		const invalidFiles = { ...this.getPluginState().invalidFiles };
 		let uploading = false;
+		let pendingPathChecks = 0;
+
+		const onPathCheckComplete = () => {
+			pendingPathChecks--;
+			if (pendingPathChecks === 0) {
+				if (uploading) this.opts.onPendingChanges(true);
+			}
+		};
+
 		Object.keys(invalidFiles).forEach((fileID) => {
 			if (invalidFiles[fileID]) {
 				invalidFiles[fileID] = false;
@@ -369,11 +393,12 @@ export class Dashboard extends UppyDashboard {
 						name: suggestedName,
 						path
 					});
+					pendingPathChecks++;
 					this.checkPathAndUpload(fileID, path, invalidFiles, {
 						onUploadStarted: () => {
 							uploading = true;
-							this.opts.onPendingChanges(true);
-						}
+						},
+						onComplete: onPathCheckComplete
 					});
 				} else {
 					this.uppy.removeFile(fileID);
@@ -381,8 +406,8 @@ export class Dashboard extends UppyDashboard {
 			}
 		});
 		this.setPluginState({ invalidFiles });
-		if (uploading) {
-			this.opts.onPendingChanges(true);
+		if (pendingPathChecks === 0) {
+			if (uploading) this.opts.onPendingChanges(true);
 		}
 	};
 

--- a/ui/uppy/src/plugins/locale.js
+++ b/ui/uppy/src/plugins/locale.js
@@ -149,6 +149,8 @@ export default {
 			0: '%{smart_count} more file added',
 			1: '%{smart_count} more files added'
 		},
-		showErrorDetails: 'Show error details'
+		showErrorDetails: 'Show error details',
+		// Shown when the path-existence check fails before upload
+		pathExistenceCheckFailed: 'Unable to verify whether the file already exists'
 	}
 };

--- a/ui/uppy/types/generatedLocale.d.ts
+++ b/ui/uppy/types/generatedLocale.d.ts
@@ -43,6 +43,7 @@ type DashboardLocale = Uppy.Locale<
 	| 'poweredBy'
 	| 'validating'
 	| 'validateAndRetry'
+	| 'confirmOverwrite'
 	| 'rejectAll'
 	| 'acceptAll'
 	| 'clear'


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added remote path existence checking to site-policy uploads, triggering an overwrite-required state when the target file already exists.
  - Introduced a “confirm overwrite” action in the dashboard, alongside existing validate/retry flows.
  - Extended dashboard and upload dialog messaging to support overwrite prompts and related button labels.

- **Bug Fixes**
  - Improved completion/invalid counting to account for overwrite-required files.
  - Refined confirmation handling so overwrite decisions reliably clear warnings and restart uploads, including better error reporting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->