### PR TITLE
[8803] Fix RTE light mode styling issues

### DIFF
--- a/ui/app/src/components/FormsEngine/controls/RichTextEditor.tsx
+++ b/ui/app/src/components/FormsEngine/controls/RichTextEditor.tsx
@@ -120,15 +120,6 @@ export function RichTextEditor(props: RichTextEditorProps) {
 				},
 				'.tox .tox-statusbar': {
 					borderTopColor: 'divider'
-				},
-				'.tox.tox-tinymce-inline .tox-editor-header': {
-					backgroundColor: '#1C1C1E'
-				},
-				'.tox:not(.tox-tinymce-inline) .tox-editor-header': {
-					backgroundColor: '#1C1C1E'
-				},
-				'.tox:not(.tox-tinymce-inline).tox-tinymce--toolbar-sticky-on .tox-editor-header': {
-					backgroundColor: '#1C1C1E'
 				}
 			}}
 		>


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed custom background colors from the rich text editor toolbar across inline, standard, and sticky-toolbar modes.
  * Preserved the existing status bar border styling for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->