### PR TITLE
[8795] Make the Assets Panel configurable

### DIFF
--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -103,6 +103,7 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 
 	const mimeTypes = mimeTypesProp ?? assetsPanelInitialState.query.filters['mime-type'];
 	const assetsPath = path ? ensureSingleSlash(`${path}/.+`) : undefined;
+	const cachedSiteRef = useRef<string | undefined>(undefined);
 	const cachedPathRef = useRef<string | undefined>(undefined);
 	const cachedMimeTypesRef = useRef<string[] | undefined>(undefined);
 	const cachedQueryRef = useRef<string | undefined>(undefined);
@@ -127,11 +128,13 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 		}
 
 		const configChanged =
+			cachedSiteRef.current !== site ||
 			cachedPathRef.current !== assetsPath ||
 			mimeTypesChanged(cachedMimeTypesRef.current, mimeTypes) ||
 			cachedQueryRef.current !== query;
 
 		if (configChanged) {
+			cachedSiteRef.current = site;
 			cachedPathRef.current = assetsPath;
 			cachedMimeTypesRef.current = mimeTypes;
 			cachedQueryRef.current = query;

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -135,7 +135,7 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 			cachedPathRef.current = assetsPath;
 			cachedMimeTypesRef.current = mimeTypes;
 			cachedQueryRef.current = query;
-			fetchItems();
+			fetchItems({ offset: 0 });
 		}
 	}, [site, assetsPath, mimeTypes, query, fetchItems]);
 

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -79,6 +79,7 @@ const translations = defineMessages({
 export interface PreviewAssetsPanelProps {
 	path?: string;
 	mimeTypes?: string[];
+	query?: string;
 }
 
 function mimeTypesChanged(a?: string[], b?: string[]): boolean {
@@ -90,7 +91,7 @@ function mimeTypesChanged(a?: string[], b?: string[]): boolean {
 }
 
 export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
-	const { path, mimeTypes: mimeTypesProp } = props;
+	const { path, mimeTypes: mimeTypesProp, query } = props;
 	const initialKeyword = useSelection((state) => state.preview.assets.query.keywords);
 	const [keyword, setKeyword] = useState(initialKeyword);
 	const [dragInProgress, setDragInProgress] = useState(false);
@@ -104,6 +105,7 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 	const assetsPath = path ? `${path.replace(/\/$/, '')}/.+` : undefined;
 	const cachedPathRef = useRef<string | undefined>(undefined);
 	const cachedMimeTypesRef = useRef<string[] | undefined>(undefined);
+	const cachedQueryRef = useRef<string | undefined>(undefined);
 
 	const fetchItems = useCallback(
 		(params: Partial<ElasticParams> = {}) => {
@@ -111,11 +113,12 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 				fetchAssetsPanelItems({
 					...params,
 					path: assetsPath,
-					filters: { ...params.filters, 'mime-type': mimeTypes }
+					filters: { ...params.filters, 'mime-type': mimeTypes },
+					query
 				})
 			);
 		},
-		[dispatch, assetsPath, mimeTypes]
+		[dispatch, assetsPath, mimeTypes, query]
 	);
 
 	useEffect(() => {
@@ -124,14 +127,17 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 		}
 
 		const configChanged =
-			cachedPathRef.current !== assetsPath || mimeTypesChanged(cachedMimeTypesRef.current, mimeTypes);
+			cachedPathRef.current !== assetsPath ||
+			mimeTypesChanged(cachedMimeTypesRef.current, mimeTypes) ||
+			cachedQueryRef.current !== query;
 
 		if (configChanged) {
 			cachedPathRef.current = assetsPath;
 			cachedMimeTypesRef.current = mimeTypes;
+			cachedQueryRef.current = query;
 			fetchItems();
 		}
-	}, [site, assetsPath, mimeTypes, fetchItems]);
+	}, [site, assetsPath, mimeTypes, query, fetchItems]);
 
 	const { guestBase, xsrfArgument } = useSelector<GlobalState, GlobalState['env']>((state) => state.env);
 	const { formatMessage } = useIntl();
