### PR TITLE
[8655] Saved as draft visual feedback

### DIFF
--- a/ui/app/src/components/DraftChip/DraftChip.tsx
+++ b/ui/app/src/components/DraftChip/DraftChip.tsx
@@ -18,13 +18,19 @@ import Chip, { ChipProps } from '@mui/material/Chip';
 import { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-export interface DraftChipProps extends Omit<ChipProps, 'color'> {
+export interface DraftChipProps extends ChipProps {
 	label?: ReactNode;
 }
 
-export function DraftChip(props: DraftChipProps) {
-	const { label = <FormattedMessage defaultMessage="Draft" />, variant = 'outlined', ...rest } = props;
-	return <Chip variant={variant} color="error" label={label} {...rest} />;
+export function DraftChip(props: ChipProps) {
+	return (
+		<Chip
+			{...props}
+			variant={props.variant ?? 'outlined'}
+			color={props.color ?? 'error'}
+			label={props.label ?? <FormattedMessage defaultMessage="Draft" />}
+		/>
+	);
 }
 
 export default DraftChip;

--- a/ui/app/src/components/DraftChip/DraftChip.tsx
+++ b/ui/app/src/components/DraftChip/DraftChip.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Chip, { ChipProps } from '@mui/material/Chip';
+import { ReactNode } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+export interface DraftChipProps extends Omit<ChipProps, 'color'> {
+	label?: ReactNode;
+}
+
+export function DraftChip(props: DraftChipProps) {
+	const { label = <FormattedMessage defaultMessage="Draft" />, variant = 'outlined', ...rest } = props;
+	return <Chip variant={variant} color="error" label={label} {...rest} />;
+}
+
+export default DraftChip;

--- a/ui/app/src/components/DraftChip/DraftChip.tsx
+++ b/ui/app/src/components/DraftChip/DraftChip.tsx
@@ -15,12 +15,7 @@
  */
 
 import Chip, { ChipProps } from '@mui/material/Chip';
-import { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
-
-export interface DraftChipProps extends ChipProps {
-	label?: ReactNode;
-}
 
 export function DraftChip(props: ChipProps) {
 	return (

--- a/ui/app/src/components/DraftChip/index.ts
+++ b/ui/app/src/components/DraftChip/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { default } from './DraftChip';
+
+export * from './DraftChip';

--- a/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -653,7 +653,7 @@ function FormOrchestrator(props: FormsEngineProps) {
 		lockStatus
 	});
 	const [collapseHeader, setCollapseHeader] = useState(false);
-	const [saveAsDraft, setSaveAsDraft] = useState(false);
+	const [saveAsDraftAction, setSaveAsDraftAction] = useState(false);
 	const [invalidForm, setInvalidForm] = useState(false);
 	const jotai = useJotaiStore();
 
@@ -710,7 +710,12 @@ function FormOrchestrator(props: FormsEngineProps) {
 	}, [isSubmitting, hasPendingChanges, isStackedForm, updateSubmittingOrHasPendingChanges]);
 
 	// Unlock content when the form is closed.
-	useUnlockOnClose({ ...props, saveAsDraft, invalidForm });
+	useUnlockOnClose({
+		...props,
+		saveAsDraft: saveAsDraftAction,
+		invalidForm,
+		itemSavedAsDraft: Boolean(item?.savedAsDraft)
+	});
 
 	// region Workflow item updates
 	useEffect(() => {
@@ -1010,7 +1015,7 @@ function FormOrchestrator(props: FormsEngineProps) {
 										isEmbedded={isEmbedded}
 										isStackedForm={isStackedForm}
 										isRepeatMode={isRepeatMode}
-										setSaveAsDraft={setSaveAsDraft}
+										setSaveAsDraft={setSaveAsDraftAction}
 										invalidForm={invalidForm}
 										onSave={(e, draft) => saveFn(draft)}
 									/>

--- a/ui/app/src/components/FormsEngine/components/EditModeHeader.tsx
+++ b/ui/app/src/components/FormsEngine/components/EditModeHeader.tsx
@@ -81,6 +81,9 @@ export function EditModeHeader({ isEmbedded, collapse = false }: { isEmbedded: b
 					{isLargeContainer && collapse && <CollapseToCButton />}
 					<ItemTypeIcon item={typeIconItem} sx={{ color: 'info.main' }} />
 					<Typography>{itemLabel}</Typography>
+					{item.savedAsDraft && (
+						<Chip variant="outlined" color="error" label={<FormattedMessage defaultMessage="Draft" />} />
+					)}
 					{readonly && (
 						<Chip
 							sx={{ [`.${chipClasses.label}`]: { display: 'flex', alignItems: 'center' } }}
@@ -160,7 +163,10 @@ export function EditModeHeader({ isEmbedded, collapse = false }: { isEmbedded: b
 									</Box>
 									<Box component="span" display="flex" alignItems="center">
 										<ItemStateIcon fontSize="inherit" sxs={{ root: { mr: 0.25 } }} item={item} />{' '}
-										{getItemStateText(item.stateMap, formatMessage, { user: item.lockOwner?.username })}
+										{getItemStateText(item.stateMap, formatMessage, {
+											user: item.lockOwner?.username,
+											draft: item.savedAsDraft
+										})}
 									</Box>
 								</Typography>
 							</div>

--- a/ui/app/src/components/FormsEngine/components/EditModeHeader.tsx
+++ b/ui/app/src/components/FormsEngine/components/EditModeHeader.tsx
@@ -41,6 +41,7 @@ import MenuOpenIcon from '@mui/icons-material/MenuOpenRounded';
 import { XmlKeys } from '../lib/formConsts';
 import { useAtom } from 'jotai';
 import Collapse from '@mui/material/Collapse';
+import { DraftChip } from '../../DraftChip';
 
 export function EditModeHeader({ isEmbedded, collapse = false }: { isEmbedded: boolean; collapse?: boolean }) {
 	const { atoms } = useContext(StableFormContext);
@@ -81,9 +82,7 @@ export function EditModeHeader({ isEmbedded, collapse = false }: { isEmbedded: b
 					{isLargeContainer && collapse && <CollapseToCButton />}
 					<ItemTypeIcon item={typeIconItem} sx={{ color: 'info.main' }} />
 					<Typography>{itemLabel}</Typography>
-					{item.savedAsDraft && (
-						<Chip variant="outlined" color="error" label={<FormattedMessage defaultMessage="Draft" />} />
-					)}
+					{item.savedAsDraft && <DraftChip />}
 					{readonly && (
 						<Chip
 							sx={{ [`.${chipClasses.label}`]: { display: 'flex', alignItems: 'center' } }}

--- a/ui/app/src/components/FormsEngine/lib/formUtils.tsx
+++ b/ui/app/src/components/FormsEngine/lib/formUtils.tsx
@@ -654,6 +654,7 @@ export interface ShouldUnlockArguments {
 	isRenamed: boolean;
 	saveAsDraft: boolean;
 	invalidForm: boolean;
+	itemSavedAsDraft: boolean;
 }
 
 /**
@@ -669,7 +670,8 @@ export function shouldUnlockItem(props: ShouldUnlockArguments): boolean {
 		isParentReadonly,
 		isRenamed,
 		saveAsDraft,
-		invalidForm
+		invalidForm,
+		itemSavedAsDraft
 	} = props;
 	return (
 		!invalidForm &&
@@ -678,6 +680,7 @@ export function shouldUnlockItem(props: ShouldUnlockArguments): boolean {
 		!isRepeatMode &&
 		!isCreateMode &&
 		!readonly &&
+		!itemSavedAsDraft &&
 		// Note these "Or" statements below build on top of the previous one (i.e. it only gets to the next if the previous is false).
 		// If it's not embedded, unlock the item.
 		(!isEmbedded ||
@@ -692,8 +695,10 @@ export function shouldUnlockItem(props: ShouldUnlockArguments): boolean {
  * When the consumer component is being unmounted, checks if it should be unlocked and unlocks if so.
  * @param props {FormsEngineProps}
  **/
-export function useUnlockOnClose(props: FormsEngineProps & { saveAsDraft?: boolean; invalidForm?: boolean }) {
-	const { create, update, repeat, stackIndex = 0, saveAsDraft = false, invalidForm } = props;
+export function useUnlockOnClose(
+	props: FormsEngineProps & { saveAsDraft?: boolean; invalidForm?: boolean; itemSavedAsDraft?: boolean }
+) {
+	const { create, update, repeat, stackIndex = 0, saveAsDraft = false, invalidForm, itemSavedAsDraft } = props;
 	const itemPath = useContext(ItemContext)?.path;
 	const { atoms } = useContext(StableFormContext);
 	const { formsStackData } = useContext(StableGlobalContext);
@@ -721,7 +726,8 @@ export function useUnlockOnClose(props: FormsEngineProps & { saveAsDraft?: boole
 		siteId,
 		isRenamed,
 		saveAsDraft,
-		invalidForm
+		invalidForm,
+		itemSavedAsDraft
 	});
 	useEffect(
 		() => () => {

--- a/ui/app/src/components/ItemDisplay/utils.tsx
+++ b/ui/app/src/components/ItemDisplay/utils.tsx
@@ -32,7 +32,7 @@ export function getItemPublishingTargetText(
 export function getItemStateText(
 	stateMap: ItemStateMap,
 	formatMessage: IntlFormatters['formatMessage'],
-	values?: { user: string }
+	values?: { user: string; draft?: boolean }
 ): string {
 	const map: { [key in ItemStates]: string } = {
 		new: formatMessage({ id: 'itemState.new', defaultMessage: 'New' }),
@@ -40,10 +40,16 @@ export function getItemStateText(
 		deleted: formatMessage({ id: 'itemState.deleted', defaultMessage: 'Deleted' }),
 		locked: values?.user
 			? (formatMessage(
-					{ id: 'itemState.lockedBy', defaultMessage: 'Locked by {user}' },
+					values?.draft
+						? { id: 'itemState.lockedByDraft', defaultMessage: 'Locked by {user} - Draft' }
+						: { id: 'itemState.lockedBy', defaultMessage: 'Locked by {user}' },
 					{ user: values.user }
 				) as string)
-			: formatMessage({ id: 'itemState.locked', defaultMessage: 'Locked' }),
+			: formatMessage(
+					values?.draft
+						? { id: 'itemState.lockedDraft', defaultMessage: 'Locked - Draft' }
+						: { id: 'itemState.locked', defaultMessage: 'Locked' }
+				),
 		systemProcessing: formatMessage({ id: 'itemState.systemProcessing', defaultMessage: 'System Processing' }),
 		submitted: formatMessage({ id: 'itemState.submitted', defaultMessage: 'Submitted' }),
 		scheduled: formatMessage({ id: 'itemState.scheduled', defaultMessage: 'Scheduled' }),

--- a/ui/app/src/components/ItemMegaMenu/ItemMegaMenuUI.tsx
+++ b/ui/app/src/components/ItemMegaMenu/ItemMegaMenuUI.tsx
@@ -106,6 +106,7 @@ export function ItemMegaMenuUI(props: ItemMegaMenuUIProps) {
 	const isFolder = item?.systemType === 'folder';
 	const inWorkflow = isInWorkflow(item?.stateMap);
 	const { formatMessage } = useIntl();
+
 	return (
 		<Popover
 			open={open}
@@ -207,7 +208,10 @@ export function ItemMegaMenuUI(props: ItemMegaMenuUIProps) {
 										sxs={{ root: { fontSize: '0.8rem', verticalAlign: 'middle', ...sxs?.icon } }}
 									/>
 									<Typography variant="body2" component="span">
-										{getItemStateText(item?.stateMap, formatMessage, { user: item?.lockOwner?.username })}
+										{getItemStateText(item?.stateMap, formatMessage, {
+											user: item?.lockOwner?.username,
+											draft: item?.savedAsDraft
+										})}
 									</Typography>
 								</>
 							) : (

--- a/ui/app/src/components/ItemStateIcon/ItemStateIcon.tsx
+++ b/ui/app/src/components/ItemStateIcon/ItemStateIcon.tsx
@@ -50,7 +50,7 @@ export type ItemStateIconClassKey =
 	| 'stateNotInWorkflow';
 
 export interface ItemStateIconProps {
-	item: Pick<ContentItem, 'systemType' | 'stateMap' | 'lockOwner'>;
+	item: Pick<ContentItem, 'systemType' | 'stateMap' | 'lockOwner' | 'savedAsDraft'>;
 	classes?: Partial<Record<ItemStateIconClassKey, string>>;
 	sxs?: PartialSxRecord<ItemStateIconClassKey>;
 	className?: string;
@@ -161,7 +161,11 @@ export function ItemStateIcon(props: ItemStateIconProps) {
 		/>
 	) : (
 		<Tooltip
-			title={displayTooltip ? getItemStateText(item.stateMap, formatMessage, { user: item.lockOwner?.username }) : ''}
+			title={
+				displayTooltip
+					? getItemStateText(item.stateMap, formatMessage, { user: item.lockOwner?.username, draft: item.savedAsDraft })
+					: ''
+			}
 			open={displayTooltip ? void 0 : false}
 		>
 			<Icon
@@ -169,7 +173,10 @@ export function ItemStateIcon(props: ItemStateIconProps) {
 					...sxs?.root,
 					...stateSpecificSx
 				}}
-				aria-label={getItemStateText(item.stateMap, formatMessage, { user: item.lockOwner?.username })}
+				aria-label={getItemStateText(item.stateMap, formatMessage, {
+					user: item.lockOwner?.username,
+					draft: item.savedAsDraft
+				})}
 				aria-hidden={false}
 				className={[className, stateSpecificClass].filter(Boolean).join(' ')}
 				fontSize={fontSize}

--- a/ui/app/src/components/PackageItems/utils.tsx
+++ b/ui/app/src/components/PackageItems/utils.tsx
@@ -22,12 +22,12 @@ import { DependencyChip, DependencyMap } from '../PublishDialog';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import Box from '@mui/material/Box';
 import ItemDisplay from '../ItemDisplay';
-import { Chip, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import MoreVertRounded from '@mui/icons-material/MoreVertRounded';
 import Checkbox from '@mui/material/Checkbox';
 import FolderOpenRoundedIcon from '@mui/icons-material/FolderOpenRounded';
-import { FormattedMessage } from 'react-intl';
+import { DraftChip } from '../DraftChip';
 
 export function renderTreeNode(props: {
 	itemMap: LookupTable<LightItem>;
@@ -69,14 +69,7 @@ export function renderTreeNode(props: {
 									showPublishingTarget={false}
 									sx={{ mr: 1 }}
 								/>
-								{itemsByPath?.[node.path]?.savedAsDraft && (
-									<Chip
-										size="small"
-										variant="outlined"
-										color="error"
-										label={<FormattedMessage defaultMessage="Draft" />}
-									/>
-								)}
+								{itemsByPath?.[node.path]?.savedAsDraft && <DraftChip size="small" />}
 								{isDependency && <DependencyChip type={dependencyTypeMap[node.path]} />}
 							</Box>
 							<Typography

--- a/ui/app/src/components/PackageItems/utils.tsx
+++ b/ui/app/src/components/PackageItems/utils.tsx
@@ -15,7 +15,7 @@
  */
 
 import LookupTable from '../../models/LookupTable';
-import { ContentInstance, ContentItem, LightItem } from '../../models';
+import { ContentItem, LightItem } from '../../models';
 import { PathTreeNode } from '../PublishDialog/buildPathTrees';
 import React from 'react';
 import { DependencyChip, DependencyMap } from '../PublishDialog';

--- a/ui/app/src/components/PackageItems/utils.tsx
+++ b/ui/app/src/components/PackageItems/utils.tsx
@@ -15,18 +15,19 @@
  */
 
 import LookupTable from '../../models/LookupTable';
-import { LightItem } from '../../models';
+import { ContentInstance, ContentItem, LightItem } from '../../models';
 import { PathTreeNode } from '../PublishDialog/buildPathTrees';
 import React from 'react';
 import { DependencyChip, DependencyMap } from '../PublishDialog';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import Box from '@mui/material/Box';
 import ItemDisplay from '../ItemDisplay';
-import { Typography } from '@mui/material';
+import { Chip, Typography } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import MoreVertRounded from '@mui/icons-material/MoreVertRounded';
 import Checkbox from '@mui/material/Checkbox';
 import FolderOpenRoundedIcon from '@mui/icons-material/FolderOpenRounded';
+import { FormattedMessage } from 'react-intl';
 
 export function renderTreeNode(props: {
 	itemMap: LookupTable<LightItem>;
@@ -36,9 +37,11 @@ export function renderTreeNode(props: {
 	onCheckboxChange?: (e: React.ChangeEvent<HTMLInputElement>, checked: boolean, path: string) => void;
 	selectedDependencies?: string[];
 	showItemTarget?: boolean;
+	itemsByPath?: LookupTable<ContentItem>;
 }) {
 	const {
 		itemMap,
+		itemsByPath,
 		node,
 		onMenuClick,
 		dependencyTypeMap,
@@ -66,6 +69,14 @@ export function renderTreeNode(props: {
 									showPublishingTarget={false}
 									sx={{ mr: 1 }}
 								/>
+								{itemsByPath?.[node.path]?.savedAsDraft && (
+									<Chip
+										size="small"
+										variant="outlined"
+										color="error"
+										label={<FormattedMessage defaultMessage="Draft" />}
+									/>
+								)}
 								{isDependency && <DependencyChip type={dependencyTypeMap[node.path]} />}
 							</Box>
 							<Typography
@@ -112,6 +123,7 @@ export function renderTreeNode(props: {
 					: node.children.map((child) =>
 							renderTreeNode({
 								itemMap,
+								itemsByPath,
 								node: child,
 								dependencyTypeMap,
 								onMenuClick,

--- a/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -50,6 +50,7 @@ import useActiveUser from '../../hooks/useActiveUser';
 import { pushErrorDialog } from '../../utils/system';
 import { useEnhancedDialogContext } from '../EnhancedDialog';
 import { ConfirmDropdown } from '../ConfirmDropdown';
+import { useItemsByPath } from '../../hooks/useItemsByPath';
 
 export type DependencyType = 'soft' | 'hard';
 export type DependencyMap = Record<string, DependencyType>;
@@ -129,6 +130,11 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 		(state) => state.uiConfig.publishing.submissionCommentMaxLength
 	);
 	const { formatMessage } = useIntl();
+	const itemsByPath = useItemsByPath();
+
+	const areSomeItemsDraft = useMemo(() => {
+		return itemsDataSummary.itemPaths.some((path) => itemsByPath[path]?.savedAsDraft);
+	}, [itemsDataSummary.itemPaths, itemsByPath]);
 
 	// Auto-generate submission comment based on mainItems labels if comment is blank
 	useEffect(() => {
@@ -439,6 +445,13 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 											<Fade in={arePublishingItemsFolders}>
 												<Alert severity="warning" sx={{ borderTopRightRadius: 0, borderTopLeftRadius: 0 }}>
 													<FormattedMessage defaultMessage="Publishing only folders is not allowed" />
+												</Alert>
+											</Fade>
+										)}
+										{areSomeItemsDraft && (
+											<Fade in={areSomeItemsDraft}>
+												<Alert severity="error" sx={{ borderTopRightRadius: 0, borderTopLeftRadius: 0 }}>
+													<FormattedMessage defaultMessage="Draft items in package. Publishing draft items may result in errors if required fields are not filled in." />
 												</Alert>
 											</Fade>
 										)}

--- a/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
+++ b/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
@@ -15,8 +15,8 @@
  */
 
 import Box from '@mui/material/Box';
-import { Chip, listItemSecondaryActionClasses, Typography } from '@mui/material';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { listItemSecondaryActionClasses, Typography } from '@mui/material';
+import { useIntl } from 'react-intl';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';

--- a/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
+++ b/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
@@ -44,6 +44,7 @@ import PackageItemsActions from '../PackageItems/PackageItemsActions';
 import useItemsByPath from '../../hooks/useItemsByPath';
 import { fetchContentItem } from '../../services/content';
 import { List, type RowComponentProps } from 'react-window';
+import DraftChip from '../DraftChip';
 
 export interface PublishItemsProps {
 	itemMap: Record<string, LightItem>;
@@ -232,14 +233,7 @@ export function PublishPackageItemsView(props: PublishItemsProps) {
 														sx={{ mr: 1 }}
 														showPublishingTarget={false}
 													/>
-													{itemsByPath[path]?.savedAsDraft && (
-														<Chip
-															size="small"
-															variant="outlined"
-															color="error"
-															label={<FormattedMessage defaultMessage="Draft" />}
-														/>
-													)}
+													{itemsByPath[path]?.savedAsDraft && <DraftChip size="small" />}
 													<DependencyChip type={dependencyTypeMap?.[path]} />
 												</Box>
 											}

--- a/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
+++ b/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
@@ -233,7 +233,7 @@ export function PublishPackageItemsView(props: PublishItemsProps) {
 														sx={{ mr: 1 }}
 														showPublishingTarget={false}
 													/>
-													{itemsByPath[path]?.savedAsDraft && <DraftChip size="small" />}
+													{itemsByPath?.[path]?.savedAsDraft && <DraftChip size="small" />}
 													<DependencyChip type={dependencyTypeMap?.[path]} />
 												</Box>
 											}

--- a/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
+++ b/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
@@ -15,7 +15,7 @@
  */
 
 import Box from '@mui/material/Box';
-import { listItemSecondaryActionClasses, Typography } from '@mui/material';
+import { listItemSecondaryActionClasses } from '@mui/material';
 import { useIntl } from 'react-intl';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';

--- a/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
+++ b/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
@@ -15,8 +15,8 @@
  */
 
 import Box from '@mui/material/Box';
-import { listItemSecondaryActionClasses } from '@mui/material';
-import { useIntl } from 'react-intl';
+import { Chip, listItemSecondaryActionClasses, Typography } from '@mui/material';
+import { FormattedMessage, useIntl } from 'react-intl';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
@@ -170,6 +170,7 @@ export function PublishPackageItemsView(props: PublishItemsProps) {
 						{trees.map((node) =>
 							renderTreeNode({
 								itemMap,
+								itemsByPath,
 								node,
 								dependencyTypeMap,
 								onMenuClick: onContextMenuOpen,
@@ -231,6 +232,14 @@ export function PublishPackageItemsView(props: PublishItemsProps) {
 														sx={{ mr: 1 }}
 														showPublishingTarget={false}
 													/>
+													{itemsByPath[path]?.savedAsDraft && (
+														<Chip
+															size="small"
+															variant="outlined"
+															color="error"
+															label={<FormattedMessage defaultMessage="Draft" />}
+														/>
+													)}
 													<DependencyChip type={dependencyTypeMap?.[path]} />
 												</Box>
 											}

--- a/ui/app/src/components/PublishDialog/PublishReferencesLegend.tsx
+++ b/ui/app/src/components/PublishDialog/PublishReferencesLegend.tsx
@@ -19,6 +19,7 @@ import { Chip, Typography } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import Box from '@mui/material/Box';
 import { DependencyChip } from './PublishDialogContainer';
+import { DraftChip } from '../DraftChip';
 
 export function PublishReferencesLegend() {
 	return (
@@ -39,13 +40,7 @@ export function PublishReferencesLegend() {
 				</Typography>
 			</Box>
 			<Box sx={{ display: 'flex', gap: 1 }}>
-				<Chip
-					size="small"
-					variant="outlined"
-					color="error"
-					label={<FormattedMessage defaultMessage="Draft" />}
-					sx={{ px: '11px' }}
-				/>
+				<DraftChip size="small" sx={{ px: '11px' }} />
 				<Typography variant="body2" color="textSecondary">
 					<FormattedMessage defaultMessage="Draft item. Required fields may be empty and can cause errors when published." />
 				</Typography>

--- a/ui/app/src/components/PublishDialog/PublishReferencesLegend.tsx
+++ b/ui/app/src/components/PublishDialog/PublishReferencesLegend.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Typography } from '@mui/material';
+import { Chip, Typography } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import Box from '@mui/material/Box';
 import { DependencyChip } from './PublishDialogContainer';
@@ -32,10 +32,22 @@ export function PublishReferencesLegend() {
 					<FormattedMessage defaultMessage="References of mandatory submission" />
 				</Typography>
 			</Box>
-			<Box sx={{ display: 'flex', gap: 1 }}>
+			<Box sx={{ display: 'flex', mb: 1, gap: 1 }}>
 				<DependencyChip type="soft" />
 				<Typography variant="body2" color="textSecondary">
 					<FormattedMessage defaultMessage="References of optional submission" />
+				</Typography>
+			</Box>
+			<Box sx={{ display: 'flex', gap: 1 }}>
+				<Chip
+					size="small"
+					variant="outlined"
+					color="error"
+					label={<FormattedMessage defaultMessage="Draft" />}
+					sx={{ px: '11px' }}
+				/>
+				<Typography variant="body2" color="textSecondary">
+					<FormattedMessage defaultMessage="Draft item. Required fields may be empty and can cause errors when published." />
 				</Typography>
 			</Box>
 		</Box>

--- a/ui/app/src/components/PublishDialog/PublishReferencesLegend.tsx
+++ b/ui/app/src/components/PublishDialog/PublishReferencesLegend.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Chip, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import Box from '@mui/material/Box';
 import { DependencyChip } from './PublishDialogContainer';


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new reusable **Draft** chip and now show draft indicators across item headers, mega menus, state icons/tooltips (including accessibility labels), package item trees/lists, and publish dialog legends.
  * Publish UI now warns with an additional alert when draft items are selected, noting they may cause errors.
* **Bug Fixes**
  * Updated close/unlock behavior and draft “save as draft” tracking so draft items aren’t unlocked on close.
  * Improved state text to clearly differentiate locked vs locked-draft variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->