### PR TITLE
[8786] FE2 doesn't reload content when a contentLifecycle script updates the path configuration on save

### DIFF
--- a/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -256,7 +256,15 @@ function GlobalFormsState(props: FormsEngineProps) {
 
 // Fetches the requirements for the form and sets up various contexts.
 function FormBootstrap(props: FormsEngineProps) {
-	const { create, update, repeat, fieldsToRender, readonly: readonlyProp, stackIndex = 0, isDialog } = props;
+	// When creating a new item. If we save the form, and do not close it, we need to update the 'mode' from create to update, using the path of the created item.
+	// effectiveProps are the props that are used to render the form, considering the scenario mentioned above.
+	const [savedCreatePath, setSavedCreatePath] = useState<string | null>(null);
+	const effectiveProps = useMemo((): FormsEngineProps => {
+		if (!savedCreatePath) return props;
+		const { create: _create, ...rest } = props;
+		return { ...rest, update: { path: savedCreatePath } };
+	}, [props, savedCreatePath]);
+	const { create, update, repeat, fieldsToRender, readonly: readonlyProp, stackIndex = 0, isDialog } = effectiveProps;
 	const siteId = useActiveSiteId();
 	const dispatch = useDispatch();
 	const contentTypesById = useContentTypes();
@@ -309,7 +317,7 @@ function FormBootstrap(props: FormsEngineProps) {
 			: state.content.itemsByPath[effectiveUpdatePath ?? formsStackData[stackIndex - 1]?.props?.update?.path]
 	);
 
-	api.updateProps(stackIndex, props);
+	api.updateProps(stackIndex, effectiveProps);
 
 	useEffect(() => {
 		if (!create && !repeat && !liveUpdatedItem) setReady(false);
@@ -579,8 +587,10 @@ function FormBootstrap(props: FormsEngineProps) {
 				<StableFormContext.Provider value={stableFormContextRef.current}>
 					<ItemContext.Provider value={liveUpdatedItem}>
 						<ItemMetaContext.Provider value={itemMeta}>
-							<RenamedPathContext.Provider value={{ renamedPath, setRenamedPath, reloadNonce, triggerReload }}>
-								{createElement(FormOrchestrator, props)}
+							<RenamedPathContext.Provider
+								value={{ renamedPath, setRenamedPath, reloadNonce, triggerReload, setSavedCreatePath }}
+							>
+								{createElement(FormOrchestrator, effectiveProps)}
 							</RenamedPathContext.Provider>
 						</ItemMetaContext.Provider>
 					</ItemContext.Provider>

--- a/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -20,7 +20,16 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import useActiveSite from '../../hooks/useActiveSite';
 import useContentTypes from '../../hooks/useContentTypes';
-import React, { createElement, type RefCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+	createElement,
+	type RefCallback,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState
+} from 'react';
 import { ContentTypeField, PublishPackage } from '../../models';
 import {
 	FormsEngineAtoms,
@@ -263,6 +272,8 @@ function FormBootstrap(props: FormsEngineProps) {
 	const effectRefs = useUpdateRefs({ contentTypesById, username });
 	const stableFormContextRef = useRef<StableFormContextProps>(formsStackData[stackIndex]);
 	const [renamedPath, setRenamedPath] = useState<string | null>(null);
+	const [reloadNonce, setReloadNonce] = useState(0);
+	const triggerReload = useCallback(() => setReloadNonce((nonce) => nonce + 1), []);
 	const effectiveUpdatePath = renamedPath ?? update?.path;
 
 	const contextApi = useMemo<FormsEngineFormApiContextProps>(() => {
@@ -552,7 +563,8 @@ function FormBootstrap(props: FormsEngineProps) {
 		store,
 		update,
 		username,
-		renamedPath
+		renamedPath,
+		reloadNonce
 	]);
 
 	if (prepError) {
@@ -567,7 +579,7 @@ function FormBootstrap(props: FormsEngineProps) {
 				<StableFormContext.Provider value={stableFormContextRef.current}>
 					<ItemContext.Provider value={liveUpdatedItem}>
 						<ItemMetaContext.Provider value={itemMeta}>
-							<RenamedPathContext.Provider value={{ renamedPath, setRenamedPath }}>
+							<RenamedPathContext.Provider value={{ renamedPath, setRenamedPath, reloadNonce, triggerReload }}>
 								{createElement(FormOrchestrator, props)}
 							</RenamedPathContext.Provider>
 						</ItemMetaContext.Provider>

--- a/ui/app/src/components/FormsEngine/lib/formsEngineContext.ts
+++ b/ui/app/src/components/FormsEngine/lib/formsEngineContext.ts
@@ -159,4 +159,6 @@ export const useItemMetaContext = /*#__PURE__*/ createUseContextHook('useItemMet
 export const RenamedPathContext = createContext<{
 	renamedPath: string | null;
 	setRenamedPath(path: string | null): void;
-}>({ renamedPath: null, setRenamedPath: () => {} });
+	reloadNonce: number;
+	triggerReload(): void;
+}>({ renamedPath: null, setRenamedPath: () => {}, reloadNonce: 0, triggerReload: () => {} });

--- a/ui/app/src/components/FormsEngine/lib/formsEngineContext.ts
+++ b/ui/app/src/components/FormsEngine/lib/formsEngineContext.ts
@@ -161,4 +161,11 @@ export const RenamedPathContext = createContext<{
 	setRenamedPath(path: string | null): void;
 	reloadNonce: number;
 	triggerReload(): void;
-}>({ renamedPath: null, setRenamedPath: () => {}, reloadNonce: 0, triggerReload: () => {} });
+	setSavedCreatePath(path: string | null): void;
+}>({
+	renamedPath: null,
+	setRenamedPath: () => {},
+	reloadNonce: 0,
+	triggerReload: () => {},
+	setSavedCreatePath: () => {}
+});

--- a/ui/app/src/components/FormsEngine/lib/useSaveForm.tsx
+++ b/ui/app/src/components/FormsEngine/lib/useSaveForm.tsx
@@ -89,7 +89,7 @@ export function useSaveForm(props: UseSaveFormProps) {
 	const setHasPendingChanges = useSetAtom(stableFormContext.atoms.hasPendingChanges);
 	const onSave = wrapOnSaveProp(props.onSave);
 	const fileName = useAtomValue(stableFormContext.atoms.fileName);
-	const { setRenamedPath } = useContext(RenamedPathContext);
+	const { setRenamedPath, triggerReload } = useContext(RenamedPathContext);
 	const initialFileName = itemPath ? getFileNameValueFromPath(itemPath, isPage) : '';
 	const item = useContext(ItemContext);
 	return async (draft?: boolean) => {
@@ -170,12 +170,18 @@ export function useSaveForm(props: UseSaveFormProps) {
 		}
 
 		const saveActionCallbacks = {
-			async next() {
+			async next(ajaxResponse) {
+				const isAmended = ajaxResponse.response?.items?.[0]?.amended;
 				const dom = fromString(xml);
 				const result = (await onSave?.({ dom, xml, values, versionComment, path })) as FormSavePromiseResult;
 				const shouldClose = result.close || closeAfterSave;
-				if (isRename && !shouldClose) {
-					setRenamedPath(renamePath);
+				// TODO: handle create mode scenario.
+				if (!shouldClose && !isCreateMode) {
+					if (isRename) {
+						setRenamedPath(renamePath);
+					} else if (isAmended) {
+						triggerReload();
+					}
 				}
 				onSavePromiseHandler(result);
 			},

--- a/ui/app/src/components/FormsEngine/lib/useSaveForm.tsx
+++ b/ui/app/src/components/FormsEngine/lib/useSaveForm.tsx
@@ -38,8 +38,8 @@ import {
 import { FormSavePromiseResult, FormsEngineProps } from '../FormsEngine';
 import { XmlKeys } from './formConsts';
 import { fromString } from '../../../utils/xml';
-import { moveAndUpdateContent, writeContent } from '../../../services/content';
-import { AjaxError } from 'rxjs/ajax';
+import { moveAndUpdateContent, writeContent, WriteContentResponse } from '../../../services/content';
+import { AjaxError, AjaxResponse } from 'rxjs/ajax';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { buildContentXml } from './valueSerializers';
@@ -170,7 +170,7 @@ export function useSaveForm(props: UseSaveFormProps) {
 		}
 
 		const saveActionCallbacks = {
-			async next(ajaxResponse) {
+			async next(ajaxResponse: AjaxResponse<WriteContentResponse>) {
 				const isAmended = ajaxResponse.response?.items?.[0]?.amended;
 				const dom = fromString(xml);
 				const result = (await onSave?.({ dom, xml, values, versionComment, path })) as FormSavePromiseResult;

--- a/ui/app/src/components/FormsEngine/lib/useSaveForm.tsx
+++ b/ui/app/src/components/FormsEngine/lib/useSaveForm.tsx
@@ -89,7 +89,7 @@ export function useSaveForm(props: UseSaveFormProps) {
 	const setHasPendingChanges = useSetAtom(stableFormContext.atoms.hasPendingChanges);
 	const onSave = wrapOnSaveProp(props.onSave);
 	const fileName = useAtomValue(stableFormContext.atoms.fileName);
-	const { setRenamedPath, triggerReload } = useContext(RenamedPathContext);
+	const { setRenamedPath, triggerReload, setSavedCreatePath } = useContext(RenamedPathContext);
 	const initialFileName = itemPath ? getFileNameValueFromPath(itemPath, isPage) : '';
 	const item = useContext(ItemContext);
 	return async (draft?: boolean) => {
@@ -175,9 +175,10 @@ export function useSaveForm(props: UseSaveFormProps) {
 				const dom = fromString(xml);
 				const result = (await onSave?.({ dom, xml, values, versionComment, path })) as FormSavePromiseResult;
 				const shouldClose = result.close || closeAfterSave;
-				// TODO: handle create mode scenario.
-				if (!shouldClose && !isCreateMode) {
-					if (isRename) {
+				if (!shouldClose) {
+					if (isCreateMode) {
+						setSavedCreatePath(path);
+					} else if (isRename) {
 						setRenamedPath(renamePath);
 					} else if (isAmended) {
 						triggerReload();

--- a/ui/app/src/services/content.ts
+++ b/ui/app/src/services/content.ts
@@ -41,7 +41,7 @@ import { ItemHistoryEntry } from '../models/Version';
 import { GetChildrenOptions } from '../models/GetChildrenOptions';
 import { generateComponentPath, isPdfDocument, parseContentXML, prepareVirtualItemProps } from '../utils/content';
 import QuickCreateItem from '../models/content/QuickCreateItem';
-import ApiResponse from '../models/ApiResponse';
+import ApiResponse, { Api2ResponseFormat } from '../models/ApiResponse';
 import { fetchContentTypes } from './contentTypes';
 import { Clipboard } from '../models/GlobalState';
 import { getFileNameFromPath } from '../utils/path';
@@ -122,12 +122,20 @@ export function fetchContentInstance(
 	return fetchContentDOM(site, path).pipe(map((doc) => parseContentXML(doc, path, contentTypesLookup, {})));
 }
 
+export type WriteContentResponse = Api2ResponseFormat<{
+	items: Array<{
+		path: string;
+		action: string;
+		amended: boolean;
+	}>;
+}>;
+
 export function writeContent(
 	siteId: string,
 	path: string,
 	content: string,
 	options?: { unlock?: boolean; comment?: string }
-) {
+): Observable<AjaxResponse<WriteContentResponse>> {
 	const request$ = postJSON(`/studio/api/2/content/${siteId}`, {
 		path,
 		content,
@@ -145,7 +153,12 @@ export function uploadFile(siteId: string, formData: FormData) {
 }
 
 // TODO: add link to API docs when available
-export function moveAndUpdateContent(siteId: string, sourcePath: string, targetPath: string, content: string) {
+export function moveAndUpdateContent(
+	siteId: string,
+	sourcePath: string,
+	targetPath: string,
+	content: string
+): Observable<AjaxResponse<WriteContentResponse>> {
 	return post(`/studio/api/2/content/${siteId}/move_and_update`, {
 		sourcePath,
 		targetPath,


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forms now automatically refresh after successfully amending an existing item, without closing the editor.
* **Bug Fixes**
  * Improved post-save behavior so the UI applies the correct resulting path state for renamed items and newly created items, reflecting updates immediately.
* **Chores**
  * Updated content-write response handling to align with API v2 typing, improving consistency of save-related data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->