@@ -235,39 +241,56 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 	}
 
 	return (
-		<Box sx={dragInProgress ? { overflow: 'hidden' } : null}>
-			<div ref={elementRef}>
-				<Box sx={{ padding: '15px 15px 0 15px' }}>
-					<SearchBar showActionButton={Boolean(keyword)} onChange={handleSearchKeyword} keyword={keyword} autoFocus />
-				</Box>
-				<ErrorBoundary>
-					{assets.error ? (
-						<ApiResponseErrorState error={assets.error} />
-					) : assets.isFetching ? (
-						<LoadingState title={formatMessage(translations.retrieveAssets)} />
-					) : assets.page[assets.pageNumber] ? (
-						<>
-							{dragInProgress && (
-								<Box
-									sx={{
-										position: 'absolute',
-										background: alpha(palette.black, 0.9),
-										top: 0,
-										bottom: 0,
-										left: 0,
-										right: 0,
-										display: 'flex',
-										justifyContent: 'center',
-										alignContent: 'center',
-										zIndex: 2
-									}}
-								>
-									<UploadIcon
-										style={{ pointerEvents: 'none' }}
-										sx={{ fontSize: '8em', color: palette.gray.light5, margin: 'auto' }}
-									/>
-								</Box>
-							)}
+		<Box
+			ref={elementRef}
+			sx={(theme) => {
+				const toolbarHeight = typeof theme.mixins.toolbar.minHeight === 'number' ? theme.mixins.toolbar.minHeight : 64;
+				const panelHeight = `calc(100dvh - ${toolbarHeight * 2}px - 1px - 50px)`;
+
+				return {
+					display: 'flex',
+					flexDirection: 'column',
+					height: panelHeight,
+					maxHeight: panelHeight,
+					minHeight: 0,
+					overflow: 'hidden',
+					position: 'relative',
+					...(dragInProgress ? { overflow: 'hidden' } : {})
+				};
+			}}
+		>
+			<Box sx={{ padding: '15px 15px 0 15px', flexShrink: 0 }}>
+				<SearchBar showActionButton={Boolean(keyword)} onChange={handleSearchKeyword} keyword={keyword} autoFocus />
+			</Box>
+			<ErrorBoundary>
+				{assets.error ? (
+					<ApiResponseErrorState error={assets.error} />
+				) : assets.isFetching ? (
+					<LoadingState title={formatMessage(translations.retrieveAssets)} />
+				) : assets.page[assets.pageNumber] ? (
+					<Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+						{dragInProgress && (
+							<Box
+								sx={{
+									position: 'absolute',
+									background: alpha(palette.black, 0.9),
+									top: 0,
+									bottom: 0,
+									left: 0,
+									right: 0,
+									display: 'flex',
+									justifyContent: 'center',
+									alignContent: 'center',
+									zIndex: 2
+								}}
+							>
+								<UploadIcon
+									style={{ pointerEvents: 'none' }}
+									sx={{ fontSize: '8em', color: palette.gray.light5, margin: 'auto' }}
+								/>
+							</Box>
+						)}
+						<Box sx={{ flexShrink: 0 }}>
 							<Pagination
 								count={assets.count}
 								rowsPerPage={assets.query.limit}
@@ -275,54 +298,54 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 								onPageChange={(e, page: number) => onPageChanged(page * assets.query.limit)}
 								onRowsPerPageChange={onRowsPerPageChange}
 							/>
-							<Box sx={{ p: 2 }}>
-								{assets.page[assets.pageNumber]?.map((id) => {
-									const item = assets.byId[id];
-									return (
-										<MediaCard
-											key={item.path}
-											item={item}
-											previewAppBaseUri={guestBase}
-											avatar={<DragIndicatorRounded />}
-											sxs={{
-												root: { cursor: 'move', marginBottom: '16px' }
-											}}
-											onDragStart={() => onDragStart(item)}
-											onDragEnd={() => onDragEnd()}
-											onPreview={() =>
-												dispatch(
-													pushDialog({
-														component: createComponentId('PreviewDialog'),
-														allowMinimize: true,
-														allowFullScreen: true,
-														props: {
-															// TODO: check if it's image or video
-															type: 'image',
-															title: item.name,
-															url: item.path
-														}
-													})
-												)
-											}
-										/>
-									);
-								})}
-								{assets.count === 0 && (
-									<EmptyState
-										title={formatMessage(translations.noResults)}
+						</Box>
+						<Box sx={{ p: 2, flex: 1, minHeight: 0, overflowY: 'auto' }}>
+							{assets.page[assets.pageNumber]?.map((id) => {
+								const item = assets.byId[id];
+								return (
+									<MediaCard
+										key={item.path}
+										item={item}
+										previewAppBaseUri={guestBase}
+										avatar={<DragIndicatorRounded />}
 										sxs={{
-											image: { width: '150px' },
-											title: { fontSize: 'inherit', marginTop: '10px' }
+											root: { cursor: 'move', marginBottom: '16px' }
 										}}
+										onDragStart={() => onDragStart(item)}
+										onDragEnd={() => onDragEnd()}
+										onPreview={() =>
+											dispatch(
+												pushDialog({
+													component: createComponentId('PreviewDialog'),
+													allowMinimize: true,
+													allowFullScreen: true,
+													props: {
+														// TODO: check if it's image or video
+														type: 'image',
+														title: item.name,
+														url: item.path
+													}
+												})
+											)
+										}
 									/>
-								)}
-							</Box>
-						</>
-					) : (
-						<></>
-					)}
-				</ErrorBoundary>
-			</div>
+								);
+							})}
+							{assets.count === 0 && (
+								<EmptyState
+									title={formatMessage(translations.noResults)}
+									sxs={{
+										image: { width: '150px' },
+										title: { fontSize: 'inherit', marginTop: '10px' }
+									}}
+								/>
+							)}
+						</Box>
+					</Box>
+				) : (
+					<></>
+				)}
+			</ErrorBoundary>
 		</Box>
 	);
 }

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -48,6 +48,7 @@ import Box from '@mui/material/Box';
 import { pushDialog } from '../../state/actions/dialogStack';
 import { createComponentId } from '../../utils/system';
 import { assetsPanelInitialState } from '../../state/reducers/preview';
+import { ensureSingleSlash } from '../../utils/string';
 
 const translations = defineMessages({
 	previewAssetsPanelTitle: {
@@ -102,7 +103,7 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 	const assets = useSelection((state) => state.preview.assets);
 
 	const mimeTypes = mimeTypesProp ?? assetsPanelInitialState.query.filters['mime-type'];
-	const assetsPath = path ? `${path.replace(/\/$/, '')}/.+` : undefined;
+	const assetsPath = path ? ensureSingleSlash(`${path}/.+`) : undefined;
 	const cachedPathRef = useRef<string | undefined>(undefined);
 	const cachedMimeTypesRef = useRef<string[] | undefined>(undefined);
 	const cachedQueryRef = useRef<string | undefined>(undefined);

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -46,7 +46,6 @@ import { ApiResponseErrorState } from '../ApiResponseErrorState';
 import { ErrorBoundary } from '../ErrorBoundary';
 import Box from '@mui/material/Box';
 import { pushDialog } from '../../state/actions/dialogStack';
-import { nanoid } from 'nanoid';
 import { createComponentId } from '../../utils/system';
 
 const translations = defineMessages({
@@ -78,14 +77,13 @@ const translations = defineMessages({
 
 export interface PreviewAssetsPanelProps {
 	path?: string;
+	mimeTypes?: string[];
 }
 
 export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
-	const { path } = props;
+	const { path, mimeTypes } = props;
 	const initialKeyword = useSelection((state) => state.preview.assets.query.keywords);
 	const assetsPath = path ? `${path.replace(/\/$/, '')}/.+` : undefined;
-	const assetsPathRef = useRef(assetsPath);
-	assetsPathRef.current = assetsPath;
 	const [keyword, setKeyword] = useState(initialKeyword);
 	const [dragInProgress, setDragInProgress] = useState(false);
 	const site = useActiveSiteId();
@@ -96,16 +94,22 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 
 	const fetchItems = useCallback(
 		(params: Partial<ElasticParams> = {}) => {
-			dispatch(fetchAssetsPanelItems({ ...params, path: assetsPathRef.current }));
+			dispatch(
+				fetchAssetsPanelItems({
+					...params,
+					path: assetsPath,
+					filters: { ...params.filters, 'mime-type': mimeTypes }
+				})
+			);
 		},
-		[dispatch]
+		[dispatch, assetsPath, mimeTypes]
 	);
 
 	useEffect(() => {
 		if (site && assets.isFetching === null) {
-			dispatch(fetchAssetsPanelItems({ path: assetsPathRef.current }));
+			fetchItems();
 		}
-	}, [assets.isFetching, site, dispatch]);
+	}, [site, assets.isFetching, fetchItems]);
 
 	const { guestBase, xsrfArgument } = useSelector<GlobalState, GlobalState['env']>((state) => state.env);
 	const { formatMessage } = useIntl();

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -84,11 +84,10 @@ export interface PreviewAssetsPanelProps {
 }
 
 function mimeTypesChanged(a?: string[], b?: string[]): boolean {
-	const left = a ?? [];
-	const right = b ?? [];
-	if (left.length !== right.length) return true;
-	const rightSet = new Set(right);
-	return left.some((type) => !rightSet.has(type));
+	const leftSet = new Set(a ?? []);
+	const rightSet = new Set(b ?? []);
+	if (leftSet.size !== rightSet.size) return true;
+	return [...leftSet].some((type) => !rightSet.has(type));
 }
 
 export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -170,7 +170,7 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 						...pluckProps(file, 'name', 'type'),
 						dataUrl: reader.result
 					},
-					'/static-assets/images/',
+					path ? ensureSingleSlash(`${path}/`) : '/static-assets/images/',
 					xsrfArgument
 				).subscribe({
 					complete() {

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -16,7 +16,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import { MediaItem } from '../../models/Search';
+import { ElasticParams, MediaItem } from '../../models/Search';
 import { alpha } from '@mui/material';
 import SearchBar from '../SearchBar/SearchBar';
 import { useDispatch, useSelector } from 'react-redux';
@@ -76,8 +76,16 @@ const translations = defineMessages({
 	}
 });
 
-export function PreviewAssetsPanel() {
+export interface PreviewAssetsPanelProps {
+	path?: string;
+}
+
+export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
+	const { path } = props;
 	const initialKeyword = useSelection((state) => state.preview.assets.query.keywords);
+	const assetsPath = path ? `${path.replace(/\/$/, '')}/.+` : undefined;
+	const assetsPathRef = useRef(assetsPath);
+	assetsPathRef.current = assetsPath;
 	const [keyword, setKeyword] = useState(initialKeyword);
 	const [dragInProgress, setDragInProgress] = useState(false);
 	const site = useActiveSiteId();
@@ -86,11 +94,18 @@ export function PreviewAssetsPanel() {
 	const editMode = useSelection((state) => state.preview.editMode);
 	const assets = useSelection((state) => state.preview.assets);
 
+	const fetchItems = useCallback(
+		(params: Partial<ElasticParams> = {}) => {
+			dispatch(fetchAssetsPanelItems({ ...params, path: assetsPathRef.current }));
+		},
+		[dispatch]
+	);
+
 	useEffect(() => {
 		if (site && assets.isFetching === null) {
-			dispatch(fetchAssetsPanelItems({}));
+			dispatch(fetchAssetsPanelItems({ path: assetsPathRef.current }));
 		}
-	}, [assets, dispatch, site]);
+	}, [assets.isFetching, site, dispatch]);
 
 	const { guestBase, xsrfArgument } = useSelector<GlobalState, GlobalState['env']>((state) => state.env);
 	const { formatMessage } = useIntl();
@@ -124,14 +139,14 @@ export function PreviewAssetsPanel() {
 					xsrfArgument
 				).subscribe({
 					complete() {
-						dispatch(fetchAssetsPanelItems({}));
+						fetchItems();
 					}
 				});
 			};
 			reader.readAsDataURL(file);
 			setDragInProgress(false);
 		},
-		[xsrfArgument, dispatch, site]
+		[xsrfArgument, fetchItems, site]
 	);
 
 	useEffect(() => {
@@ -176,19 +191,16 @@ export function PreviewAssetsPanel() {
 		}
 	}, [dragInProgress, onDragDrop]);
 
-	const onSearch = useCallback(
-		(keywords: string) => dispatch(fetchAssetsPanelItems({ keywords, offset: 0 })),
-		[dispatch]
-	);
+	const onSearch = useCallback((keywords: string) => fetchItems({ keywords, offset: 0 }), [fetchItems]);
 
 	const onSearch$ = useDebouncedInput(onSearch, 400);
 
 	function onPageChanged(newPage: number) {
-		dispatch(fetchAssetsPanelItems({ offset: newPage }));
+		fetchItems({ offset: newPage });
 	}
 
 	function onRowsPerPageChange(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) {
-		dispatch(fetchAssetsPanelItems({ offset: 0, limit: e.target.value }));
+		fetchItems({ offset: 0, limit: Number(e.target.value) });
 	}
 
 	function handleSearchKeyword(keyword: string) {

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -88,9 +88,6 @@ function mimeTypesChanged(a?: string[], b?: string[]): boolean {
 	const rightSet = new Set(right);
 	return left.some((type) => !rightSet.has(type));
 }
-function completeAssetsPath(path?: string): string {
-	return path ? `${path.replace(/\/$/, '')}/.+` : undefined;
-}
 
 export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 	const { path, mimeTypes: mimeTypesProp } = props;
@@ -104,7 +101,7 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 	const assets = useSelection((state) => state.preview.assets);
 
 	const mimeTypes = mimeTypesProp ?? assetsPanelInitialState.query.filters['mime-type'];
-	const assetsPath = completeAssetsPath(path);
+	const assetsPath = path ? `${path.replace(/\/$/, '')}/.+` : undefined;
 	const cachedPathRef = useRef<string | undefined>(undefined);
 	const cachedMimeTypesRef = useRef<string[] | undefined>(undefined);
 

--- a/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
+++ b/ui/app/src/components/PreviewAssetsPanel/PreviewAssetsPanel.tsx
@@ -47,6 +47,7 @@ import { ErrorBoundary } from '../ErrorBoundary';
 import Box from '@mui/material/Box';
 import { pushDialog } from '../../state/actions/dialogStack';
 import { createComponentId } from '../../utils/system';
+import { assetsPanelInitialState } from '../../state/reducers/preview';
 
 const translations = defineMessages({
 	previewAssetsPanelTitle: {
@@ -80,10 +81,20 @@ export interface PreviewAssetsPanelProps {
 	mimeTypes?: string[];
 }
 
+function mimeTypesChanged(a?: string[], b?: string[]): boolean {
+	const left = a ?? [];
+	const right = b ?? [];
+	if (left.length !== right.length) return true;
+	const rightSet = new Set(right);
+	return left.some((type) => !rightSet.has(type));
+}
+function completeAssetsPath(path?: string): string {
+	return path ? `${path.replace(/\/$/, '')}/.+` : undefined;
+}
+
 export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
-	const { path, mimeTypes } = props;
+	const { path, mimeTypes: mimeTypesProp } = props;
 	const initialKeyword = useSelection((state) => state.preview.assets.query.keywords);
-	const assetsPath = path ? `${path.replace(/\/$/, '')}/.+` : undefined;
 	const [keyword, setKeyword] = useState(initialKeyword);
 	const [dragInProgress, setDragInProgress] = useState(false);
 	const site = useActiveSiteId();
@@ -91,6 +102,11 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 	const dispatch = useDispatch();
 	const editMode = useSelection((state) => state.preview.editMode);
 	const assets = useSelection((state) => state.preview.assets);
+
+	const mimeTypes = mimeTypesProp ?? assetsPanelInitialState.query.filters['mime-type'];
+	const assetsPath = completeAssetsPath(path);
+	const cachedPathRef = useRef<string | undefined>(undefined);
+	const cachedMimeTypesRef = useRef<string[] | undefined>(undefined);
 
 	const fetchItems = useCallback(
 		(params: Partial<ElasticParams> = {}) => {
@@ -106,10 +122,19 @@ export function PreviewAssetsPanel(props: PreviewAssetsPanelProps) {
 	);
 
 	useEffect(() => {
-		if (site && assets.isFetching === null) {
+		if (!site) {
+			return;
+		}
+
+		const configChanged =
+			cachedPathRef.current !== assetsPath || mimeTypesChanged(cachedMimeTypesRef.current, mimeTypes);
+
+		if (configChanged) {
+			cachedPathRef.current = assetsPath;
+			cachedMimeTypesRef.current = mimeTypes;
 			fetchItems();
 		}
-	}, [site, assets.isFetching, fetchItems]);
+	}, [site, assetsPath, mimeTypes, fetchItems]);
 
 	const { guestBase, xsrfArgument } = useSelector<GlobalState, GlobalState['env']>((state) => state.env);
 	const { formatMessage } = useIntl();

--- a/ui/app/src/state/epics/assets.ts
+++ b/ui/app/src/state/epics/assets.ts
@@ -15,11 +15,7 @@
  */
 
 import { ofType } from 'redux-observable';
-import {
-	FETCH_ASSETS_PANEL_ITEMS,
-	fetchAssetsPanelItemsComplete,
-	fetchAssetsPanelItemsFailed
-} from '../actions/preview';
+import { fetchAssetsPanelItems, fetchAssetsPanelItemsComplete, fetchAssetsPanelItemsFailed } from '../actions/preview';
 import { map, switchMap, withLatestFrom } from 'rxjs/operators';
 import { catchAjaxError } from '../../utils/ajax';
 import { search } from '../../services/search';
@@ -30,7 +26,7 @@ import { CrafterCMSEpic } from '../store';
 export default [
 	(action$, state$: Observable<GlobalState>) =>
 		action$.pipe(
-			ofType(FETCH_ASSETS_PANEL_ITEMS),
+			ofType(fetchAssetsPanelItems.type),
 			withLatestFrom(state$),
 			switchMap(([, state]) =>
 				search(state.sites.active, state.preview.assets.query).pipe(

--- a/ui/app/src/state/reducers/preview.ts
+++ b/ui/app/src/state/reducers/preview.ts
@@ -723,7 +723,7 @@ const reducer = createReducer<GlobalState['preview']>(initialState, (builder) =>
 					}
 				]
 			};
-			const arrays = ['widgets', 'devices', 'values'];
+			const arrays = ['widgets', 'devices', 'values', 'mimeTypes'];
 			const configDOM = fromString(payload.configXml);
 			const icePanel = configDOM.querySelector('[id="craftercms.components.ICEToolsPanel"] > configuration > widgets');
 			if (icePanel) {

--- a/ui/app/src/state/reducers/preview.ts
+++ b/ui/app/src/state/reducers/preview.ts
@@ -119,7 +119,7 @@ const audiencesPanelInitialState = {
 	applied: false
 };
 
-const assetsPanelInitialState = createEntityState({
+export const assetsPanelInitialState = createEntityState({
 	page: [],
 	query: {
 		keywords: '',


### PR DESCRIPTION
- Updated the PanelAssets to be configurable from the ui.xml (path, mimetypes and query)
- Fix assets layout to scroll content

https://github.com/craftercms/craftercms/issues/8795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Asset previews can be scoped with optional **path** and **MIME-type** filtering, plus an optional **search query** for more targeted browsing.

* **Bug Fixes**
  * Asset lists now refresh correctly after drag-and-drop uploads.
  * Search, pagination, and rows-per-page changes reliably preserve the selected scope and MIME-type filtering so results stay consistent.

* **Improvements**
  * Preview panel loading and layout behavior were updated to better handle dynamic sizing and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->